### PR TITLE
Add support for Literate Haskell

### DIFF
--- a/scrod.cabal
+++ b/scrod.cabal
@@ -171,6 +171,7 @@ library
     Scrod.Spec
     Scrod.TestSuite.All
     Scrod.TestSuite.Integration
+    Scrod.Unlit
     Scrod.Version
     Scrod.Xml.Attribute
     Scrod.Xml.Comment

--- a/source/library/Scrod/Executable/Config.hs
+++ b/source/library/Scrod/Executable/Config.hs
@@ -13,6 +13,7 @@ import qualified Scrod.Spec as Spec
 data Config = MkConfig
   { format :: Format.Format,
     help :: Bool,
+    unlit :: Bool,
     version :: Bool
   }
   deriving (Eq, Ord, Show)
@@ -30,6 +31,11 @@ applyFlag config flag = case flag of
     Just string -> do
       bool <- Read.readM string
       pure config {help = bool}
+  Flag.Unlit maybeString -> case maybeString of
+    Nothing -> pure config {unlit = True}
+    Just string -> do
+      bool <- Read.readM string
+      pure config {unlit = bool}
   Flag.Version maybeString -> case maybeString of
     Nothing -> pure config {version = True}
     Just string -> do
@@ -41,6 +47,7 @@ initial =
   MkConfig
     { format = Format.Json,
       help = False,
+      unlit = False,
       version = False
     }
 
@@ -62,6 +69,19 @@ spec s = do
 
       Spec.it s "fails with invalid format" $ do
         Spec.assertEq s (fromFlags [Flag.Format "invalid"]) Nothing
+
+    Spec.describe s "unlit" $ do
+      Spec.it s "works with nothing" $ do
+        Spec.assertEq s (fromFlags [Flag.Unlit Nothing]) $ Just initial {unlit = True}
+
+      Spec.it s "works with just false" $ do
+        Spec.assertEq s (fromFlags [Flag.Unlit $ Just "False"]) $ Just initial
+
+      Spec.it s "works with just true" $ do
+        Spec.assertEq s (fromFlags [Flag.Unlit $ Just "True"]) $ Just initial {unlit = True}
+
+      Spec.it s "fails with just invalid" $ do
+        Spec.assertEq s (fromFlags [Flag.Unlit $ Just "invalid"]) Nothing
 
     Spec.describe s "help" $ do
       Spec.it s "works with nothing" $ do

--- a/source/library/Scrod/Executable/Config.hs
+++ b/source/library/Scrod/Executable/Config.hs
@@ -13,7 +13,7 @@ import qualified Scrod.Spec as Spec
 data Config = MkConfig
   { format :: Format.Format,
     help :: Bool,
-    unlit :: Bool,
+    literate :: Bool,
     version :: Bool
   }
   deriving (Eq, Ord, Show)
@@ -31,11 +31,11 @@ applyFlag config flag = case flag of
     Just string -> do
       bool <- Read.readM string
       pure config {help = bool}
-  Flag.Unlit maybeString -> case maybeString of
-    Nothing -> pure config {unlit = True}
+  Flag.Literate maybeString -> case maybeString of
+    Nothing -> pure config {literate = True}
     Just string -> do
       bool <- Read.readM string
-      pure config {unlit = bool}
+      pure config {literate = bool}
   Flag.Version maybeString -> case maybeString of
     Nothing -> pure config {version = True}
     Just string -> do
@@ -47,7 +47,7 @@ initial =
   MkConfig
     { format = Format.Json,
       help = False,
-      unlit = False,
+      literate = False,
       version = False
     }
 
@@ -70,18 +70,18 @@ spec s = do
       Spec.it s "fails with invalid format" $ do
         Spec.assertEq s (fromFlags [Flag.Format "invalid"]) Nothing
 
-    Spec.describe s "unlit" $ do
+    Spec.describe s "literate" $ do
       Spec.it s "works with nothing" $ do
-        Spec.assertEq s (fromFlags [Flag.Unlit Nothing]) $ Just initial {unlit = True}
+        Spec.assertEq s (fromFlags [Flag.Literate Nothing]) $ Just initial {literate = True}
 
       Spec.it s "works with just false" $ do
-        Spec.assertEq s (fromFlags [Flag.Unlit $ Just "False"]) $ Just initial
+        Spec.assertEq s (fromFlags [Flag.Literate $ Just "False"]) $ Just initial
 
       Spec.it s "works with just true" $ do
-        Spec.assertEq s (fromFlags [Flag.Unlit $ Just "True"]) $ Just initial {unlit = True}
+        Spec.assertEq s (fromFlags [Flag.Literate $ Just "True"]) $ Just initial {literate = True}
 
       Spec.it s "fails with just invalid" $ do
-        Spec.assertEq s (fromFlags [Flag.Unlit $ Just "invalid"]) Nothing
+        Spec.assertEq s (fromFlags [Flag.Literate $ Just "invalid"]) Nothing
 
     Spec.describe s "help" $ do
       Spec.it s "works with nothing" $ do

--- a/source/library/Scrod/Executable/Flag.hs
+++ b/source/library/Scrod/Executable/Flag.hs
@@ -10,6 +10,7 @@ import qualified System.Console.GetOpt as GetOpt
 data Flag
   = Format String
   | Help (Maybe String)
+  | Unlit (Maybe String)
   | Version (Maybe String)
   deriving (Eq, Ord, Show)
 
