### PR TITLE
Allow web app to select JSON output instead of HTML

### DIFF
--- a/wasm/Main.hs
+++ b/wasm/Main.hs
@@ -3,8 +3,10 @@ module Main where
 import qualified GHC.Wasm.Prim as Wasm
 import qualified Scrod.Convert.FromGhc as FromGhc
 import qualified Scrod.Convert.ToHtml as ToHtml
+import qualified Scrod.Convert.ToJson as ToJson
 import qualified Scrod.Extra.Builder as Builder
 import qualified Scrod.Ghc.Parse as Parse
+import qualified Scrod.Json.Value as Json
 import qualified Scrod.Xml.Document as Xml
 
 -- | Not called at runtime. The WASM reactor module uses -no-hs-main, but GHC
@@ -13,29 +15,20 @@ main :: IO ()
 main = pure ()
 
 foreign export javascript "processHaskell"
-  processHaskell :: Wasm.JSString -> IO Wasm.JSString
+  processHaskell :: Wasm.JSString -> Wasm.JSString -> IO Wasm.JSString
 
-processHaskell :: Wasm.JSString -> IO Wasm.JSString
-processHaskell input = do
-  let source = Wasm.fromJSString input
-  pure . Wasm.toJSString $ case pipeline source of
-    Left err -> "<pre class=\"error\">" <> escapeHtml err <> "</pre>"
-    Right html -> html
+processHaskell :: Wasm.JSString -> Wasm.JSString -> IO Wasm.JSString
+processHaskell formatStr input = do
+  let format = Wasm.fromJSString formatStr
+      source = Wasm.fromJSString input
+  case pipeline format source of
+    Left err -> fail err
+    Right out -> pure $ Wasm.toJSString out
 
-pipeline :: String -> Either String String
-pipeline source = do
+pipeline :: String -> String -> Either String String
+pipeline format source = do
   result <- Parse.parse source
   module_ <- FromGhc.fromGhc result
-  pure
-    . Builder.toString
-    . Xml.encode
-    $ ToHtml.toHtml module_
-
-escapeHtml :: String -> String
-escapeHtml = concatMap $ \c -> case c of
-  '<' -> "&lt;"
-  '>' -> "&gt;"
-  '&' -> "&amp;"
-  '"' -> "&quot;"
-  '\'' -> "&#39;"
-  _ -> [c]
+  pure . Builder.toString $ case format of
+    "json" -> Json.encode $ ToJson.toJson module_
+    _ -> Xml.encode $ ToHtml.toHtml module_

--- a/wasm/www/index.html
+++ b/wasm/www/index.html
@@ -11,7 +11,16 @@
     <label for="source" class="sr-only">Haskell source code</label>
     <textarea id="source" placeholder="Enter Haskell source..." spellcheck="false"></textarea>
   </div>
-  <div class="pane output-pane" id="output" role="region" aria-live="polite" aria-label="Output"></div>
+  <div class="pane output-pane">
+    <div class="toolbar">
+      <label for="format" class="sr-only">Output format</label>
+      <select id="format">
+        <option value="html" selected>HTML</option>
+        <option value="json">JSON</option>
+      </select>
+    </div>
+    <div id="output" role="region" aria-live="polite" aria-label="Output"></div>
+  </div>
   <script src="index.js"></script>
 </body>
 </html>

