### PR TITLE
Add CPP preprocessing support

### DIFF
--- a/scrod.cabal
+++ b/scrod.cabal
@@ -122,6 +122,9 @@ library
     Scrod.Core.TableCell
     Scrod.Core.Version
     Scrod.Core.Warning
+    Scrod.Cpp
+    Scrod.Cpp.Directive
+    Scrod.Cpp.Expr
     Scrod.Css.AtRule
     Scrod.Css.Block
     Scrod.Css.BlockContent

--- a/source/library/Scrod/Cpp.hs
+++ b/source/library/Scrod/Cpp.hs
@@ -1,0 +1,218 @@
+{-# LANGUAGE TemplateHaskellQuotes #-}
+
+module Scrod.Cpp where
+
+import qualified Data.Map.Strict as Map
+import qualified Data.Maybe as Maybe
+import qualified Scrod.Cpp.Directive as Directive
+import qualified Scrod.Cpp.Expr as Expr
+import qualified Scrod.Spec as Spec
+
+data Branch
+  = Active
+  | Inactive
+  | Done
+  deriving (Eq)
+
+data State = MkState
+  { defines :: Map.Map String String,
+    stack :: [Branch],
+    seenElse :: [Bool]
+  }
+
+initialState :: State
+initialState =
+  MkState
+    { defines = Map.empty,
+      stack = [],
+      seenElse = []
+    }
+
+cpp :: String -> Either String String
+cpp input = do
+  let ls = lines input
+  outputLines <- go ls initialState []
+  Right $ unlines (reverse outputLines)
+
+go :: [String] -> State -> [String] -> Either String [String]
+go [] state acc =
+  if null (stack state)
+    then Right acc
+    else Left "unterminated #if"
+go (line : rest) state acc =
+  case Directive.parse line of
+    Nothing -> go rest state (keepOrBlank state line : acc)
+    Just dir -> do
+      state' <- processDirective state dir
+      go rest state' ("" : acc)
+
+isActive :: State -> Bool
+isActive state = case stack state of
+  [] -> True
+  Active : _ -> True
+  _ -> False
+
+keepOrBlank :: State -> String -> String
+keepOrBlank state line =
+  if isActive state then line else ""
+
+processDirective :: State -> Directive.Directive -> Either String State
+processDirective state dir = case dir of
+  Directive.If expr -> do
+    if isActive state
+      then do
+        val <- Expr.evaluate (defines state) expr
+        let branch = if val /= 0 then Active else Inactive
+        Right state {stack = branch : stack state, seenElse = False : seenElse state}
+      else
+        Right state {stack = Inactive : stack state, seenElse = False : seenElse state}
+  Directive.Ifdef name ->
+    processDirective state (Directive.If $ "defined(" <> name <> ")")
+  Directive.Ifndef name ->
+    processDirective state (Directive.If $ "!defined(" <> name <> ")")
+  Directive.Elif expr -> case (stack state, seenElse state) of
+    ([], _) -> Left "unexpected #elif without matching #if"
+    (_, True : _) -> Left "unexpected #elif after #else"
+    (Active : rest, e : es) ->
+      Right state {stack = Done : rest, seenElse = e : es}
+    (Inactive : rest, e : es) -> do
+      let parentActive = case rest of
+            [] -> True
+            Active : _ -> True
+            _ -> False
+      if parentActive
+        then do
+          val <- Expr.evaluate (defines state) expr
+          let branch = if val /= 0 then Active else Inactive
+          Right state {stack = branch : rest, seenElse = e : es}
+        else Right state {stack = Inactive : rest, seenElse = e : es}
+    (Done : _, _ : _) ->
+      Right state
+    (_, []) -> Left "unexpected #elif without matching #if"
+  Directive.Else -> case (stack state, seenElse state) of
+    ([], _) -> Left "unexpected #else without matching #if"
+    (_, True : _) -> Left "unexpected #else after #else"
+    (Active : rest, _ : es) ->
+      Right state {stack = Done : rest, seenElse = True : es}
+    (Inactive : rest, _ : es) -> do
+      let parentActive = case rest of
+            [] -> True
+            Active : _ -> True
+            _ -> False
+      if parentActive
+        then Right state {stack = Active : rest, seenElse = True : es}
+        else Right state {stack = Inactive : rest, seenElse = True : es}
+    (Done : _, _ : es) ->
+      Right state {stack = Done : stack state, seenElse = True : es}
+    (_, []) -> Left "unexpected #else without matching #if"
+  Directive.Endif -> case (stack state, seenElse state) of
+    ([], _) -> Left "unexpected #endif without matching #if"
+    (_ : rest, _ : es) -> Right state {stack = rest, seenElse = es}
+    (_, []) -> Left "unexpected #endif without matching #if"
+  Directive.Define name mValue ->
+    if isActive state
+      then
+        let v = Maybe.fromMaybe "1" mValue
+         in Right state {defines = Map.insert name v (defines state)}
+      else Right state
+  Directive.Undef name ->
+    if isActive state
+      then Right state {defines = Map.delete name (defines state)}
+      else Right state
+  Directive.Other -> Right state
+
+spec :: (Applicative m, Monad n) => Spec.Spec m n -> n ()
+spec s = do
+  Spec.named s 'cpp $ do
+    Spec.it s "passes through source without directives" $ do
+      Spec.assertEq s (cpp "module M where") $ Right "module M where\n"
+
+    Spec.it s "replaces directive lines with blank lines" $ do
+      Spec.assertEq s (cpp "#define FOO\nmodule M where") $ Right "\nmodule M where\n"
+
+    Spec.it s "keeps active ifdef branch" $ do
+      Spec.assertEq s (cpp "#define FOO\n#ifdef FOO\nkeep\n#endif") $ Right "\n\nkeep\n\n"
+
+    Spec.it s "removes inactive ifdef branch" $ do
+      Spec.assertEq s (cpp "#ifdef FOO\nskip\n#endif") $ Right "\n\n\n"
+
+    Spec.it s "handles ifndef" $ do
+      Spec.assertEq s (cpp "#ifndef FOO\nkeep\n#endif") $ Right "\nkeep\n\n"
+
+    Spec.it s "handles else branch" $ do
+      Spec.assertEq s (cpp "#ifdef FOO\nskip\n#else\nkeep\n#endif") $ Right "\n\n\nkeep\n\n"
+
+    Spec.it s "handles elif" $ do
+      Spec.assertEq s (cpp "#if 0\nskip\n#elif 1\nkeep\n#endif") $ Right "\n\n\nkeep\n\n"
+
+    Spec.it s "handles nested if" $ do
+      Spec.assertEq s (cpp "#if 1\n#if 1\nkeep\n#endif\n#endif") $ Right "\n\nkeep\n\n\n"
+
+    Spec.it s "handles nested if in inactive branch" $ do
+      Spec.assertEq s (cpp "#if 0\n#if 1\nskip\n#endif\n#endif") $ Right "\n\n\n\n\n"
+
+    Spec.it s "handles undef" $ do
+      Spec.assertEq s (cpp "#define FOO\n#undef FOO\n#ifdef FOO\nskip\n#endif") $ Right "\n\n\n\n\n"
+
+    Spec.it s "fails with unmatched endif" $ do
+      Spec.assertEq s (cpp "#endif") $ Left "unexpected #endif without matching #if"
+
+    Spec.it s "fails with unterminated if" $ do
+      Spec.assertEq s (cpp "#if 1\ncode") $ Left "unterminated #if"
+
+    Spec.it s "fails with else after else" $ do
+      Spec.assertEq s (cpp "#if 1\n#else\n#else\n#endif") $ Left "unexpected #else after #else"
+
+    Spec.it s "fails with elif after else" $ do
+      Spec.assertEq s (cpp "#if 0\n#else\n#elif 1\n#endif") $ Left "unexpected #elif after #else"
+
+    Spec.it s "preserves line count" $ do
+      Spec.assertEq s (length . lines <$> cpp "#if 1\nline2\nline3\n#endif\nline5") $ Right 5
+
+    Spec.it s "handles typical Haskell CPP pattern" $ do
+      Spec.assertEq
+        s
+        ( cpp $
+            unlines
+              [ "#ifdef __GLASGOW_HASKELL__",
+                "import GHC.Specific",
+                "#else",
+                "import Data.Old",
+                "#endif"
+              ]
+        )
+        ( Right $
+            unlines
+              [ "",
+                "",
+                "",
+                "import Data.Old",
+                ""
+              ]
+        )
+
+    Spec.it s "handles define then ifdef" $ do
+      Spec.assertEq
+        s
+        ( cpp $
+            unlines
+              [ "#define MY_FLAG",
+                "#ifdef MY_FLAG",
+                "import My.Module",
+                "#endif"
+              ]
+        )
+        ( Right $
+            unlines
+              [ "",
+                "",
+                "import My.Module",
+                ""
+              ]
+        )
+
+    Spec.it s "handles define with value in if" $ do
+      Spec.assertEq s (cpp "#define VER 10\n#if VER >= 10\nkeep\n#endif") $ Right "\n\nkeep\n\n"
+
+    Spec.it s "replaces other directives with blank lines" $ do
+      Spec.assertEq s (cpp "#include <stdio.h>\nmodule M where") $ Right "\nmodule M where\n"

--- a/source/library/Scrod/Cpp.hs
+++ b/source/library/Scrod/Cpp.hs
@@ -103,7 +103,7 @@ processDirective state dir = case dir of
         then Right state {stack = Active : rest, seenElse = True : es}
         else Right state {stack = Inactive : rest, seenElse = True : es}
     (Done : _, _ : es) ->
-      Right state {stack = Done : stack state, seenElse = True : es}
+      Right state {stack = stack state, seenElse = True : es}
     (_, []) -> Left "unexpected #else without matching #if"
   Directive.Endif -> case (stack state, seenElse state) of
     ([], _) -> Left "unexpected #endif without matching #if"
@@ -165,6 +165,9 @@ spec s = do
 
     Spec.it s "fails with elif after else" $ do
       Spec.assertEq s (cpp "#if 0\n#else\n#elif 1\n#endif") $ Left "unexpected #elif after #else"
+
+    Spec.it s "handles else after elif" $ do
+      Spec.assertEq s (cpp "#if 1\nkeep\n#elif 0\nskip\n#else\nskip\n#endif") $ Right "\nkeep\n\n\n\n\n\n"
 
     Spec.it s "preserves line count" $ do
       Spec.assertEq s (length . lines <$> cpp "#if 1\nline2\nline3\n#endif\nline5") $ Right 5

--- a/source/library/Scrod/Cpp.hs
+++ b/source/library/Scrod/Cpp.hs
@@ -35,16 +35,17 @@ cpp input = do
   Right $ unlines (reverse outputLines)
 
 go :: [String] -> State -> [String] -> Either String [String]
-go [] state acc =
-  if null (stack state)
-    then Right acc
-    else Left "unterminated #if"
-go (line : rest) state acc =
-  case Directive.parse line of
-    Nothing -> go rest state (keepOrBlank state line : acc)
-    Just dir -> do
-      state' <- processDirective state dir
-      go rest state' ("" : acc)
+go ls state acc = case ls of
+  [] ->
+    if null (stack state)
+      then Right acc
+      else Left "unterminated #if"
+  line : rest ->
+    case Directive.parse line of
+      Nothing -> go rest state (keepOrBlank state line : acc)
+      Just dir -> do
+        state' <- processDirective state dir
+        go rest state' ("" : acc)
 
 isActive :: State -> Bool
 isActive state = case stack state of

--- a/source/library/Scrod/Cpp/Directive.hs
+++ b/source/library/Scrod/Cpp/Directive.hs
@@ -1,0 +1,102 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TemplateHaskellQuotes #-}
+
+module Scrod.Cpp.Directive where
+
+import qualified Scrod.Spec as Spec
+import qualified Text.Parsec as Parsec
+
+data Directive
+  = If String
+  | Ifdef String
+  | Ifndef String
+  | Elif String
+  | Else
+  | Endif
+  | Define String (Maybe String)
+  | Undef String
+  | Other
+  deriving (Eq, Show)
+
+parse :: String -> Maybe Directive
+parse = either (const Nothing) Just . Parsec.parse directive ""
+
+directive :: (Parsec.Stream s m Char) => Parsec.ParsecT s u m Directive
+directive = do
+  Parsec.skipMany (Parsec.oneOf " \t")
+  _ <- Parsec.char '#'
+  Parsec.skipMany (Parsec.oneOf " \t")
+  keyword <- Parsec.many Parsec.letter
+  case keyword of
+    "if" -> If <$> rest
+    "ifdef" -> Ifdef <$> name
+    "ifndef" -> Ifndef <$> name
+    "elif" -> Elif <$> rest
+    "else" -> pure Else
+    "endif" -> pure Endif
+    "define" -> do
+      n <- name
+      Define n <$> value
+    "undef" -> Undef <$> name
+    _ -> pure Other
+
+name :: (Parsec.Stream s m Char) => Parsec.ParsecT s u m String
+name = do
+  Parsec.skipMany1 (Parsec.oneOf " \t")
+  Parsec.many1 (Parsec.alphaNum Parsec.<|> Parsec.char '_')
+
+rest :: (Parsec.Stream s m Char) => Parsec.ParsecT s u m String
+rest = do
+  Parsec.skipMany1 (Parsec.oneOf " \t")
+  Parsec.many Parsec.anyChar
+
+value :: (Parsec.Stream s m Char) => Parsec.ParsecT s u m (Maybe String)
+value =
+  Parsec.optionMaybe $ do
+    Parsec.skipMany1 (Parsec.oneOf " \t")
+    Parsec.many1 Parsec.anyChar
+
+spec :: (Applicative m, Monad n) => Spec.Spec m n -> n ()
+spec s = do
+  Spec.named s 'parse $ do
+    Spec.it s "parses #if" $ do
+      Spec.assertEq s (parse "#if 1") $ Just (If "1")
+
+    Spec.it s "parses #ifdef" $ do
+      Spec.assertEq s (parse "#ifdef FOO") $ Just (Ifdef "FOO")
+
+    Spec.it s "parses #ifndef" $ do
+      Spec.assertEq s (parse "#ifndef FOO") $ Just (Ifndef "FOO")
+
+    Spec.it s "parses #elif" $ do
+      Spec.assertEq s (parse "#elif 0") $ Just (Elif "0")
+
+    Spec.it s "parses #else" $ do
+      Spec.assertEq s (parse "#else") $ Just Else
+
+    Spec.it s "parses #endif" $ do
+      Spec.assertEq s (parse "#endif") $ Just Endif
+
+    Spec.it s "parses #define without value" $ do
+      Spec.assertEq s (parse "#define FOO") $ Just (Define "FOO" Nothing)
+
+    Spec.it s "parses #define with value" $ do
+      Spec.assertEq s (parse "#define FOO 42") $ Just (Define "FOO" (Just "42"))
+
+    Spec.it s "parses #undef" $ do
+      Spec.assertEq s (parse "#undef FOO") $ Just (Undef "FOO")
+
+    Spec.it s "parses #include as Other" $ do
+      Spec.assertEq s (parse "#include <stdio.h>") $ Just Other
+
+    Spec.it s "parses #error as Other" $ do
+      Spec.assertEq s (parse "#error msg") $ Just Other
+
+    Spec.it s "handles leading whitespace" $ do
+      Spec.assertEq s (parse "  #if 1") $ Just (If "1")
+
+    Spec.it s "handles whitespace after hash" $ do
+      Spec.assertEq s (parse "#  if 1") $ Just (If "1")
+
+    Spec.it s "fails on non-directive line" $ do
+      Spec.assertEq s (parse "not a directive") Nothing

--- a/source/library/Scrod/Cpp/Directive.hs
+++ b/source/library/Scrod/Cpp/Directive.hs
@@ -43,7 +43,7 @@ directive = do
 name :: (Parsec.Stream s m Char) => Parsec.ParsecT s u m String
 name = do
   Parsec.skipMany1 (Parsec.oneOf " \t")
-  Parsec.many1 (Parsec.alphaNum Parsec.<|> Parsec.char '_')
+  Parsec.many1 (Parsec.choice [Parsec.alphaNum, Parsec.char '_'])
 
 rest :: (Parsec.Stream s m Char) => Parsec.ParsecT s u m String
 rest = do

--- a/source/library/Scrod/Cpp/Expr.hs
+++ b/source/library/Scrod/Cpp/Expr.hs
@@ -1,0 +1,272 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TemplateHaskellQuotes #-}
+
+module Scrod.Cpp.Expr where
+
+import qualified Data.Char as Char
+import qualified Data.Functor as Functor
+import qualified Data.Map.Strict as Map
+import qualified Scrod.Spec as Spec
+import qualified Text.Parsec as Parsec
+
+evaluate :: Map.Map String String -> String -> Either String Integer
+evaluate defines input =
+  case Parsec.parse (spaces *> expr defines <* Parsec.eof) "" input of
+    Left err -> Left $ show err
+    Right n -> Right n
+
+spaces :: (Parsec.Stream s m Char) => Parsec.ParsecT s u m ()
+spaces = Parsec.skipMany (Parsec.oneOf " \t")
+
+lexeme :: (Parsec.Stream s m Char) => Parsec.ParsecT s u m a -> Parsec.ParsecT s u m a
+lexeme p = p <* spaces
+
+expr :: (Parsec.Stream s m Char) => Map.Map String String -> Parsec.ParsecT s u m Integer
+expr = orExpr
+
+orExpr :: (Parsec.Stream s m Char) => Map.Map String String -> Parsec.ParsecT s u m Integer
+orExpr defines = do
+  l <- andExpr defines
+  rs <- Parsec.many $ do
+    _ <- lexeme $ Parsec.try (Parsec.string "||")
+    andExpr defines
+  pure $ foldl (\a b -> if a /= 0 || b /= 0 then 1 else 0) l rs
+
+andExpr :: (Parsec.Stream s m Char) => Map.Map String String -> Parsec.ParsecT s u m Integer
+andExpr defines = do
+  l <- eqExpr defines
+  rs <- Parsec.many $ do
+    _ <- lexeme $ Parsec.try (Parsec.string "&&")
+    eqExpr defines
+  pure $ foldl (\a b -> if a /= 0 && b /= 0 then 1 else 0) l rs
+
+eqExpr :: (Parsec.Stream s m Char) => Map.Map String String -> Parsec.ParsecT s u m Integer
+eqExpr defines = do
+  l <- relExpr defines
+  rs <- Parsec.many $ do
+    op <-
+      lexeme $
+        Parsec.try (Parsec.string "==" Functor.$> (==))
+          Parsec.<|> Parsec.try (Parsec.string "!=" Functor.$> (/=))
+    r <- relExpr defines
+    pure (op, r)
+  pure $ foldl (\a (op, b) -> boolToInt $ op a b) l rs
+
+relExpr :: (Parsec.Stream s m Char) => Map.Map String String -> Parsec.ParsecT s u m Integer
+relExpr defines = do
+  l <- addExpr defines
+  rs <- Parsec.many $ do
+    op <-
+      lexeme $
+        Parsec.try (Parsec.string "<=" Functor.$> (<=))
+          Parsec.<|> Parsec.try (Parsec.string ">=" Functor.$> (>=))
+          Parsec.<|> Parsec.try (Parsec.string "<" Functor.$> (<))
+          Parsec.<|> Parsec.try (Parsec.string ">" Functor.$> (>))
+    r <- addExpr defines
+    pure (op, r)
+  pure $ foldl (\a (op, b) -> boolToInt $ op a b) l rs
+
+addExpr :: (Parsec.Stream s m Char) => Map.Map String String -> Parsec.ParsecT s u m Integer
+addExpr defines = do
+  l <- mulExpr defines
+  rs <- Parsec.many $ do
+    op <-
+      lexeme $
+        Parsec.try ((Parsec.char '+' *> Parsec.notFollowedBy Parsec.digit) Functor.$> (+))
+          Parsec.<|> Parsec.try ((Parsec.char '-' *> Parsec.notFollowedBy Parsec.digit) Functor.$> (-))
+    r <- mulExpr defines
+    pure (op, r)
+  pure $ foldl (\a (op, b) -> op a b) l rs
+
+mulExpr :: (Parsec.Stream s m Char) => Map.Map String String -> Parsec.ParsecT s u m Integer
+mulExpr defines = do
+  l <- unaryExpr defines
+  rs <- Parsec.many $ do
+    op <-
+      lexeme $
+        Parsec.try (Parsec.char '*' Functor.$> (*))
+          Parsec.<|> Parsec.try (Parsec.char '/' Functor.$> div)
+          Parsec.<|> Parsec.try (Parsec.char '%' Functor.$> mod)
+    r <- unaryExpr defines
+    pure (op, r)
+  pure $ foldl (\a (op, b) -> op a b) l rs
+
+unaryExpr :: (Parsec.Stream s m Char) => Map.Map String String -> Parsec.ParsecT s u m Integer
+unaryExpr defines =
+  Parsec.choice
+    [ do
+        _ <- lexeme $ Parsec.char '!'
+        n <- unaryExpr defines
+        pure $ if n == 0 then 1 else 0,
+      do
+        _ <- lexeme $ Parsec.char '-'
+        n <- unaryExpr defines
+        pure $ negate n,
+      do
+        _ <- lexeme $ Parsec.char '+'
+        unaryExpr defines,
+      primary defines
+    ]
+
+primary :: (Parsec.Stream s m Char) => Map.Map String String -> Parsec.ParsecT s u m Integer
+primary defines =
+  Parsec.choice
+    [ lexeme intLiteral,
+      lexeme $ definedExpr defines,
+      lexeme $ identifier defines,
+      do
+        _ <- lexeme $ Parsec.char '('
+        n <- expr defines
+        _ <- lexeme $ Parsec.char ')'
+        pure n
+    ]
+
+intLiteral :: (Parsec.Stream s m Char) => Parsec.ParsecT s u m Integer
+intLiteral = Parsec.try hexLiteral Parsec.<|> decLiteral
+
+hexLiteral :: (Parsec.Stream s m Char) => Parsec.ParsecT s u m Integer
+hexLiteral = do
+  _ <- Parsec.char '0'
+  _ <- Parsec.oneOf "xX"
+  digits <- Parsec.many1 Parsec.hexDigit
+  pure $ foldl (\acc d -> acc * 16 + fromIntegral (Char.digitToInt d)) 0 digits
+
+decLiteral :: (Parsec.Stream s m Char) => Parsec.ParsecT s u m Integer
+decLiteral = do
+  digits <- Parsec.many1 Parsec.digit
+  pure $ read digits
+
+definedExpr :: (Parsec.Stream s m Char) => Map.Map String String -> Parsec.ParsecT s u m Integer
+definedExpr defines = do
+  _ <- Parsec.try $ Parsec.string "defined"
+  spaces
+  parenned <-
+    Parsec.optionMaybe . Parsec.try $ do
+      _ <- Parsec.char '('
+      spaces
+      n <- identName
+      spaces
+      _ <- Parsec.char ')'
+      pure n
+  case parenned of
+    Just n -> pure $ if Map.member n defines then 1 else 0
+    Nothing -> do
+      n <- identName
+      pure $ if Map.member n defines then 1 else 0
+
+identName :: (Parsec.Stream s m Char) => Parsec.ParsecT s u m String
+identName = do
+  c <- Parsec.letter Parsec.<|> Parsec.char '_'
+  cs <- Parsec.many (Parsec.alphaNum Parsec.<|> Parsec.char '_')
+  pure (c : cs)
+
+identifier :: (Parsec.Stream s m Char) => Map.Map String String -> Parsec.ParsecT s u m Integer
+identifier defines = do
+  n <- identName
+  -- Handle undefined function-like macro calls: NAME(...) -> 0
+  mParen <- Parsec.optionMaybe . Parsec.try $ do
+    _ <- Parsec.char '('
+    consumeBalancedParens 1
+  case mParen of
+    Just () -> pure 0
+    Nothing ->
+      case Map.lookup n defines of
+        Nothing -> pure 0
+        Just v -> case reads v of
+          [(i, "")] -> pure i
+          _ -> pure 0
+
+consumeBalancedParens :: (Parsec.Stream s m Char) => Int -> Parsec.ParsecT s u m ()
+consumeBalancedParens 0 = pure ()
+consumeBalancedParens depth = do
+  c <- Parsec.anyChar
+  case c of
+    '(' -> consumeBalancedParens (depth + 1)
+    ')' -> consumeBalancedParens (depth - 1)
+    _ -> consumeBalancedParens depth
+
+boolToInt :: Bool -> Integer
+boolToInt b = if b then 1 else 0
+
+spec :: (Applicative m, Monad n) => Spec.Spec m n -> n ()
+spec s = do
+  Spec.named s 'evaluate $ do
+    Spec.it s "evaluates integer literal" $ do
+      Spec.assertEq s (evaluate Map.empty "42") $ Right 42
+
+    Spec.it s "evaluates zero" $ do
+      Spec.assertEq s (evaluate Map.empty "0") $ Right 0
+
+    Spec.it s "evaluates hexadecimal literal" $ do
+      Spec.assertEq s (evaluate Map.empty "0x1F") $ Right 31
+
+    Spec.it s "evaluates undefined name as 0" $ do
+      Spec.assertEq s (evaluate Map.empty "FOO") $ Right 0
+
+    Spec.it s "evaluates defined name" $ do
+      Spec.assertEq s (evaluate (Map.singleton "FOO" "1") "FOO") $ Right 1
+
+    Spec.it s "evaluates defined name with numeric value" $ do
+      Spec.assertEq s (evaluate (Map.singleton "FOO" "5") "FOO") $ Right 5
+
+    Spec.it s "evaluates defined name with non-numeric value as 0" $ do
+      Spec.assertEq s (evaluate (Map.singleton "FOO" "bar") "FOO") $ Right 0
+
+    Spec.it s "evaluates defined(NAME) with parens" $ do
+      Spec.assertEq s (evaluate (Map.singleton "FOO" "1") "defined(FOO)") $ Right 1
+
+    Spec.it s "evaluates defined(NAME) for undefined" $ do
+      Spec.assertEq s (evaluate Map.empty "defined(FOO)") $ Right 0
+
+    Spec.it s "evaluates defined NAME without parens" $ do
+      Spec.assertEq s (evaluate (Map.singleton "FOO" "1") "defined FOO") $ Right 1
+
+    Spec.it s "evaluates logical not of zero" $ do
+      Spec.assertEq s (evaluate Map.empty "!0") $ Right 1
+
+    Spec.it s "evaluates logical not of nonzero" $ do
+      Spec.assertEq s (evaluate Map.empty "!5") $ Right 0
+
+    Spec.it s "evaluates logical or" $ do
+      Spec.assertEq s (evaluate Map.empty "0 || 1") $ Right 1
+
+    Spec.it s "evaluates logical and" $ do
+      Spec.assertEq s (evaluate Map.empty "1 && 0") $ Right 0
+
+    Spec.it s "evaluates equality" $ do
+      Spec.assertEq s (evaluate Map.empty "1 == 1") $ Right 1
+
+    Spec.it s "evaluates inequality" $ do
+      Spec.assertEq s (evaluate Map.empty "1 != 2") $ Right 1
+
+    Spec.it s "evaluates less than" $ do
+      Spec.assertEq s (evaluate Map.empty "2 < 3") $ Right 1
+
+    Spec.it s "evaluates greater than" $ do
+      Spec.assertEq s (evaluate Map.empty "3 > 2") $ Right 1
+
+    Spec.it s "evaluates addition" $ do
+      Spec.assertEq s (evaluate Map.empty "2 + 3") $ Right 5
+
+    Spec.it s "evaluates subtraction" $ do
+      Spec.assertEq s (evaluate Map.empty "5 - 3") $ Right 2
+
+    Spec.it s "evaluates multiplication" $ do
+      Spec.assertEq s (evaluate Map.empty "3 * 4") $ Right 12
+
+    Spec.it s "evaluates parenthesized expression" $ do
+      Spec.assertEq s (evaluate Map.empty "(1 + 2) * 3") $ Right 9
+
+    Spec.it s "evaluates complex expression" $ do
+      Spec.assertEq s (evaluate (Map.singleton "X" "10") "defined(X) && X >= 10") $ Right 1
+
+    Spec.it s "evaluates unary minus" $ do
+      Spec.assertEq s (evaluate Map.empty "-1") $ Right (-1)
+
+    Spec.it s "handles undefined function-like macro call" $ do
+      Spec.assertEq s (evaluate Map.empty "MIN_VERSION_base(4,16,0)") $ Right 0
+
+    Spec.it s "fails on empty expression" $ do
+      case evaluate Map.empty "" of
+        Left _ -> pure ()
+        Right _ -> Spec.assertFailure s "expected failure on empty expression"

--- a/source/library/Scrod/TestSuite/All.hs
+++ b/source/library/Scrod/TestSuite/All.hs
@@ -1,6 +1,9 @@
 module Scrod.TestSuite.All where
 
 import qualified Scrod.Convert.FromHaddock
+import qualified Scrod.Cpp
+import qualified Scrod.Cpp.Directive
+import qualified Scrod.Cpp.Expr
 import qualified Scrod.Css.AtRule
 import qualified Scrod.Css.Block
 import qualified Scrod.Css.BlockContent
@@ -53,6 +56,9 @@ import qualified Scrod.Xml.Text
 spec :: (Monad m, Monad n) => Spec.Spec m n -> n ()
 spec s = do
   Scrod.Convert.FromHaddock.spec s
+  Scrod.Cpp.spec s
+  Scrod.Cpp.Directive.spec s
+  Scrod.Cpp.Expr.spec s
   Scrod.Css.AtRule.spec s
   Scrod.Css.Block.spec s
   Scrod.Css.BlockContent.spec s

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -1468,6 +1468,37 @@ spec s = Spec.describe s "integration" $ do
         """
         []
 
+  Spec.describe s "cpp" $ do
+    Spec.it s "works with simple ifdef" $ do
+      check
+        s
+        "{-# language CPP #-}\n#define MY_FLAG\n#ifdef MY_FLAG\nmodule M where\n#endif"
+        [("/name/value", "\"M\"")]
+
+    Spec.it s "works with undefined macro" $ do
+      check
+        s
+        "{-# language CPP #-}\n#ifdef UNDEFINED\nmodule M where\n#endif"
+        [("/name", "null")]
+
+    Spec.it s "preserves line numbers" $ do
+      check
+        s
+        "{-# language CPP #-}\n#ifdef FOO\nimport Fake\n#endif\nx = 0"
+        [("/items/0/location/line", "5")]
+
+    Spec.it s "uses else branch for undefined macros" $ do
+      check
+        s
+        "{-# language CPP #-}\n#ifdef __GLASGOW_HASKELL__\nmodule GHC where\n#else\nmodule Other where\n#endif"
+        [("/name/value", "\"Other\"")]
+
+    Spec.it s "does not preprocess without CPP extension" $ do
+      check
+        s
+        "x = 0"
+        [("/items/0/value/name", "\"x\"")]
+
   Spec.describe s "literate" $ do
     Spec.describe s "bird" $ do
       Spec.it s "works" $ do

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -1493,12 +1493,6 @@ spec s = Spec.describe s "integration" $ do
         "{-# language CPP #-}\n#ifdef __GLASGOW_HASKELL__\nmodule GHC where\n#else\nmodule Other where\n#endif"
         [("/name/value", "\"Other\"")]
 
-    Spec.it s "does not preprocess without CPP extension" $ do
-      check
-        s
-        "x = 0"
-        [("/items/0/value/name", "\"x\"")]
-
   Spec.describe s "literate" $ do
     Spec.describe s "bird" $ do
       Spec.it s "works" $ do


### PR DESCRIPTION
## Summary

Closes #30.

- Adds a pure CPP preprocessor that automatically runs when `{-# LANGUAGE CPP #-}` is detected during extension discovery in `Parse.parse`
- Handles conditional compilation directives (`#if`, `#ifdef`, `#ifndef`, `#elif`, `#else`, `#endif`), `#define`, `#undef`
- Includes a Parsec-based expression evaluator for `#if`/`#elif` conditions supporting integer literals, `defined()`, logical/comparison/arithmetic operators, and graceful handling of undefined function-like macro calls (e.g. `MIN_VERSION_base(4,16,0)` → 0)
- Nothing is predefined (v1 assumes nothing is defined); `#define` within the file is tracked
- Inactive code and directive lines become blank lines to preserve line numbers
- No CLI flag needed — auto-detected from the CPP extension pragma
- Works for CLI, WASM, and test entry points since it's integrated into `Parse.parse`

### New modules
- `Scrod.Cpp` — main preprocessor (`cpp :: String -> Either String String`)
- `Scrod.Cpp.Directive` — Parsec-based directive line parser
- `Scrod.Cpp.Expr` — Parsec-based CPP expression evaluator

### Not in scope for v1
- Function-like macro definitions, textual macro substitution in code
- `#include` (no file system access)
- Predefined macros (`__GLASGOW_HASKELL__`, `MIN_VERSION_*`, platform macros)

## Test plan

- [x] All 783 tests pass (`cabal test`)
- [x] Pedantic build clean (`cabal build --flags=pedantic`)
- [x] hlint clean
- [x] ormolu formatting clean
- [x] cabal-gild clean
- [x] cabal check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)