### PR TITLE
Handle Literate Haskell

### DIFF
--- a/scrod.cabal
+++ b/scrod.cabal
@@ -126,6 +126,7 @@ library
     Scrod.Executable.Flag
     Scrod.Executable.Format
     Scrod.Executable.Main
+    Scrod.Executable.Style
     Scrod.Extra.Builder
     Scrod.Extra.Either
     Scrod.Extra.Maybe

--- a/scrod.cabal
+++ b/scrod.cabal
@@ -147,6 +147,7 @@ library
     Scrod.Ghc.Uninitialized
     Scrod.Ghc.UnitId
     Scrod.Ghc.UnitSettings
+    Scrod.Ghc.Unlit
     Scrod.Json.Array
     Scrod.Json.Boolean
     Scrod.Json.Null

--- a/source/library/Scrod/Executable/Config.hs
+++ b/source/library/Scrod/Executable/Config.hs
@@ -8,13 +8,11 @@ import qualified GHC.Stack as Stack
 import qualified Scrod.Executable.Flag as Flag
 import qualified Scrod.Executable.Format as Format
 import qualified Scrod.Extra.Read as Read
-import qualified Scrod.Ghc.Unlit as Unlit
 import qualified Scrod.Spec as Spec
 
 data Config = MkConfig
   { format :: Format.Format,
     help :: Bool,
-    style :: Maybe Unlit.Style,
     version :: Bool
   }
   deriving (Eq, Ord, Show)
@@ -32,9 +30,6 @@ applyFlag config flag = case flag of
     Just string -> do
       bool <- Read.readM string
       pure config {help = bool}
-  Flag.Style string -> do
-    sty <- Unlit.fromString string
-    pure config {style = Just sty}
   Flag.Version maybeString -> case maybeString of
     Nothing -> pure config {version = True}
     Just string -> do
@@ -46,7 +41,6 @@ initial =
   MkConfig
     { format = Format.Json,
       help = False,
-      style = Nothing,
       version = False
     }
 
@@ -68,19 +62,6 @@ spec s = do
 
       Spec.it s "fails with invalid format" $ do
         Spec.assertEq s (fromFlags [Flag.Format "invalid"]) Nothing
-
-    Spec.describe s "style" $ do
-      Spec.it s "defaults to nothing" $ do
-        Spec.assertEq s (style <$> fromFlags []) $ Just Nothing
-
-      Spec.it s "works with bird" $ do
-        Spec.assertEq s (fromFlags [Flag.Style "bird"]) $ Just initial {style = Just Unlit.Bird}
-
-      Spec.it s "works with latex" $ do
-        Spec.assertEq s (fromFlags [Flag.Style "latex"]) $ Just initial {style = Just Unlit.Latex}
-
-      Spec.it s "fails with invalid style" $ do
-        Spec.assertEq s (fromFlags [Flag.Style "invalid"]) Nothing
 
     Spec.describe s "help" $ do
       Spec.it s "works with nothing" $ do

--- a/source/library/Scrod/Executable/Config.hs
+++ b/source/library/Scrod/Executable/Config.hs
@@ -8,11 +8,13 @@ import qualified GHC.Stack as Stack
 import qualified Scrod.Executable.Flag as Flag
 import qualified Scrod.Executable.Format as Format
 import qualified Scrod.Extra.Read as Read
+import qualified Scrod.Ghc.Unlit as Unlit
 import qualified Scrod.Spec as Spec
 
 data Config = MkConfig
   { format :: Format.Format,
     help :: Bool,
+    style :: Maybe Unlit.Style,
     version :: Bool
   }
   deriving (Eq, Ord, Show)
@@ -30,6 +32,9 @@ applyFlag config flag = case flag of
     Just string -> do
       bool <- Read.readM string
       pure config {help = bool}
+  Flag.Style string -> do
+    sty <- Unlit.fromString string
+    pure config {style = Just sty}
   Flag.Version maybeString -> case maybeString of
     Nothing -> pure config {version = True}
     Just string -> do
@@ -41,6 +46,7 @@ initial =
   MkConfig
     { format = Format.Json,
       help = False,
+      style = Nothing,
       version = False
     }
 
@@ -62,6 +68,19 @@ spec s = do
 
       Spec.it s "fails with invalid format" $ do
         Spec.assertEq s (fromFlags [Flag.Format "invalid"]) Nothing