@@ -25,7 +26,8 @@ optDescrs :: [GetOpt.OptDescr Flag]
 optDescrs =
   [ GetOpt.Option ['h'] ["help"] (GetOpt.OptArg Help "BOOL") "Shows the help.",
     GetOpt.Option [] ["version"] (GetOpt.OptArg Version "BOOL") "Shows the version.",
-    GetOpt.Option [] ["format"] (GetOpt.ReqArg Format "FORMAT") "Sets the output format (json or html)."
+    GetOpt.Option [] ["format"] (GetOpt.ReqArg Format "FORMAT") "Sets the output format (json or html).",
+    GetOpt.Option [] ["unlit"] (GetOpt.OptArg Unlit "BOOL") "Enables literate Haskell unlitting."
   ]
 
 spec :: (Applicative m, Monad n) => Spec.Spec m n -> n ()
@@ -56,6 +58,13 @@ spec s = do
 
       Spec.it s "works with an argument" $ do
         Spec.assertEq s (fromArguments ["--help="]) $ Just [Help $ Just ""]
+
+    Spec.describe s "unlit" $ do
+      Spec.it s "works with no argument" $ do
+        Spec.assertEq s (fromArguments ["--unlit"]) $ Just [Unlit Nothing]
+
+      Spec.it s "works with an argument" $ do
+        Spec.assertEq s (fromArguments ["--unlit="]) $ Just [Unlit $ Just ""]
 
     Spec.describe s "version" $ do
       Spec.it s "works with no argument" $ do

--- a/source/library/Scrod/Executable/Flag.hs
+++ b/source/library/Scrod/Executable/Flag.hs
@@ -10,7 +10,7 @@ import qualified System.Console.GetOpt as GetOpt
 data Flag
   = Format String
   | Help (Maybe String)
-  | Unlit (Maybe String)
+  | Literate (Maybe String)
   | Version (Maybe String)
   deriving (Eq, Ord, Show)
 
@@ -27,7 +27,7 @@ optDescrs =
   [ GetOpt.Option ['h'] ["help"] (GetOpt.OptArg Help "BOOL") "Shows the help.",
     GetOpt.Option [] ["version"] (GetOpt.OptArg Version "BOOL") "Shows the version.",
     GetOpt.Option [] ["format"] (GetOpt.ReqArg Format "FORMAT") "Sets the output format (json or html).",
-    GetOpt.Option [] ["unlit"] (GetOpt.OptArg Unlit "BOOL") "Enables literate Haskell unlitting."
+    GetOpt.Option [] ["literate"] (GetOpt.OptArg Literate "BOOL") "Treats the input as Literate Haskell."
   ]
 
 spec :: (Applicative m, Monad n) => Spec.Spec m n -> n ()
@@ -59,12 +59,12 @@ spec s = do
       Spec.it s "works with an argument" $ do
         Spec.assertEq s (fromArguments ["--help="]) $ Just [Help $ Just ""]
 
-    Spec.describe s "unlit" $ do
+    Spec.describe s "literate" $ do
       Spec.it s "works with no argument" $ do
-        Spec.assertEq s (fromArguments ["--unlit"]) $ Just [Unlit Nothing]
+        Spec.assertEq s (fromArguments ["--literate"]) $ Just [Literate Nothing]
 
       Spec.it s "works with an argument" $ do
-        Spec.assertEq s (fromArguments ["--unlit="]) $ Just [Unlit $ Just ""]
+        Spec.assertEq s (fromArguments ["--literate="]) $ Just [Literate $ Just ""]
 
     Spec.describe s "version" $ do
       Spec.it s "works with no argument" $ do

--- a/source/library/Scrod/Executable/Main.hs
+++ b/source/library/Scrod/Executable/Main.hs
@@ -48,7 +48,7 @@ mainWith name arguments myGetContents = ExceptT.runExceptT $ do
     $ Version.showVersion Version.version <> "\n"
   contents <- Trans.lift myGetContents
   source <-
-    if Config.unlit config
+    if Config.literate config
       then Either.throw . Bifunctor.first userError $ Unlit.unlit contents
       else pure contents
   result <- Either.throw . Bifunctor.first userError $ Parse.parse source

--- a/source/library/Scrod/Executable/Main.hs
+++ b/source/library/Scrod/Executable/Main.hs
@@ -17,6 +17,7 @@ import qualified Scrod.Executable.Format as Format
 import qualified Scrod.Extra.Either as Either
 import qualified Scrod.Ghc.Parse as Parse
 import qualified Scrod.Json.Value as Json
+import qualified Scrod.Unlit as Unlit
 import qualified Scrod.Version as Version
 import qualified Scrod.Xml.Document as Xml
 import qualified System.Console.GetOpt as GetOpt
@@ -46,7 +47,11 @@ mainWith name arguments myGetContents = ExceptT.runExceptT $ do
     . ExceptT.throwE
     $ Version.showVersion Version.version <> "\n"
   contents <- Trans.lift myGetContents
-  result <- Either.throw . Bifunctor.first userError $ Parse.parse contents
+  source <-
+    if Config.unlit config
+      then Either.throw . Bifunctor.first userError $ Unlit.unlit contents
+      else pure contents
+  result <- Either.throw . Bifunctor.first userError $ Parse.parse source
   module_ <- Either.throw . Bifunctor.first userError $ FromGhc.fromGhc result
   let convert = case Config.format config of
         Format.Json -> Json.encode . ToJson.toJson

--- a/source/library/Scrod/TestSuite/All.hs
+++ b/source/library/Scrod/TestSuite/All.hs
@@ -37,6 +37,7 @@ import qualified Scrod.JsonPointer.Pointer
 import qualified Scrod.JsonPointer.Token
 import qualified Scrod.Spec as Spec
 import qualified Scrod.TestSuite.Integration
