### PR TITLE
Add concurrency group to GitHub Pages deploy job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,9 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     needs: wasm
+    concurrency:
+      group: github-pages
+      cancel-in-progress: true
     permissions:
       id-token: write
       pages: write


### PR DESCRIPTION
Prevents an older commit from being deployed when two pushes are merged in quick succession and the earlier workflow finishes last.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>