+
+    Spec.describe s "style" $ do
+      Spec.it s "defaults to nothing" $ do
+        Spec.assertEq s (style <$> fromFlags []) $ Just Nothing
+
+      Spec.it s "works with bird" $ do
+        Spec.assertEq s (fromFlags [Flag.Style "bird"]) $ Just initial {style = Just Unlit.Bird}
+
+      Spec.it s "works with latex" $ do
+        Spec.assertEq s (fromFlags [Flag.Style "latex"]) $ Just initial {style = Just Unlit.Latex}
+
+      Spec.it s "fails with invalid style" $ do
+        Spec.assertEq s (fromFlags [Flag.Style "invalid"]) Nothing
 
     Spec.describe s "help" $ do
       Spec.it s "works with nothing" $ do

--- a/source/library/Scrod/Executable/Flag.hs
+++ b/source/library/Scrod/Executable/Flag.hs
@@ -10,6 +10,7 @@ import qualified System.Console.GetOpt as GetOpt
 data Flag
   = Format String
   | Help (Maybe String)
+  | Style String
   | Version (Maybe String)
   deriving (Eq, Ord, Show)
 
@@ -25,7 +26,8 @@ optDescrs :: [GetOpt.OptDescr Flag]
 optDescrs =
   [ GetOpt.Option ['h'] ["help"] (GetOpt.OptArg Help "BOOL") "Shows the help.",
     GetOpt.Option [] ["version"] (GetOpt.OptArg Version "BOOL") "Shows the version.",
-    GetOpt.Option [] ["format"] (GetOpt.ReqArg Format "FORMAT") "Sets the output format (json or html)."
+    GetOpt.Option [] ["format"] (GetOpt.ReqArg Format "FORMAT") "Sets the output format (json or html).",
+    GetOpt.Option [] ["style"] (GetOpt.ReqArg Style "STYLE") "Sets the literate Haskell style (bird, latex, or none)."
   ]
 
 spec :: (Applicative m, Monad n) => Spec.Spec m n -> n ()
@@ -56,6 +58,19 @@ spec s = do
 
       Spec.it s "works with an argument" $ do
         Spec.assertEq s (fromArguments ["--help="]) $ Just [Help $ Just ""]
+
+    Spec.describe s "style" $ do
+      Spec.it s "works with bird" $ do
+        Spec.assertEq s (fromArguments ["--style=bird"]) $ Just [Style "bird"]
+
+      Spec.it s "works with latex" $ do
+        Spec.assertEq s (fromArguments ["--style=latex"]) $ Just [Style "latex"]
+
+      Spec.it s "works with none" $ do
+        Spec.assertEq s (fromArguments ["--style=none"]) $ Just [Style "none"]
+
+      Spec.it s "fails with no argument" $ do
+        Spec.assertEq s (fromArguments ["--style"]) Nothing
 
     Spec.describe s "version" $ do
       Spec.it s "works with no argument" $ do

--- a/source/library/Scrod/Executable/Flag.hs
+++ b/source/library/Scrod/Executable/Flag.hs
@@ -10,6 +10,7 @@ import qualified System.Console.GetOpt as GetOpt
 data Flag
   = Format String
   | Help (Maybe String)
+  | Style String
   | Version (Maybe String)
   deriving (Eq, Ord, Show)
 
@@ -25,7 +26,8 @@ optDescrs :: [GetOpt.OptDescr Flag]
 optDescrs =
   [ GetOpt.Option ['h'] ["help"] (GetOpt.OptArg Help "BOOL") "Shows the help.",
     GetOpt.Option [] ["version"] (GetOpt.OptArg Version "BOOL") "Shows the version.",
-    GetOpt.Option [] ["format"] (GetOpt.ReqArg Format "FORMAT") "Sets the output format (json or html)."
+    GetOpt.Option [] ["format"] (GetOpt.ReqArg Format "FORMAT") "Sets the output format (json or html).",
+    GetOpt.Option [] ["style"] (GetOpt.ReqArg Style "STYLE") "Sets the input style (bird or latex) for Literate Haskell."
   ]
 
 spec :: (Applicative m, Monad n) => Spec.Spec m n -> n ()
@@ -49,6 +51,16 @@ spec s = do
 
       Spec.it s "fails with no argument" $ do
         Spec.assertEq s (fromArguments ["--format"]) Nothing
+
+    Spec.describe s "style" $ do
+      Spec.it s "works with an argument" $ do
+        Spec.assertEq s (fromArguments ["--style=bird"]) $ Just [Style "bird"]
+
+      Spec.it s "works with latex" $ do
+        Spec.assertEq s (fromArguments ["--style=latex"]) $ Just [Style "latex"]
+
+      Spec.it s "fails with no argument" $ do
+        Spec.assertEq s (fromArguments ["--style"]) Nothing
 
     Spec.describe s "help" $ do
       Spec.it s "works with no argument" $ do