+import qualified Scrod.Unlit
 import qualified Scrod.Version
 import qualified Scrod.Xml.Attribute
 import qualified Scrod.Xml.Comment
@@ -87,6 +88,7 @@ spec s = do
   Scrod.JsonPointer.Pointer.spec s
   Scrod.JsonPointer.Token.spec s
   Scrod.TestSuite.Integration.spec s
+  Scrod.Unlit.spec s
   Scrod.Version.spec s
   Scrod.Xml.Attribute.spec s
   Scrod.Xml.Comment.spec s

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -1469,10 +1469,13 @@ spec s = Spec.describe s "integration" $ do
         []
 
 check :: (Stack.HasCallStack, Monad m) => Spec.Spec m n -> String -> [(String, String)] -> m ()
-check s input assertions = do
+check s = checkWith s []
+
+checkWith :: (Stack.HasCallStack, Monad m) => Spec.Spec m n -> [String] -> String -> [(String, String)] -> m ()
+checkWith s arguments input assertions = do
   result <-
     either (Spec.assertFailure s . Exception.displayException) pure
-      . Main.mainWith "scrod-test-suite" []
+      . Main.mainWith "scrod-test-suite" arguments
       $ pure input
   module_ <- either (Spec.assertFailure s) pure result
   json <-

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -1469,57 +1469,77 @@ spec s = Spec.describe s "integration" $ do
         []
 
   Spec.describe s "unlit" $ do
-    Spec.it s "works with bird style" $ do
-      checkWith
-        s
-        ["--unlit"]
-        "\n> x = 0\n"
-        [ ("/items/0/value/name", "\"x\""),
-          ("/items/0/value/kind", "\"Function\"")
-        ]
+    Spec.describe s "bird" $ do
+      Spec.it s "works" $ do
+        checkWith
+          s
+          ["--unlit"]
+          "> x = 0"
+          [("/items/0/value/name", "\"x\"")]
 
-    Spec.it s "works with latex style" $ do
-      checkWith
-        s
-        ["--unlit"]
-        "\\begin{code}\nx = 0\n\\end{code}"
-        [ ("/items/0/value/name", "\"x\""),
-          ("/items/0/value/kind", "\"Function\"")
-        ]
+      Spec.it s "preserves line numbers" $ do
+        checkWith
+          s
+          ["--unlit"]
+          """
+          comment
 
-    Spec.it s "works with module declaration in bird style" $ do
-      checkWith
-        s
-        ["--unlit"]
-        "\n> module M where\n\n> x = 0\n"
-        [ ("/name/value", "\"M\""),
-          ("/items/0/value/name", "\"x\"")
-        ]
+          > x = 0
+          """
+          [("/items/0/location/line", "3")]
 
-    Spec.it s "works with module declaration in latex style" $ do
-      checkWith
-        s
-        ["--unlit"]
-        "\\begin{code}\nmodule M where\nx = 0\n\\end{code}"
-        [ ("/name/value", "\"M\""),
-          ("/items/0/value/name", "\"x\"")
-        ]
+    Spec.describe s "latex" $ do
+      Spec.it s "works" $ do
+        checkWith
+          s
+          ["--unlit"]
+          """
+          \\begin{code}
+          x = 0
+          \\end{code}
+          """
+          [("/items/0/value/name", "\"x\"")]
 
-    Spec.it s "works with mixed styles" $ do
+      Spec.it s "preserves line numbers" $ do
+        checkWith
+          s
+          ["--unlit"]
+          """
+          \\begin{code}
+          x = 0
+          \\end{code}
+          """
+          [("/items/0/location/line", "2")]
+
+    Spec.it s "works with bird then latex" $ do
       checkWith
         s
         ["--unlit"]
-        "\n>x = 0\n\n\\begin{code}\ny = 1\n\\end{code}"
+        """
+        > x = 0
+
+        \\begin{code}
+          y = 1
+        \\end{code}
+        """
         [ ("/items/0/value/name", "\"x\""),
           ("/items/1/value/name", "\"y\"")
         ]
 
-    Spec.it s "preserves line numbers" $ do
+    Spec.it s "works with latex then bird" $ do
       checkWith
         s
         ["--unlit"]
-        "comment\n\n> x = 0\n"
-        [("/items/0/location/line", "3")]
+        """
+        \\begin{code}
+          x = 0
+        \\end{code}
+
+        > y = 1
+        """
+        [ ("/items/0/value/name", "\"x\""),
+          ("/items/1/value/name", "\"y\"")
+        ]
 
 check :: (Stack.HasCallStack, Monad m) => Spec.Spec m n -> String -> [(String, String)] -> m ()
 check s = checkWith s []

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -1468,6 +1468,59 @@ spec s = Spec.describe s "integration" $ do
         """
         []
 
+  Spec.describe s "unlit" $ do
+    Spec.it s "works with bird style" $ do
+      checkWith
+        s
+        ["--unlit"]
+        "\n> x = 0\n"
+        [ ("/items/0/value/name", "\"x\""),
+          ("/items/0/value/kind", "\"Function\"")
+        ]
+
+    Spec.it s "works with latex style" $ do
+      checkWith
+        s
+        ["--unlit"]
+        "\\begin{code}\nx = 0\n\\end{code}"
+        [ ("/items/0/value/name", "\"x\""),
+          ("/items/0/value/kind", "\"Function\"")
+        ]
+
+    Spec.it s "works with module declaration in bird style" $ do
+      checkWith
+        s
+        ["--unlit"]
+        "\n> module M where\n\n> x = 0\n"
+        [ ("/name/value", "\"M\""),
+          ("/items/0/value/name", "\"x\"")
+        ]
+
+    Spec.it s "works with module declaration in latex style" $ do
+      checkWith
+        s
+        ["--unlit"]
+        "\\begin{code}\nmodule M where\nx = 0\n\\end{code}"
+        [ ("/name/value", "\"M\""),
+          ("/items/0/value/name", "\"x\"")
+        ]
+
+    Spec.it s "works with mixed styles" $ do
+      checkWith
+        s
+        ["--unlit"]
+        "\n>x = 0\n\n\\begin{code}\ny = 1\n\\end{code}"
+        [ ("/items/0/value/name", "\"x\""),
+          ("/items/1/value/name", "\"y\"")
+        ]
+
+    Spec.it s "preserves line numbers" $ do
+      checkWith
+        s
+        ["--unlit"]
+        "comment\n\n> x = 0\n"
+        [("/items/0/location/line", "3")]
+
 check :: (Stack.HasCallStack, Monad m) => Spec.Spec m n -> String -> [(String, String)] -> m ()
 check s = checkWith s []
 

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -1468,19 +1468,19 @@ spec s = Spec.describe s "integration" $ do
         """
         []
 
