### PR TITLE
Add immutable releases via workflow_dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch: {}
 jobs:
   build:
     name: Build on ${{ matrix.os }}
@@ -144,3 +145,22 @@ jobs:
     steps:
       - id: deploy
         uses: actions/deploy-pages@v4
+  release:
+    name: Release
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - meta
+      - wasm
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v7
+        with:
+          pattern: ${{ needs.meta.outputs.name }}-${{ github.sha }}-*
+      - run: .github/workflows/release.sh ${{ needs.meta.outputs.name }} ${{ needs.meta.outputs.version }} ${{ github.sha }}
+      - env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create ${{ needs.meta.outputs.version }} --draft --generate-notes --target ${{ github.sha }} ${{ needs.meta.outputs.name }}-*.tar.gz

--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -8,18 +8,31 @@ artifact_prefix="${name}-${sha}"
 
 tar --extract --file "${artifact_prefix}-Linux/artifact.tar" --strip-components=1 --wildcards '*.tar.gz'
 
-for dir in ${artifact_prefix}-*/
+shopt -s nullglob
+dirs=("${artifact_prefix}"-*/)
+if [ ${#dirs[@]} -eq 0 ]; then
+  echo "no artifact directories found for prefix: $artifact_prefix" >&2
+  exit 1
+fi
+
+for dir in "${dirs[@]}"
 do
   platform="${dir%/}"
   platform="${platform##*-}"
   case "$platform" in
-    macOS) platform=darwin; files="${name}" ;;
-    Linux) platform=linux; files="${name}" ;;
-    Windows) platform=win32; files="${name}.exe" ;;
-    wasm) files="${name}-wasm.wasm ${name}-wasi.wasm" ;;
+    macOS) platform=darwin; file="${name}" ;;
+    Linux) platform=linux; file="${name}" ;;
+    Windows) platform=win32; file="${name}.exe" ;;
+    wasm)
+      tar --extract --file "$dir/artifact.tar"
+      tar --create --gzip --file "${name}-${version}-wasm.tar.gz" -C artifact "${name}-wasm.wasm"
+      tar --create --gzip --file "${name}-${version}-wasi.tar.gz" -C artifact "${name}-wasi.wasm"
+      rm -rf artifact
+      continue
+      ;;
     *) echo "unknown platform: $platform" >&2; exit 1 ;;
   esac
   tar --extract --file "$dir/artifact.tar"
-  tar --create --gzip --file "${name}-${version}-${platform}.tar.gz" -C artifact $files
+  tar --create --gzip --file "${name}-${version}-${platform}.tar.gz" -C artifact "$file"
   rm -rf artifact
 done

--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -o errexit -o nounset -o pipefail
+
+name="$1"
+version="$2"
+sha="$3"
+artifact_prefix="${name}-${sha}"
+
+tar --extract --file "${artifact_prefix}-Linux/artifact.tar" --strip-components=1 --wildcards '*.tar.gz'
+
+for dir in ${artifact_prefix}-*/
+do
+  platform="${dir%/}"
+  platform="${platform##*-}"
+  case "$platform" in
+    macOS) platform=darwin; files="${name}" ;;
+    Linux) platform=linux; files="${name}" ;;
+    Windows) platform=win32; files="${name}.exe" ;;
+    wasm) files="${name}-wasm.wasm ${name}-wasi.wasm" ;;
+    *) echo "unknown platform: $platform" >&2; exit 1 ;;
+  esac
+  tar --extract --file "$dir/artifact.tar"
+  tar --create --gzip --file "${name}-${version}-${platform}.tar.gz" -C artifact $files
+  rm -rf artifact
+done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ There are two kinds of tests:
 
 ### WASM web app
 
-The WASM build exports a `processHaskell` function via JavaScript FFI. The web frontend runs it in a Web Worker (`worker.js`) to avoid blocking the UI. Shareable URLs use base64-encoded hash fragments.
+The WASM build exports a `scrod` function via JavaScript FFI. The web frontend runs it in a Web Worker (`worker.js`) to avoid blocking the UI. Shareable URLs use base64-encoded hash fragments.
 
 ## Code Conventions
 

--- a/wasm/wasm.hs
+++ b/wasm/wasm.hs
@@ -5,11 +5,11 @@ import qualified Scrod.Extra.Builder as Builder
 main :: IO ()
 main = error "required by ghc but ignored by wasm"
 
-foreign export javascript "processHaskell"
-  processHaskell :: Wasm.JSVal -> Wasm.JSString -> IO Wasm.JSString
+foreign export javascript "scrod"
+  scrod :: Wasm.JSVal -> Wasm.JSString -> IO Wasm.JSString
 
-processHaskell :: Wasm.JSVal -> Wasm.JSString -> IO Wasm.JSString
-processHaskell rawArguments input = do
+scrod :: Wasm.JSVal -> Wasm.JSString -> IO Wasm.JSString
+scrod rawArguments input = do
   size <- jsArrayLength rawArguments
   arguments <- traverse (fmap Wasm.fromJSString . jsArrayIndex rawArguments) [0 .. size - 1]
   result <-

--- a/wasm/www/worker.js
+++ b/wasm/www/worker.js
@@ -1,7 +1,7 @@
 import ghcWasmJsffi from './ghc_wasm_jsffi.js';
 import { WASI, File, OpenFile, ConsoleStdout } from './vendor/browser_wasi_shim/index.js';
 
-let processHaskell;
+let scrod;
 
 async function initialize() {
   const fds = [
@@ -41,7 +41,7 @@ async function initialize() {
   exports = result.instance.exports;
   wasi.initialize(result.instance);
 
-  processHaskell = result.instance.exports.processHaskell;
+  scrod = result.instance.exports.scrod;
   postMessage({ tag: 'ready' });
 }
 
@@ -50,12 +50,12 @@ initialize().catch(function (e) {
 });
 
 onmessage = async function (e) {
-  if (processHaskell) {
+  if (scrod) {
     try {
       const msg = e.data;
       const args = ['--format', msg.format];
       if (msg.literate) args.push('--literate');
-      const result = await processHaskell(args, msg.source);
+      const result = await scrod(args, msg.source);
       postMessage({ tag: 'result', value: result, format: msg.format });
     } catch (err) {
       postMessage({ tag: 'error', message: err.message });


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to the CI workflow so manually dispatching creates a draft GitHub release
- A new `release` job downloads all build artifacts (Linux, macOS, Windows, WASM), repackages them as versioned gzipped tarballs containing only executables, and creates a draft release via `gh release create`
- The release script is extracted to `.github/workflows/release.sh` for readability

## Release workflow
1. Go to Actions → CI → Run workflow (defaults to main)
2. CI builds all platforms + WASM, runs quality checks and tests
3. The `release` job creates a draft release tagged with the version from the cabal file
4. Review the draft on GitHub and publish to make it immutable

## Assets
- `scrod-VERSION-darwin.tar.gz` — macOS executable
- `scrod-VERSION-linux.tar.gz` — Linux executable
- `scrod-VERSION-win32.tar.gz` — Windows executable
- `scrod-VERSION-wasm.tar.gz` — WASM and WASI binaries
- `scrod-VERSION.tar.gz` — source distribution

Closes #33

## Test plan
- [ ] Trigger workflow_dispatch on main and verify the draft release is created with all expected assets
- [ ] Verify asset contents contain only the expected executables
- [ ] Publish the draft and confirm it becomes immutable

🤖 Generated with [Claude Code](https://claude.com/claude-code)