--- a/source/library/Scrod/Executable/Flag.hs
+++ b/source/library/Scrod/Executable/Flag.hs
@@ -10,7 +10,6 @@ import qualified System.Console.GetOpt as GetOpt
 data Flag
   = Format String
   | Help (Maybe String)
-  | Style String
   | Version (Maybe String)
   deriving (Eq, Ord, Show)
 
@@ -26,8 +25,7 @@ optDescrs :: [GetOpt.OptDescr Flag]
 optDescrs =
   [ GetOpt.Option ['h'] ["help"] (GetOpt.OptArg Help "BOOL") "Shows the help.",
     GetOpt.Option [] ["version"] (GetOpt.OptArg Version "BOOL") "Shows the version.",
-    GetOpt.Option [] ["format"] (GetOpt.ReqArg Format "FORMAT") "Sets the output format (json or html).",
-    GetOpt.Option [] ["style"] (GetOpt.ReqArg Style "STYLE") "Sets the input style (bird or latex) for Literate Haskell."
+    GetOpt.Option [] ["format"] (GetOpt.ReqArg Format "FORMAT") "Sets the output format (json or html)."
   ]
 
 spec :: (Applicative m, Monad n) => Spec.Spec m n -> n ()
@@ -51,16 +49,6 @@ spec s = do
 
       Spec.it s "fails with no argument" $ do
         Spec.assertEq s (fromArguments ["--format"]) Nothing
-
-    Spec.describe s "style" $ do
-      Spec.it s "works with an argument" $ do
-        Spec.assertEq s (fromArguments ["--style=bird"]) $ Just [Style "bird"]
-
-      Spec.it s "works with latex" $ do
-        Spec.assertEq s (fromArguments ["--style=latex"]) $ Just [Style "latex"]
-
-      Spec.it s "fails with no argument" $ do
-        Spec.assertEq s (fromArguments ["--style"]) Nothing
 
     Spec.describe s "help" $ do
       Spec.it s "works with no argument" $ do

--- a/source/library/Scrod/Executable/Main.hs
+++ b/source/library/Scrod/Executable/Main.hs
@@ -10,6 +10,7 @@ import qualified Scrod.Convert.ToJson as ToJson
 import qualified Scrod.Executable.Config as Config
 import qualified Scrod.Executable.Flag as Flag
 import qualified Scrod.Executable.Format as Format
+import qualified Scrod.Executable.Style as ExecStyle
 import qualified Scrod.Ghc.Parse as Parse
 import qualified Scrod.Ghc.Unlit as Unlit
 import qualified Scrod.Json.Value as Json
@@ -37,7 +38,11 @@ mainWith name arguments = do
     putStrLn $ Version.showVersion Version.version
     Exit.exitSuccess
   input <- getContents
-  result <- either fail pure $ Parse.parse (Unlit.preprocess input)
+  let preprocessed = case Config.style config of
+        ExecStyle.None -> input
+        ExecStyle.Bird -> Unlit.unlit Unlit.Bird input
+        ExecStyle.Latex -> Unlit.unlit Unlit.Latex input
+  result <- either fail pure $ Parse.parse preprocessed
   module_ <- either fail pure $ FromGhc.fromGhc result
   let encoder = case Config.format config of
         Format.Json -> Json.encode . ToJson.toJson

--- a/source/library/Scrod/Executable/Main.hs
+++ b/source/library/Scrod/Executable/Main.hs
@@ -11,6 +11,7 @@ import qualified Scrod.Executable.Config as Config
 import qualified Scrod.Executable.Flag as Flag
 import qualified Scrod.Executable.Format as Format
 import qualified Scrod.Ghc.Parse as Parse
+import qualified Scrod.Ghc.Unlit as Unlit
 import qualified Scrod.Json.Value as Json
 import qualified Scrod.Version as Version
 import qualified Scrod.Xml.Document as Xml
@@ -36,7 +37,8 @@ mainWith name arguments = do
     putStrLn $ Version.showVersion Version.version
     Exit.exitSuccess
   input <- getContents
-  result <- either fail pure $ Parse.parse input
+  let source = maybe id Unlit.unlit (Config.style config) input
+  result <- either fail pure $ Parse.parse source
   module_ <- either fail pure $ FromGhc.fromGhc result
   let encoder = case Config.format config of
         Format.Json -> Json.encode . ToJson.toJson