-  Spec.describe s "unlit" $ do
+  Spec.describe s "literate" $ do
     Spec.describe s "bird" $ do
       Spec.it s "works" $ do
         checkWith
           s
-          ["--unlit"]
+          ["--literate"]
           "> x = 0"
           [("/items/0/value/name", "\"x\"")]
 
       Spec.it s "preserves line numbers" $ do
         checkWith
           s
-          ["--unlit"]
+          ["--literate"]
           """
           comment
 
@@ -1492,7 +1492,7 @@ spec s = Spec.describe s "integration" $ do
       Spec.it s "works" $ do
         checkWith
           s
-          ["--unlit"]
+          ["--literate"]
           """
           \\begin{code}
           x = 0
@@ -1503,7 +1503,7 @@ spec s = Spec.describe s "integration" $ do
       Spec.it s "preserves line numbers" $ do
         checkWith
           s
-          ["--unlit"]
+          ["--literate"]
           """
           \\begin{code}
           x = 0
@@ -1514,7 +1514,7 @@ spec s = Spec.describe s "integration" $ do
     Spec.it s "works with bird then latex" $ do
       checkWith
         s
-        ["--unlit"]
+        ["--literate"]
         """
         > x = 0
 
@@ -1529,7 +1529,7 @@ spec s = Spec.describe s "integration" $ do
     Spec.it s "works with latex then bird" $ do
       checkWith
         s
