### PR TITLE
Accept URLs as web app input

### DIFF
--- a/wasm/www/index.js
+++ b/wasm/www/index.js
@@ -81,8 +81,38 @@ function updateHash() {
   }
 }
 
+function isUrl(text) {
+  try {
+    var url = new URL(text);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch (e) {
+    return false;
+  }
+}
+
+function fetchUrl(url) {
+  shadow.innerHTML = '<p style="color: #888; font-style: italic">Fetching URL...</p>';
+  fetch(url).then(function (response) {
+    if (!response.ok) {
+      throw new Error('HTTP ' + response.status + ' ' + response.statusText);
+    }
+    return response.text();
+  }).then(function (text) {
+    source.value = text;
+    updateHash();
+    process();
+  }).catch(function (err) {
+    showError('Failed to fetch URL: ' + err.message);
+  });
+}
+
 function process() {
   if (ready) {
+    var trimmed = source.value.trim();
+    if (isUrl(trimmed)) {
+      fetchUrl(trimmed);
+      return;
+    }
     worker.postMessage({ source: source.value, format: format.value, literate: literate.checked });
   }
 }

--- a/wasm/www/index.js
+++ b/wasm/www/index.js
@@ -128,13 +128,8 @@ function process(skipUrlDetection) {
 source.addEventListener('input', function () {
   clearTimeout(debounceTimer);
   debounceTimer = setTimeout(function () {
-    var trimmed = source.value.trim();
-    if (isUrl(trimmed)) {
-      process();
-    } else {
-      updateHash();
-      process();
-    }
+    updateHash();
+    process();
   }, 300);
 });
 


### PR DESCRIPTION
## Summary
- When the trimmed input in the web app textarea is a valid HTTP(S) URL, it is fetched and the response body replaces the input
- Shows a "Fetching URL..." indicator while loading, and an error message if the fetch fails
- Makes it easy to load module sources from GitHub raw URLs and Hackage

Closes #42

## Test plan
- [x] Paste a raw GitHub URL (e.g. `https://raw.githubusercontent.com/tfausak/scrod/main/source/library/Scrod.hs`) into the input and verify it fetches and renders
- [x] Paste an invalid URL and verify an error is shown
- [x] Type normal Haskell source and verify it still works as before
- [x] Verify the URL hash updates to contain the fetched source (not the URL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)