--- a/source/library/Scrod/Executable/Main.hs
+++ b/source/library/Scrod/Executable/Main.hs
@@ -37,8 +37,7 @@ mainWith name arguments = do
     putStrLn $ Version.showVersion Version.version
     Exit.exitSuccess
   input <- getContents
-  let source = maybe id Unlit.unlit (Config.style config) input
-  result <- either fail pure $ Parse.parse source
+  result <- either fail pure $ Parse.parse (Unlit.preprocess input)
   module_ <- either fail pure $ FromGhc.fromGhc result
   let encoder = case Config.format config of
         Format.Json -> Json.encode . ToJson.toJson

--- a/source/library/Scrod/Executable/Style.hs
+++ b/source/library/Scrod/Executable/Style.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE TemplateHaskellQuotes #-}
+
+module Scrod.Executable.Style where
+
+import qualified Control.Monad.Catch as Exception
+import qualified GHC.Stack as Stack
+import qualified Scrod.Spec as Spec
+
+data Style
+  = Bird
+  | Latex
+  | None
+  deriving (Eq, Ord, Show)
+
+fromString :: (Stack.HasCallStack, Exception.MonadThrow m) => String -> m Style
+fromString string = case string of
+  "bird" -> pure Bird
+  "latex" -> pure Latex
+  "none" -> pure None
+  _ -> Exception.throwM . userError $ "invalid style: " <> show string
+
+spec :: (Applicative m, Monad n) => Spec.Spec m n -> n ()
+spec s = do
+  Spec.named s 'fromString $ do
+    Spec.it s "parses bird" $ do
+      Spec.assertEq s (fromString "bird") $ Just Bird
+
+    Spec.it s "parses latex" $ do
+      Spec.assertEq s (fromString "latex") $ Just Latex
+
+    Spec.it s "parses none" $ do
+      Spec.assertEq s (fromString "none") $ Just None
+
+    Spec.it s "fails with invalid input" $ do
+      Spec.assertEq s (fromString "invalid") Nothing

--- a/source/library/Scrod/TestSuite/All.hs
+++ b/source/library/Scrod/TestSuite/All.hs
@@ -14,6 +14,7 @@ import qualified Scrod.Decimal
 import qualified Scrod.Executable.Config
 import qualified Scrod.Executable.Flag
 import qualified Scrod.Executable.Format
+import qualified Scrod.Executable.Style
 import qualified Scrod.Extra.Builder
 import qualified Scrod.Extra.Either
 import qualified Scrod.Extra.Maybe
@@ -66,6 +67,7 @@ spec s = do
   Scrod.Executable.Config.spec s
   Scrod.Executable.Format.spec s
   Scrod.Executable.Flag.spec s
+  Scrod.Executable.Style.spec s
   Scrod.Extra.Builder.spec s
   Scrod.Extra.Either.spec s
   Scrod.Extra.Maybe.spec s

--- a/source/library/Scrod/TestSuite/All.hs
+++ b/source/library/Scrod/TestSuite/All.hs
@@ -24,6 +24,7 @@ import qualified Scrod.Extra.Read
 import qualified Scrod.Extra.Semigroup
 import qualified Scrod.Ghc.OnOff
 import qualified Scrod.Ghc.Parse
+import qualified Scrod.Ghc.Unlit
 import qualified Scrod.Json.Array
 import qualified Scrod.Json.Boolean
 import qualified Scrod.Json.Null
@@ -75,6 +76,7 @@ spec s = do
   Scrod.Extra.Semigroup.spec s
   Scrod.Ghc.OnOff.spec s
   Scrod.Ghc.Parse.spec s
+  Scrod.Ghc.Unlit.spec s
   Scrod.Json.Array.spec s
   Scrod.Json.Boolean.spec s
   Scrod.Json.Null.spec s

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -1473,27 +1473,24 @@ spec s = Spec.describe s "integration" $ do
   Spec.describe s "literate" $ do
     Spec.describe s "bird" $ do
       Spec.it s "works with a simple declaration" $ do
-        checkLiterate
+        checkPreprocess
           s
-          Unlit.Bird
           "> x = 0"
           [ ("/items/0/value/kind", "\"Function\""),
             ("/items/0/value/name", "\"x\"")
           ]
 
       Spec.it s "works with comments and code" $ do
-        checkLiterate
+        checkPreprocess
           s
-          Unlit.Bird
           "This is a comment.\n\n> x = 0"
           [ ("/items/0/value/name", "\"x\""),
             ("/items/0/location/line", "3")
           ]
 
       Spec.it s "works with a module declaration" $ do