-        ["--unlit"]
+        ["--literate"]
         """
         \\begin{code}
           x = 0

--- a/source/library/Scrod/Unlit.hs
+++ b/source/library/Scrod/Unlit.hs
@@ -1,0 +1,123 @@
+{-# LANGUAGE TemplateHaskellQuotes #-}
+
+module Scrod.Unlit where
+
+import qualified Control.Monad as Monad
+import qualified Data.Char as Char
+import qualified Scrod.Spec as Spec
+
+unlit :: String -> Either String String
+unlit input = do
+  let ls = lines input
+  (hasCode, outputLines) <- go ls Blank False False []
+  Monad.unless hasCode $ Left "no code in literate file"
+  Right $ unlines (reverse outputLines)
+  where
+    go [] _ True _ _ = Left "unterminated \\begin{code}"
+    go [] _ False hasCode acc = Right (hasCode, acc)
+    go (line : rest) prev inLatex hasCode acc =
+      let cls = classifyLine line
+       in case inLatex of
+            True -> case cls of
+              EndCode -> go rest EndCode False hasCode ("" : acc)
+              BeginCode -> Left "nested \\begin{code}"
+              _ -> go rest cls True True (line : acc)
+            False -> case cls of
+              Blank -> go rest Blank False hasCode ("" : acc)
+              Bird -> do
+                Monad.when (prev == Comment) $ Left "bird track adjacent to comment"
+                go rest Bird False True (drop 1 line : acc)
+              BeginCode -> go rest BeginCode True True ("" : acc)
+              EndCode -> Left "unexpected \\end{code}"
+              Comment -> do
+                Monad.when (prev == Bird) $ Left "bird track adjacent to comment"
+                go rest Comment False hasCode ("" : acc)
+
+data LineClass
+  = Blank
+  | Bird
+  | BeginCode
+  | EndCode
+  | Comment
+  deriving (Eq)
+
+classifyLine :: String -> LineClass
+classifyLine line
+  | all Char.isSpace line = Blank
+  | '>' : _ <- line = Bird
+  | matchesDelimiter "\\begin{code}" line = BeginCode
+  | matchesDelimiter "\\end{code}" line = EndCode
+  | otherwise = Comment
+
+matchesDelimiter :: String -> String -> Bool
+matchesDelimiter delim line =
+  let stripped = dropWhile Char.isSpace line
+      (prefix, _) = splitAt (length delim) stripped
+   in fmap Char.toLower prefix == delim
+
+spec :: (Applicative m, Monad n) => Spec.Spec m n -> n ()
+spec s = do
+  Spec.named s 'unlit $ do
+    Spec.it s "fails with no code" $ do
+      Spec.assertEq s (unlit "") $ Left "no code in literate file"
+
+    Spec.it s "fails with only comments" $ do
+      Spec.assertEq s (unlit "hello") $ Left "no code in literate file"
+
+    Spec.it s "works with empty latex block" $ do
+      Spec.assertEq s (unlit "\\begin{code}\n\\end{code}") $ Right "\n\n"
+
+    Spec.it s "works with bird style" $ do
+      Spec.assertEq s (unlit "> x = 0") $ Right " x = 0\n"
+
+    Spec.it s "works with bird style without space" $ do
+      Spec.assertEq s (unlit ">x = 0") $ Right "x = 0\n"
+
+    Spec.it s "works with latex style" $ do
+      Spec.assertEq s (unlit "\\begin{code}\nx = 0\n\\end{code}") $ Right "\nx = 0\n\n"
+
+    Spec.describe s "bird adjacency" $ do
+      Spec.it s "fails with comment before bird" $ do
+        Spec.assertEq s (unlit "before\n> x = 0") $ Left "bird track adjacent to comment"
+
+      Spec.it s "works with blank before bird" $ do
+        Spec.assertEq s (unlit "before\n\n> x = 0") $ Right "\n\n x = 0\n"
+
+      Spec.it s "fails with comment after bird" $ do
+        Spec.assertEq s (unlit "> x = 0\nafter") $ Left "bird track adjacent to comment"
+
+      Spec.it s "works with blank after bird" $ do
+        Spec.assertEq s (unlit "> x = 0\n\nafter") $ Right " x = 0\n\n\n"
+
+    Spec.describe s "latex blocks" $ do
+      Spec.it s "fails with unclosed begin" $ do
+        Spec.assertEq s (unlit "\\begin{code}") $ Left "unterminated \\begin{code}"
+
+      Spec.it s "fails with extra end" $ do
+        Spec.assertEq s (unlit "\\begin{code}\n\\end{code}\n\\end{code}") $ Left "unexpected \\end{code}"
+
+      Spec.it s "fails with end without begin" $ do
+        Spec.assertEq s (unlit "\\end{code}") $ Left "unexpected \\end{code}"
+
+      Spec.it s "fails with nested begin" $ do
+        Spec.assertEq s (unlit "\\begin{code}\n\\begin{code}") $ Left "nested \\begin{code}"
+
+    Spec.describe s "latex indentation" $ do
+      Spec.it s "works with indented delimiters" $ do
+        Spec.assertEq s (unlit " \\begin{code}\nx = 0\n \\end{code}") $ Right "\nx = 0\n\n"
+
+      Spec.it s "fails with spaces in delimiter" $ do
+        Spec.assertEq s (unlit " \\ begin { code }\nx = 0\n \\end{code}") $ Left "unexpected \\end{code}"
+
+    Spec.describe s "latex trailing text" $ do
+      Spec.it s "works with text after delimiters" $ do
+        Spec.assertEq s (unlit "\\begin{code} foo\nx = 0\n\\end{code} bar") $ Right "\nx = 0\n\n"
+
+      Spec.it s "fails with text before delimiter" $ do
+        Spec.assertEq s (unlit "foo \\begin{code}\nx = 0\nbar \\end{code}") $ Left "no code in literate file"
+
+    Spec.it s "is case insensitive for latex" $ do
+      Spec.assertEq s (unlit "\\BEGIN{CODE}\nx = 0\n\\END{CODE}") $ Right "\nx = 0\n\n"
+
+    Spec.it s "converts comment lines to blank lines" $ do
+      Spec.assertEq s (unlit "comment\n\n> x = 0\n\ncomment") $ Right "\n\n x = 0\n\n\n"

--- a/source/library/Scrod/Unlit.hs
+++ b/source/library/Scrod/Unlit.hs
@@ -26,7 +26,7 @@ unlit input = do
               Blank -> go rest Blank False hasCode ("" : acc)
               Bird -> do
                 Monad.when (prev == Comment) $ Left "bird track adjacent to comment"
-                go rest Bird False True (drop 1 line : acc)
+                go rest Bird False True ((' ' : drop 1 line) : acc)
               BeginCode -> go rest BeginCode True True ("" : acc)
               EndCode -> Left "unexpected \\end{code}"
               Comment -> do
@@ -68,10 +68,10 @@ spec s = do
       Spec.assertEq s (unlit "\\begin{code}\n\\end{code}") $ Right "\n\n"
 
     Spec.it s "works with bird style" $ do
-      Spec.assertEq s (unlit "> x = 0") $ Right " x = 0\n"
+      Spec.assertEq s (unlit "> x = 0") $ Right "  x = 0\n"
 
     Spec.it s "works with bird style without space" $ do
-      Spec.assertEq s (unlit ">x = 0") $ Right "x = 0\n"
+      Spec.assertEq s (unlit ">x = 0") $ Right " x = 0\n"
 
     Spec.it s "works with latex style" $ do
       Spec.assertEq s (unlit "\\begin{code}\nx = 0\n\\end{code}") $ Right "\nx = 0\n\n"
@@ -81,13 +81,13 @@ spec s = do
         Spec.assertEq s (unlit "before\n> x = 0") $ Left "bird track adjacent to comment"
 
       Spec.it s "works with blank before bird" $ do
-        Spec.assertEq s (unlit "before\n\n> x = 0") $ Right "\n\n x = 0\n"
+        Spec.assertEq s (unlit "before\n\n> x = 0") $ Right "\n\n  x = 0\n"
 
       Spec.it s "fails with comment after bird" $ do
         Spec.assertEq s (unlit "> x = 0\nafter") $ Left "bird track adjacent to comment"
 
       Spec.it s "works with blank after bird" $ do
-        Spec.assertEq s (unlit "> x = 0\n\nafter") $ Right " x = 0\n\n\n"
+        Spec.assertEq s (unlit "> x = 0\n\nafter") $ Right "  x = 0\n\n\n"
 
     Spec.describe s "latex blocks" $ do
       Spec.it s "fails with unclosed begin" $ do
@@ -120,4 +120,4 @@ spec s = do
       Spec.assertEq s (unlit "\\BEGIN{CODE}\nx = 0\n\\END{CODE}") $ Right "\nx = 0\n\n"
 
     Spec.it s "converts comment lines to blank lines" $ do
-      Spec.assertEq s (unlit "comment\n\n> x = 0\n\ncomment") $ Right "\n\n x = 0\n\n\n"
+      Spec.assertEq s (unlit "comment\n\n> x = 0\n\ncomment") $ Right "\n\n  x = 0\n\n\n"

--- a/wasm/www/index.html
+++ b/wasm/www/index.html
@@ -1,27 +1,30 @@
-<!DOCTYPE html>
-<html lang="en">
+<!doctype html>
+<html lang='en-US'>
+
 <head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta charset='utf-8'>
+  <meta name='viewport' content='initial-scale = 1, width = device-width'>
   <title>Scrod</title>
-  <link rel="stylesheet" href="style.css">
+  <link rel='stylesheet' href='style.css'>
 </head>
+
 <body>
-  <div class="pane input-pane">
-    <label for="source" class="sr-only">Haskell source code</label>
-    <textarea id="source" placeholder="Enter Haskell source..." spellcheck="false"></textarea>
+  <div class='pane input-pane'>
+    <label for='source' class='sr-only'>Haskell source code</label>
+    <textarea id='source' placeholder='Enter Haskell source...' spellcheck='false'></textarea>
   </div>
-  <div class="pane output-pane">
-    <div class="toolbar">
-      <label for="format" class="sr-only">Output format</label>
-      <select id="format">
-        <option value="html" selected>HTML</option>
-        <option value="json">JSON</option>
+  <div class='pane output-pane'>
+    <div class='toolbar'>
+      <label for='format' class='sr-only'>Output format</label>
+      <select id='format'>
+        <option value='html' selected>HTML</option>
+        <option value='json'>JSON</option>
       </select>
-      <label><input type="checkbox" id="unlit"> Literate</label>
+      <label><input type='checkbox' id='unlit'> Literate</label>
     </div>
-    <div id="output" role="region" aria-live="polite" aria-label="Output"></div>
+    <div id='output' role='region' aria-live='polite' aria-label='Output'></div>
   </div>
-  <script src="index.js"></script>
+  <script src='index.js'></script>
 </body>
+
 </html>

--- a/wasm/www/index.html
+++ b/wasm/www/index.html
@@ -20,7 +20,7 @@
         <option value='html' selected>HTML</option>
         <option value='json'>JSON</option>
       </select>
-      <label><input type='checkbox' id='unlit'> Literate</label>
+      <label><input type='checkbox' id='literate'> Literate</label>
     </div>
     <div id='output' role='region' aria-live='polite' aria-label='Output'></div>
   </div>

--- a/wasm/www/index.html
+++ b/wasm/www/index.html
@@ -18,6 +18,7 @@
         <option value="html" selected>HTML</option>
         <option value="json">JSON</option>
       </select>
+      <label><input type="checkbox" id="unlit"> Literate</label>
     </div>
     <div id="output" role="region" aria-live="polite" aria-label="Output"></div>
   </div>

--- a/wasm/www/index.js
+++ b/wasm/www/index.js
@@ -4,7 +4,7 @@ const worker = new Worker('worker.js', { type: 'module' });
 const source = document.getElementById('source');
 const output = document.getElementById('output');
 const format = document.getElementById('format');
-const unlit = document.getElementById('unlit');
+const literate = document.getElementById('literate');
 const shadow = output.attachShadow({ mode: 'open' });
 shadow.innerHTML = '<p style="color: #888; font-style: italic">Loading WASM module...</p>';
 let debounceTimer;
@@ -71,8 +71,8 @@ function updateHash() {
     if (format.value !== 'html') {
       params.set('format', format.value);
     }
-    if (unlit.checked) {
-      params.set('unlit', 'true');
+    if (literate.checked) {
+      params.set('literate', 'true');
     }
     params.set('input', encodeHash(source.value));
     history.replaceState(null, '', `#${params.toString()}`);
@@ -83,7 +83,7 @@ function updateHash() {
 
 function process() {
   if (ready) {
-    worker.postMessage({ source: source.value, format: format.value, unlit: unlit.checked });
+    worker.postMessage({ source: source.value, format: format.value, literate: literate.checked });
   }
 }
 
@@ -100,7 +100,7 @@ format.addEventListener('change', function () {
   process();
 });
 
-unlit.addEventListener('change', function () {
+literate.addEventListener('change', function () {
   updateHash();
   process();
 });
@@ -118,8 +118,8 @@ if (location.hash.length > 1) {
           format.value = hashFormat;
         }
       }
-      if (params.get('unlit') === 'true') {
-        unlit.checked = true;
+      if (params.get('literate') === 'true') {
+        literate.checked = true;
       }
     } else {
       // Legacy format: bare base64-encoded source

--- a/wasm/www/index.js
+++ b/wasm/www/index.js
@@ -4,6 +4,7 @@ const worker = new Worker("worker.js", { type: "module" });
 const source = document.getElementById("source");
 const output = document.getElementById("output");
 const format = document.getElementById("format");
+const unlit = document.getElementById("unlit");
 const shadow = output.attachShadow({ mode: "open" });
 shadow.innerHTML = '<p style="color: #888; font-style: italic">Loading WASM module...</p>';
 let debounceTimer;
@@ -70,6 +71,9 @@ function updateHash() {
     if (format.value !== "html") {
       params.set("format", format.value);
     }
+    if (unlit.checked) {
+      params.set("unlit", "true");
+    }
     params.set("input", encodeHash(source.value));
     history.replaceState(null, "", "#" + params.toString());
   } else {
@@ -79,7 +83,7 @@ function updateHash() {
 
 function process() {
   if (ready) {
-    worker.postMessage({ source: source.value, format: format.value });
+    worker.postMessage({ source: source.value, format: format.value, unlit: unlit.checked });
   }
 }
 
@@ -96,6 +100,11 @@ format.addEventListener("change", function () {
   process();
 });
 
+unlit.addEventListener("change", function () {
+  updateHash();
+  process();
+});
+
 // Load content from URL hash on startup
 if (location.hash.length > 1) {
   try {
@@ -108,6 +117,9 @@ if (location.hash.length > 1) {
         if (hashFormat === "html" || hashFormat === "json") {
           format.value = hashFormat;
         }
+      }
+      if (params.get("unlit") === "true") {
+        unlit.checked = true;
       }
     } else {
       // Legacy format: bare base64-encoded source

--- a/wasm/www/index.js
+++ b/wasm/www/index.js
@@ -1,27 +1,27 @@
-"use strict";
+'use strict';
 
-const worker = new Worker("worker.js", { type: "module" });
-const source = document.getElementById("source");
-const output = document.getElementById("output");
-const format = document.getElementById("format");
-const unlit = document.getElementById("unlit");
-const shadow = output.attachShadow({ mode: "open" });
+const worker = new Worker('worker.js', { type: 'module' });
+const source = document.getElementById('source');
+const output = document.getElementById('output');
+const format = document.getElementById('format');
+const unlit = document.getElementById('unlit');
+const shadow = output.attachShadow({ mode: 'open' });
 shadow.innerHTML = '<p style="color: #888; font-style: italic">Loading WASM module...</p>';
 let debounceTimer;
 let ready = false;
 
 function showError(message) {
-  shadow.textContent = "";
-  const pre = document.createElement("pre");
-  pre.style.cssText = "color: #c00; white-space: pre-wrap; font-family: monospace; font-size: 14px";
+  shadow.textContent = '';
+  const pre = document.createElement('pre');
+  pre.style.cssText = 'color: #c00; white-space: pre-wrap; font-family: monospace; font-size: 14px';
   pre.textContent = message;
   shadow.appendChild(pre);
 }
 
 function showJson(json) {
-  shadow.textContent = "";
-  const pre = document.createElement("pre");
-  pre.style.cssText = "white-space: pre-wrap; font-family: monospace; font-size: 14px";
+  shadow.textContent = '';
+  const pre = document.createElement('pre');
+  pre.style.cssText = 'white-space: pre-wrap; font-family: monospace; font-size: 14px';
   try {
     pre.textContent = JSON.stringify(JSON.parse(json), null, 2);
   } catch (e) {
@@ -32,31 +32,31 @@ function showJson(json) {
 
 worker.onmessage = function (e) {
   const msg = e.data;
-  if (msg.tag === "ready") {
+  if (msg.tag === 'ready') {
     ready = true;
-    shadow.innerHTML = "";
+    shadow.innerHTML = '';
     if (source.value) {
       process();
     }
-  } else if (msg.tag === "result") {
-    if (msg.format === "json") {
+  } else if (msg.tag === 'result') {
+    if (msg.format === 'json') {
       showJson(msg.value);
     } else {
       shadow.innerHTML = msg.value;
     }
-  } else if (msg.tag === "error") {
+  } else if (msg.tag === 'error') {
     showError(msg.message);
   }
 };
 
 worker.onerror = function (e) {
-  showError("Worker error: " + e.message);
+  showError(`Worker error: ${e.message}`);
 };
 
 function encodeHash(text) {
   return btoa(new TextEncoder().encode(text).reduce(function (s, b) {
     return s + String.fromCharCode(b);
-  }, ""));
+  }, ''));
 }
 
 function decodeHash(hash) {
@@ -68,16 +68,16 @@ function decodeHash(hash) {
 function updateHash() {
   if (source.value) {
     var params = new URLSearchParams();
-    if (format.value !== "html") {
-      params.set("format", format.value);
+    if (format.value !== 'html') {
+      params.set('format', format.value);
     }
     if (unlit.checked) {
-      params.set("unlit", "true");
+      params.set('unlit', 'true');
     }
-    params.set("input", encodeHash(source.value));
-    history.replaceState(null, "", "#" + params.toString());
+    params.set('input', encodeHash(source.value));
+    history.replaceState(null, '', `#${params.toString()}`);
   } else {
-    history.replaceState(null, "", location.pathname);
+    history.replaceState(null, '', location.pathname);
   }
 }
 
@@ -87,7 +87,7 @@ function process() {
   }
 }
 
-source.addEventListener("input", function () {
+source.addEventListener('input', function () {
   clearTimeout(debounceTimer);
   debounceTimer = setTimeout(function () {
     updateHash();
@@ -95,12 +95,12 @@ source.addEventListener("input", function () {
   }, 300);
 });
 
-format.addEventListener("change", function () {
+format.addEventListener('change', function () {
   updateHash();
   process();
 });
 
-unlit.addEventListener("change", function () {
+unlit.addEventListener('change', function () {
   updateHash();
   process();
 });
@@ -110,15 +110,15 @@ if (location.hash.length > 1) {
   try {
     var hash = location.hash.slice(1);
     var params = new URLSearchParams(hash);
-    if (params.has("input")) {
-      source.value = decodeHash(params.get("input"));
-      if (params.has("format")) {
-        var hashFormat = params.get("format");
-        if (hashFormat === "html" || hashFormat === "json") {
+    if (params.has('input')) {
+      source.value = decodeHash(params.get('input'));
+      if (params.has('format')) {
+        var hashFormat = params.get('format');
+        if (hashFormat === 'html' || hashFormat === 'json') {
           format.value = hashFormat;
         }
       }
-      if (params.get("unlit") === "true") {
+      if (params.get('unlit') === 'true') {
         unlit.checked = true;
       }
     } else {

--- a/wasm/www/style.css
+++ b/wasm/www/style.css
@@ -54,7 +54,8 @@ body {
   flex-shrink: 0;
 }
 
-.toolbar select {
+.toolbar select,
+.toolbar label {
   font-family: system-ui, sans-serif;
   font-size: 14px;
   padding: 2px 4px;

--- a/wasm/www/worker.js
+++ b/wasm/www/worker.js
@@ -54,7 +54,7 @@ onmessage = async function (e) {
     try {
       const msg = e.data;
       const args = ['--format', msg.format];
-      if (msg.unlit) args.push('--unlit');
+      if (msg.literate) args.push('--literate');
       const result = await processHaskell(args, msg.source);
       postMessage({ tag: 'result', value: result, format: msg.format });
     } catch (err) {

--- a/wasm/www/worker.js
+++ b/wasm/www/worker.js
@@ -57,7 +57,9 @@ onmessage = async function (e) {
   if (processHaskell) {
     try {
       const msg = e.data;
-      const result = await processHaskell(['--format', msg.format], msg.source);
+      const args = ['--format', msg.format];
+      if (msg.unlit) args.push('--unlit');
+      const result = await processHaskell(args, msg.source);
       postMessage({ tag: "result", value: result, format: msg.format });
     } catch (err) {
       postMessage({ tag: "error", message: err.message });

--- a/wasm/www/worker.js
+++ b/wasm/www/worker.js
@@ -1,5 +1,5 @@
-import ghcWasmJsffi from "./ghc_wasm_jsffi.js";
-import { WASI, File, OpenFile, ConsoleStdout } from "./vendor/browser_wasi_shim/index.js";
+import ghcWasmJsffi from './ghc_wasm_jsffi.js';
+import { WASI, File, OpenFile, ConsoleStdout } from './vendor/browser_wasi_shim/index.js';
 
 let processHaskell;
 
@@ -17,7 +17,7 @@ async function initialize() {
     {
       get: function (_, property) {
         if (!exports) {
-          throw new Error("WASM exports not initialized");
+          throw new Error('WASM exports not initialized');
         }
         return exports[property];
       },
@@ -26,14 +26,10 @@ async function initialize() {
 
   const jsffi = ghcWasmJsffi(exportsProxy);
 
-  const response = await fetch("scrod-wasm.wasm");
+  const response = await fetch('scrod-wasm.wasm');
   if (!response.ok) {
     throw new Error(
-      "Failed to fetch WASM module (status " +
-        response.status +
-        " " +
-        response.statusText +
-        ")"
+      `Failed to fetch WASM module (status ${response.status} ${response.statusText})`
     );
   }
   const wasmBuffer = await response.arrayBuffer();
@@ -46,11 +42,11 @@ async function initialize() {
   wasi.initialize(result.instance);
 
   processHaskell = result.instance.exports.processHaskell;
-  postMessage({ tag: "ready" });
+  postMessage({ tag: 'ready' });
 }
 
 initialize().catch(function (e) {
-  postMessage({ tag: "error", message: "Failed to load WASM module: " + e.message });
+  postMessage({ tag: 'error', message: 'Failed to load WASM module: ' + e.message });
 });
 
 onmessage = async function (e) {
@@ -60,11 +56,11 @@ onmessage = async function (e) {
       const args = ['--format', msg.format];
       if (msg.unlit) args.push('--unlit');
       const result = await processHaskell(args, msg.source);
-      postMessage({ tag: "result", value: result, format: msg.format });
+      postMessage({ tag: 'result', value: result, format: msg.format });
     } catch (err) {
-      postMessage({ tag: "error", message: err.message });
+      postMessage({ tag: 'error', message: err.message });
     }
   } else {
-    postMessage({ tag: "error", message: "WASM module is not initialized yet." });
+    postMessage({ tag: 'error', message: 'WASM module is not initialized yet.' });
   }
 };


### PR DESCRIPTION
Fixes #29. 

## Summary
- Add `Scrod.Unlit` module implementing literate Haskell unlitting with support for bird-style (`>` prefix) and LaTeX-style (`\begin{code}`/`\end{code}`) blocks
- Add `--literate` CLI flag (off by default, togglable bool like `--help`/`--version`) wired through Flag, Config, and the main pipeline
- Add "Literate" checkbox to the web app toolbar, persisted in shareable URL hash fragments
- Add 22 unit tests for the unlit function and 6 integration tests exercising the full pipeline

## Test plan
- [x] All 719 tests pass (`cabal test --test-options='--hide-successes'`)
- [x] Pedantic build passes (`cabal build --flags=pedantic`)
- [x] Ormolu formatting passes on all changed files
- [x] HLint passes on all changed files
- [x] `cabal-gild` and `cabal check` pass
- [x] Smoke tested CLI: `printf '\n> x = 0\n' | cabal run scrod -- --literate --format json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)