### PR TITLE
Extract `@since` information from module documentation

### DIFF
--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -49,6 +49,7 @@ import qualified Scrod.Core.Located as Located
 import qualified Scrod.Core.Location as Location
 import qualified Scrod.Core.Module as Module
 import qualified Scrod.Core.ModuleName as ModuleName
+import qualified Scrod.Core.PackageName as PackageName
 import qualified Scrod.Core.Section as Section
 import qualified Scrod.Core.Since as Since
 import qualified Scrod.Core.Subordinates as Subordinates
@@ -194,12 +195,29 @@ extractRawDocString lHsModule = do
   Just $ DocString.renderHsDocString hsDocString
 
 -- | Extract @since information from module documentation.
--- Note: Full @since extraction requires parsing Haddock metadata which is
--- not fully supported in all haddock-library versions. Returns Nothing for now.
 extractModuleSince ::
   SrcLoc.Located (Syntax.HsModule Ghc.GhcPs) ->
   Maybe Since.Since
-extractModuleSince _ = Nothing
+extractModuleSince lHsModule = do
+  rawDocString <- extractRawDocString lHsModule
+  let metaDoc :: Haddock.MetaDoc m Haddock.Identifier
+      metaDoc = Haddock.parseParas Nothing rawDocString
+      meta = Haddock._meta metaDoc
+  metaSince <- Haddock._metaSince meta
+  metaSinceToSince metaSince
+
+-- | Convert a Haddock MetaSince to a Scrod Since.
+metaSinceToSince :: Haddock.MetaSince -> Maybe Since.Since
+metaSinceToSince metaSince = do
+  versionNE <- NonEmpty.nonEmpty $ Haddock.sinceVersion metaSince
+  Just
+    Since.MkSince
+      { Since.package =
+          PackageName.MkPackageName . Text.pack
+            <$> Haddock.sincePackage metaSince,
+        Since.version =
+          Version.MkVersion $ fmap (fromIntegral :: Int -> Natural.Natural) versionNE
+      }
 
 -- | Extract module deprecation warning.
 extractModuleWarning ::

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -483,6 +483,22 @@ spec s = Spec.describe s "integration" $ do
     Spec.it s "defaults to null" $ do
       check s "" [("/since", "null")]
 
+    Spec.it s "works with a version" $ do
+      check
+        s
+        "-- | Docs\n--\n-- @since 1.2.3\nmodule M where"
+        [ ("/since/package", "null"),
+          ("/since/version", "[1,2,3]")
+        ]
+
+    Spec.it s "works with a package and version" $ do
+      check
+        s
+        "-- | Docs\n--\n-- @since base-4.16.0\nmodule M where"
+        [ ("/since/package", "\"base\""),
+          ("/since/version", "[4,16,0]")
+        ]
+
   Spec.describe s "name" $ do
     Spec.it s "defaults to null" $ do
       check s "" [("/name", "null")]


### PR DESCRIPTION
## Summary

Closes #19.

- Implemented `extractModuleSince` to parse `@since` annotations from module documentation using haddock-library's `MetaDoc` metadata
- Supports both version-only (`@since 1.2.3`) and package-qualified (`@since base-4.16.0`) forms
- Added integration tests for both forms

## Test plan

- [x] All 684 tests pass (`cabal test`)
- [x] Pedantic build passes (`cabal build --flags=pedantic`)
- [x] Ormolu formatting check passes
- [x] HLint passes with no hints

🤖 Generated with [Claude Code](https://claude.com/claude-code)