-        checkLiterate
+        checkPreprocess
           s
-          Unlit.Bird
           "> module M where\n>\n> x = 0"
           [ ("/name/value", "\"M\""),
             ("/items/0/value/name", "\"x\"")
@@ -1501,27 +1498,24 @@ spec s = Spec.describe s "integration" $ do
 
     Spec.describe s "latex" $ do
       Spec.it s "works with a simple declaration" $ do
-        checkLiterate
+        checkPreprocess
           s
-          Unlit.Latex
           "\\begin{code}\nx = 0\n\\end{code}"
           [ ("/items/0/value/kind", "\"Function\""),
             ("/items/0/value/name", "\"x\"")
           ]
 
       Spec.it s "works with text and code" $ do
-        checkLiterate
+        checkPreprocess
           s
-          Unlit.Latex
           "This is text.\n\\begin{code}\nx = 0\n\\end{code}"
           [ ("/items/0/value/name", "\"x\""),
             ("/items/0/location/line", "3")
           ]
 
       Spec.it s "works with a module declaration" $ do
-        checkLiterate
+        checkPreprocess
           s
-          Unlit.Latex
           "\\begin{code}\nmodule M where\n\nx = 0\n\\end{code}"
           [ ("/name/value", "\"M\""),
             ("/items/0/value/name", "\"x\"")
@@ -1548,5 +1542,5 @@ check s input assertions = do
           " but got " <> maybe "(nothing)" (Builder.toString . Json.encode) actual
         ]
 
-checkLiterate :: (Stack.HasCallStack, Monad m) => Spec.Spec m n -> Unlit.Style -> String -> [(String, String)] -> m ()
-checkLiterate s sty input = check s (Unlit.unlit sty input)
+checkPreprocess :: (Stack.HasCallStack, Monad m) => Spec.Spec m n -> String -> [(String, String)] -> m ()
+checkPreprocess s input = check s (Unlit.preprocess input)

--- a/wasm/Main.hs
+++ b/wasm/Main.hs
@@ -6,6 +6,7 @@ import qualified Scrod.Convert.ToHtml as ToHtml
 import qualified Scrod.Convert.ToJson as ToJson
 import qualified Scrod.Extra.Builder as Builder
 import qualified Scrod.Ghc.Parse as Parse
+import qualified Scrod.Ghc.Unlit as Unlit
 import qualified Scrod.Json.Value as Json
 import qualified Scrod.Xml.Document as Xml
 
@@ -27,7 +28,7 @@ processHaskell formatStr input = do
 
 pipeline :: String -> String -> Either String String
 pipeline format source = do
-  result <- Parse.parse source
+  result <- Parse.parse (Unlit.preprocess source)
   module_ <- FromGhc.fromGhc result
   pure . Builder.toString $ case format of
     "json" -> Json.encode $ ToJson.toJson module_

--- a/wasm/Main.hs
+++ b/wasm/Main.hs
@@ -6,7 +6,6 @@ import qualified Scrod.Convert.ToHtml as ToHtml
 import qualified Scrod.Convert.ToJson as ToJson
 import qualified Scrod.Extra.Builder as Builder
 import qualified Scrod.Ghc.Parse as Parse
-import qualified Scrod.Ghc.Unlit as Unlit
 import qualified Scrod.Json.Value as Json
 import qualified Scrod.Xml.Document as Xml
 
@@ -28,7 +27,7 @@ processHaskell formatStr input = do
 
 pipeline :: String -> String -> Either String String
 pipeline format source = do
-  result <- Parse.parse (Unlit.preprocess source)
+  result <- Parse.parse source
   module_ <- FromGhc.fromGhc result
   pure . Builder.toString $ case format of
     "json" -> Json.encode $ ToJson.toJson module_


### PR DESCRIPTION
## Summary
- Add `Scrod.Ghc.Unlit` module that preprocesses Literate Haskell into regular Haskell, preserving line numbers
- Support both Bird style (`> ` prefixed lines) and LaTeX style (`\begin{code}`/`\end{code}` blocks)
- Add `--style` CLI flag (`bird` or `latex`) to select the input style

Fixes #29

## Test plan
- Unit tests for `fromString`, `unlit` with both Bird and LaTeX styles (13 new tests)
- Integration tests that run literate Haskell through the full parse → convert → JSON pipeline (6 new tests)
- Manual verification: `echo '> x = 0' | cabal run scrod -- --format json --style bird`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>