### PR TITLE
Convert record fields into separate items

### DIFF
--- a/source/library/Scrod/Convert/ToJson.hs
+++ b/source/library/Scrod/Convert/ToJson.hs
@@ -996,6 +996,27 @@ spec s = do
                   ]
               }
 
+      Spec.it s "converts RecordField kind" $ do
+        assertPointers
+          s
+          [("/items/0/value/kind", "\"RecordField\"")]
+          $ \m ->
+            m
+              { Module.items =
+                  [ located
+                      1
+                      1
+                      Item.MkItem
+                        { Item.key = ItemKey.MkItemKey 0,
+                          Item.kind = ItemKind.RecordField,
+                          Item.parentKey = Nothing,
+                          Item.name = Nothing,
+                          Item.documentation = Doc.Empty,
+                          Item.signature = Nothing
+                        }
+                  ]
+              }
+
       Spec.it s "converts item with parentKey" $ do
         assertPointers
           s


### PR DESCRIPTION
## Summary
- Implement `extractFieldsFromH98DetailsM` and `extractFieldsFromGADTDetailsM` which were stubbed out with `pure []`
- Record fields (e.g., `f` in `data T = C { f :: () }`) now appear as individual `RecordField` items with proper parent keys, names, types, and documentation
- Add test verifying record field extraction

## Test plan
- [x] `cabal build` succeeds
- [x] `cabal test` passes (all 600 tests)
- [x] Verified end-to-end: `echo 'data T = C { f :: () }' | cabal run scrod -- --format json` shows `f` as a `RecordField` item

Closes #13

🤖 Generated with [Claude Code](https://claude.ai/claude-code)