### PR TITLE
Try removing magic-nix-cache-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: DeterminateSystems/nix-installer-action@v21
-      - uses: DeterminateSystems/magic-nix-cache-action@v13
       - run: nix develop --command wasm32-wasi-cabal update
       - run: nix develop --command wasm/build.sh
       - uses: actions/upload-artifact@v6


### PR DESCRIPTION
I noticed that the cache sometimes takes longer than the entire build. For example this one took 7 minutes: https://github.com/tfausak/scrod/actions/runs/21756026061/job/62766426411

So I wondered if removing the cache would speed things up. The first `nix develop` took another minute, but it still saved time by not caching. 