### PR TITLE
Add CLAUDE.md and ignore .claude/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.claude/
 /.direnv/
 /.vscode/
 /a.out

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,79 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What is Scrod?
+
+Scrod is a Haskell documentation tool that parses Haskell source code using the GHC API and renders documentation as HTML or JSON. It has a CLI tool (reads from stdin) and a WASM-based web app deployed to GitHub Pages with a live split-pane editor.
+
+**Pipeline:** Haskell Source → GHC Parser → GHC AST → Scrod Core Types → HTML/JSON
+
+## Build Commands
+
+```bash
+cabal build                          # build library + CLI
+cabal build --flags=pedantic         # build with -Werror (used in CI)
+cabal test --test-options='--hide-successes' # run test suite
+cabal run scrod -- --format html     # run CLI (reads stdin)
+```
+
+### WASM build (requires Nix devshell)
+
+```bash
+nix develop --command wasm/build.sh
+```
+
+### Linting and formatting (CI checks all of these)
+
+```bash
+hlint source/                                        # lint Haskell
+ormolu --mode check $(find source -name "*.hs")      # check formatting
+cabal-gild --input scrod.cabal --mode check          # check .cabal formatting
+shellcheck wasm/*.sh                                 # lint shell scripts
+cabal check                                          # validate .cabal file
+```
+
+## Architecture
+
+### Source layout
+
+- `source/library/` — all library code under `Scrod.*` modules
+- `source/executable/` — CLI entry point
+- `source/test-suite/` — test suite entry point (uses Tasty/HUnit via custom `Scrod.Spec` abstraction)
+- `wasm/` — WASM entry point (`Main.hs`), build script, and web frontend (`www/`)
+
+### Key module groups
+
+- **`Scrod.Core.*`** — Data types for the intermediate representation (Module, Item, Doc, Export, etc.). Each type lives in its own module with a `Mk`-prefixed constructor (e.g., `MkModule`, `MkItem`).
+- **`Scrod.Convert.FromGhc`** — Converts GHC AST into Scrod Core types. Largest and most complex module.
+- **`Scrod.Convert.FromHaddock`** — Converts Haddock doc strings into Scrod's `Doc` type.
+- **`Scrod.Convert.ToHtml`** / **`ToJson`** — Render Core types to HTML/JSON output.
+- **`Scrod.Ghc.*`** — Wrappers around GHC API internals to set up parsing without a full GHC session.
+- **`Scrod.Xml.*`**, **`Scrod.Json.*`**, **`Scrod.Css.*`** — Custom implementations for XML/HTML, JSON, and CSS generation (no external libraries).
+
+### Testing
+
+Tests use `Scrod.Spec`, a custom test specification DSL (`MkSpec` record with `assertFailure`/`describe`/`it`) that abstracts over the test framework. The test-suite entry point (`source/test-suite/Main.hs`) wires the DSL into Tasty/HUnit.
+
+There are two kinds of tests:
+
+- **Unit tests** — defined inline in library modules via a `spec` function (e.g., `Scrod.Decimal.spec`). These test individual functions directly.
+- **Integration tests** — in `Scrod.TestSuite.Integration`. These run the full pipeline (parse → convert → JSON) and assert on JSON output using JSON Pointer paths. The `check` helper takes a Haskell source string and a list of `(pointer, expected JSON)` pairs.
+
+`Scrod.TestSuite.All` aggregates all module specs (both unit and integration) in one place.
+
+### WASM web app
+
+The WASM build exports a `processHaskell` function via JavaScript FFI. The web frontend runs it in a Web Worker (`worker.js`) to avoid blocking the UI. Shareable URLs use base64-encoded hash fragments.
+
+## Code Conventions
+
+- **Haskell2010** with extensions enabled per-file via pragmas
+- **Qualified imports everywhere** (e.g., `import qualified Data.Text as Text`)
+- **Formatting:** Ormolu (enforced in CI)
+- **Warnings:** `-Weverything` with specific exclusions; `-Werror` under `--flags=pedantic`
+- **HLint config:** `.hlint.yaml` — enables dollar/future/generalise groups; ignores "Use infix", "Use list comprehension", "Use tuple-section"
+
+## Git Conventions
+
+- **Never amend commits or force push.** Always create new commits.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ cabal run scrod -- --format html     # run CLI (reads stdin)
 ### WASM build (requires Nix devshell)
 
 ```bash
-nix develop --command wasm/build.sh
+nix develop --command wasm/build.hs
 ```
 
 ### Linting and formatting (CI checks all of these)
@@ -29,7 +29,6 @@ nix develop --command wasm/build.sh
 hlint source/                                        # lint Haskell
 ormolu --mode check $(find source -name "*.hs")      # check formatting
 cabal-gild --input scrod.cabal --mode check          # check .cabal formatting
-shellcheck wasm/*.sh                                 # lint shell scripts
 cabal check                                          # validate .cabal file
 ```
 


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` with project instructions for Claude Code: build commands, architecture overview, testing patterns (unit + integration), code conventions, and git conventions
- Add `/.claude/` to `.gitignore` to keep the local config directory out of version control

## Test plan
- [x] No code changes — documentation and gitignore only
- [x] Verify CLAUDE.md content matches current project structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)