### PR TITLE
Add Claude Code paths to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
+/.claude/
 /.direnv/
 /.vscode/
 /a.out
 /cabal.project.*
+/CLAUDE.md
 /dist-newstyle/
 /wasm/dist/


### PR DESCRIPTION
## Summary
- Add `/.claude/` directory to `.gitignore` (Claude Code config)
- Add `/CLAUDE.md` to `.gitignore` (local project instructions file)

## Test plan
- [x] Verify `.gitignore` entries match expected paths
- [x] No tracked files are affected (neither path is currently tracked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)