### PR TITLE
Update WASM artifact to only include executable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
       - uses: actions/upload-artifact@v6
         with:
           name: ${{ needs.meta.outputs.name }}-${{ github.sha }}-wasm
-          path: wasm/dist/
+          path: wasm/dist/scrod-wasm.wasm
       - uses: actions/upload-pages-artifact@v4
         if: github.event_name == 'push'
         with:


### PR DESCRIPTION
## Summary
- Change the WASM upload-artifact step to only include `scrod-wasm.wasm` instead of the entire `wasm/dist/` directory
- The other files (HTML, JS, CSS, vendor) are copied from `wasm/www/` which is already in the repo, and they're deployed to GitHub Pages separately

Closes #17

## Test plan
- [x] Verify the WASM CI job still passes and the artifact contains only the executable

🤖 Generated with [Claude Code](https://claude.com/claude-code)