--- a/wasm/www/index.js
+++ b/wasm/www/index.js
@@ -99,17 +99,15 @@ format.addEventListener("change", function () {
 if (location.hash.length > 1) {
   try {
     var hash = location.hash.slice(1);
-    if (hash.indexOf("=") === -1) {
-      // Legacy format: bare base64-encoded source
-      source.value = decodeHash(hash);
-    } else {
-      var params = new URLSearchParams(hash);
-      if (params.has("input")) {
-        source.value = decodeHash(params.get("input"));
-      }
+    var params = new URLSearchParams(hash);
+    if (params.has("input")) {
+      source.value = decodeHash(params.get("input"));
       if (params.has("format")) {
         format.value = params.get("format");
       }
+    } else {
+      // Legacy format: bare base64-encoded source
+      source.value = decodeHash(hash);
     }
   } catch (e) {
     // ignore invalid hash

--- a/wasm/www/index.js
+++ b/wasm/www/index.js
@@ -3,6 +3,7 @@
 const worker = new Worker("worker.js", { type: "module" });
 const source = document.getElementById("source");
 const output = document.getElementById("output");
+const format = document.getElementById("format");
 const shadow = output.attachShadow({ mode: "open" });
 shadow.innerHTML = '<p style="color: #888; font-style: italic">Loading WASM module...</p>';
 let debounceTimer;
@@ -16,18 +17,34 @@ function showError(message) {
   shadow.appendChild(pre);
 }
 
+function showJson(json) {
+  shadow.textContent = "";
+  const pre = document.createElement("pre");
+  pre.style.cssText = "white-space: pre-wrap; font-family: monospace; font-size: 14px";
+  try {
+    pre.textContent = JSON.stringify(JSON.parse(json), null, 2);
+  } catch (e) {
+    pre.textContent = json;
+  }
+  shadow.appendChild(pre);
+}
+
 worker.onmessage = function (e) {
   const msg = e.data;
   if (msg.tag === "ready") {
     ready = true;
     shadow.innerHTML = "";
     if (source.value) {
-      worker.postMessage(source.value);
+      process();
     }
   } else if (msg.tag === "result") {
-    shadow.innerHTML = msg.html;
+    if (msg.format === "json") {
+      showJson(msg.value);
+    } else {
+      shadow.innerHTML = msg.value;
+    }
   } else if (msg.tag === "error") {
-    showError(msg.html);
+    showError(msg.message);
   }
 };
 
@@ -48,10 +65,20 @@ function decodeHash(hash) {
 }
 
 function updateHash() {
+  var params = "input=" + encodeHash(source.value);
+  if (format.value !== "html") {
+    params = "format=" + format.value + "&" + params;
+  }
   if (source.value) {
-    history.replaceState(null, "", "#" + encodeHash(source.value));
+    history.replaceState(null, "", "#" + params);
   } else {
     history.replaceState(null, "", location.pathname);
+  }
+}
+
+function process() {
+  if (ready) {
+    worker.postMessage({ source: source.value, format: format.value });
   }
 }
 
@@ -59,16 +86,31 @@ source.addEventListener("input", function () {
   clearTimeout(debounceTimer);
   debounceTimer = setTimeout(function () {
     updateHash();
-    if (ready) {
-      worker.postMessage(source.value);
-    }
+    process();
   }, 300);
+});
+
+format.addEventListener("change", function () {
+  updateHash();
+  process();
 });
 
 // Load content from URL hash on startup
 if (location.hash.length > 1) {
   try {
-    source.value = decodeHash(location.hash.slice(1));
+    var hash = location.hash.slice(1);
+    if (hash.indexOf("=") === -1) {
+      // Legacy format: bare base64-encoded source
+      source.value = decodeHash(hash);
+    } else {
+      var params = new URLSearchParams(hash);
+      if (params.has("input")) {
+        source.value = decodeHash(params.get("input"));
+      }
+      if (params.has("format")) {
+        format.value = params.get("format");
+      }
+    }
   } catch (e) {
     // ignore invalid hash
   }

--- a/wasm/www/index.js
+++ b/wasm/www/index.js
@@ -65,12 +65,13 @@ function decodeHash(hash) {
 }
 
 function updateHash() {
-  var params = "input=" + encodeHash(source.value);
-  if (format.value !== "html") {
-    params = "format=" + format.value + "&" + params;
-  }
   if (source.value) {
-    history.replaceState(null, "", "#" + params);
+    var params = new URLSearchParams();
+    if (format.value !== "html") {
+      params.set("format", format.value);
+    }
+    params.set("input", encodeHash(source.value));
+    history.replaceState(null, "", "#" + params.toString());
   } else {
     history.replaceState(null, "", location.pathname);
   }
@@ -103,7 +104,10 @@ if (location.hash.length > 1) {
     if (params.has("input")) {
       source.value = decodeHash(params.get("input"));
       if (params.has("format")) {
-        format.value = params.get("format");
+        var hashFormat = params.get("format");
+        if (hashFormat === "html" || hashFormat === "json") {
+          format.value = hashFormat;
+        }
       }
     } else {
       // Legacy format: bare base64-encoded source

--- a/wasm/www/style.css
+++ b/wasm/www/style.css
@@ -44,5 +44,24 @@ body {
 }
 
 .output-pane {
+  display: flex;
+  flex-direction: column;
+}
+
+.toolbar {
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid #ccc;
+  flex-shrink: 0;
+}
+
+.toolbar select {
+  font-family: system-ui, sans-serif;
+  font-size: 14px;
+  padding: 2px 4px;
+}
+
+#output {
+  flex: 1;
+  overflow: auto;
   padding: 1rem;
 }

--- a/wasm/www/worker.js
+++ b/wasm/www/worker.js
@@ -50,18 +50,19 @@ async function initialize() {
 }
 
 initialize().catch(function (e) {
-  postMessage({ tag: "error", html: "Failed to load WASM module: " + e.message });
+  postMessage({ tag: "error", message: "Failed to load WASM module: " + e.message });
 });
 
 onmessage = async function (e) {
   if (processHaskell) {
     try {
-      const result = await processHaskell(e.data);
-      postMessage({ tag: "result", html: result });
+      const msg = e.data;
+      const result = await processHaskell(msg.format, msg.source);
+      postMessage({ tag: "result", value: result, format: msg.format });
     } catch (err) {
-      postMessage({ tag: "error", html: err.message });
+      postMessage({ tag: "error", message: err.message });
     }
   } else {
-    postMessage({ tag: "error", html: "WASM module is not initialized yet." });
+    postMessage({ tag: "error", message: "WASM module is not initialized yet." });
   }
 };


### PR DESCRIPTION
## Summary
- Adds a format selector (HTML/JSON dropdown) to the web app output pane
- JSON output is pretty-printed via `JSON.stringify` as suggested in the issue
- Format selection is persisted in the URL hash (`#format=json&input=BASE64...`) for shareable links
- Backward compatible with legacy bare base64 URL hashes

Closes #16

## Changes
- **`wasm/Main.hs`** — `processHaskell` now takes a format string parameter and dispatches to either `ToHtml` or `ToJson`. Errors are thrown via `fail` instead of being HTML-wrapped, making error handling uniform across formats.
- **`wasm/www/worker.js`** — Receives `{ source, format }` messages, passes format to WASM, includes format in results
- **`wasm/www/index.js`** — Format toggle state, new URL hash scheme with backward compatibility, format-aware rendering (HTML via `innerHTML`, JSON via pretty-printed `<pre>`)
- **`wasm/www/index.html`** — Format `<select>` in a toolbar above the output area
- **`wasm/www/style.css`** — Toolbar and flexbox layout for the output pane

## Test plan
- [ ] Verify WASM build succeeds with `nix develop --command wasm/build.hs`
- [ ] Test HTML output (default) renders as before
- [ ] Test JSON output shows pretty-printed JSON
- [ ] Test URL hash sharing: format=json links open with JSON selected
- [ ] Test backward compatibility: old bare base64 hash URLs still work
- [ ] Test error display works for both formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)