### PR TITLE
Add names for derived instances

### DIFF
--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -880,8 +880,13 @@ convertDerivedTypeM parentKey lSigTy =
 
 -- | Extract name from a derived type.
 extractDerivedTypeName :: Syntax.LHsSigType Ghc.GhcPs -> Maybe ItemName.ItemName
-extractDerivedTypeName =
-  Just . ItemName.MkItemName . Text.pack . Outputable.showSDocUnsafe . Outputable.ppr
+extractDerivedTypeName lSigTy =
+  let sigTy = SrcLoc.unLoc lSigTy
+      bodyTy = SrcLoc.unLoc $ Syntax.sig_body sigTy
+      ty = case bodyTy of
+        Syntax.HsDocTy _ lTy _ -> SrcLoc.unLoc lTy
+        _ -> bodyTy
+   in Just . ItemName.MkItemName . Text.pack . Outputable.showSDocUnsafe . Outputable.ppr $ ty
 
 -- | Extract documentation from a derived type.
 extractDerivedTypeDoc :: Syntax.LHsSigType Ghc.GhcPs -> Doc.Doc

--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -1108,9 +1108,14 @@ extractInstDeclName inst = Just $ case inst of
 
 -- | Extract name from a standalone deriving declaration.
 extractDerivDeclName :: Syntax.DerivDecl Ghc.GhcPs -> Maybe ItemName.ItemName
-extractDerivDeclName derivDecl =
-  Just . ItemName.MkItemName . Text.pack . Outputable.showSDocUnsafe . Outputable.ppr . Syntax.hswc_body $
-    Syntax.deriv_type derivDecl
+extractDerivDeclName =
+  Just
+    . ItemName.MkItemName
+    . Text.pack
+    . Outputable.showSDocUnsafe
+    . Outputable.ppr
+    . Syntax.hswc_body
+    . Syntax.deriv_type
 
 -- | Extract name from a constructor declaration.
 extractConDeclName :: Syntax.ConDecl Ghc.GhcPs -> ItemName.ItemName

--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -876,7 +876,12 @@ convertDerivedTypeM ::
   Syntax.LHsSigType Ghc.GhcPs ->
   ConvertM (Maybe (Located.Located Item.Item))
 convertDerivedTypeM parentKey lSigTy =
-  mkItemM (Annotation.getLocA lSigTy) parentKey Nothing (extractDerivedTypeDoc lSigTy) Nothing ItemKind.DerivedInstance
+  mkItemM (Annotation.getLocA lSigTy) parentKey (extractDerivedTypeName lSigTy) (extractDerivedTypeDoc lSigTy) Nothing ItemKind.DerivedInstance
+
+-- | Extract name from a derived type.
+extractDerivedTypeName :: Syntax.LHsSigType Ghc.GhcPs -> Maybe ItemName.ItemName
+extractDerivedTypeName =
+  Just . ItemName.MkItemName . Text.pack . Outputable.showSDocUnsafe . Outputable.ppr
 
 -- | Extract documentation from a derived type.
 extractDerivedTypeDoc :: Syntax.LHsSigType Ghc.GhcPs -> Doc.Doc
@@ -1040,6 +1045,7 @@ extractDeclName lDecl = case SrcLoc.unLoc lDecl of
   Syntax.ValD _ bind -> extractBindName bind
   Syntax.SigD _ sig -> extractSigName sig
   Syntax.InstD _ inst -> extractInstDeclName inst
+  Syntax.DerivD _ derivDecl -> extractDerivDeclName derivDecl
   Syntax.KindSigD _ kindSig -> Just $ extractStandaloneKindSigName kindSig
   _ -> Nothing
 
@@ -1099,6 +1105,12 @@ extractInstDeclName inst = Just $ case inst of
   Syntax.TyFamInstD _ tyFamInst ->
     ItemName.MkItemName . Text.pack . Outputable.showSDocUnsafe . Outputable.ppr $
       tyFamInst
+
+-- | Extract name from a standalone deriving declaration.
+extractDerivDeclName :: Syntax.DerivDecl Ghc.GhcPs -> Maybe ItemName.ItemName
+extractDerivDeclName derivDecl =
+  Just . ItemName.MkItemName . Text.pack . Outputable.showSDocUnsafe . Outputable.ppr . Syntax.hswc_body $
+    Syntax.deriv_type derivDecl
 
 -- | Extract name from a constructor declaration.
 extractConDeclName :: Syntax.ConDecl Ghc.GhcPs -> ItemName.ItemName

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -1062,7 +1062,9 @@ spec s = Spec.describe s "integration" $ do
         data L
         deriving instance Show L
         """
-        [("/items/1/value/kind", "\"StandaloneDeriving\"")]
+        [ ("/items/1/value/kind", "\"StandaloneDeriving\""),
+          ("/items/1/value/name", "\"Show L\"")
+        ]
 
     Spec.it s "standalone deriving stock" $ do
       check
@@ -1072,7 +1074,9 @@ spec s = Spec.describe s "integration" $ do
         data M
         deriving stock instance Show M
         """
-        [("/items/1/value/kind", "\"StandaloneDeriving\"")]
+        [ ("/items/1/value/kind", "\"StandaloneDeriving\""),
+          ("/items/1/value/name", "\"Show M\"")
+        ]
 
     Spec.it s "standalone deriving newtype" $ do
       check
@@ -1082,7 +1086,9 @@ spec s = Spec.describe s "integration" $ do
         newtype N = MkN Int
         deriving newtype instance Show N
         """
-        [("/items/2/value/kind", "\"StandaloneDeriving\"")]
+        [ ("/items/2/value/kind", "\"StandaloneDeriving\""),
+          ("/items/2/value/name", "\"Show N\"")
+        ]
 
     Spec.it s "standalone deriving anyclass" $ do
       check
@@ -1093,7 +1099,9 @@ spec s = Spec.describe s "integration" $ do
         data W2
         deriving anyclass instance O W2
         """
-        [("/items/2/value/kind", "\"StandaloneDeriving\"")]
+        [ ("/items/2/value/kind", "\"StandaloneDeriving\""),
+          ("/items/2/value/name", "\"O W2\"")
+        ]
 
     Spec.it s "standalone deriving via" $ do
       check
@@ -1103,14 +1111,17 @@ spec s = Spec.describe s "integration" $ do
         newtype P = MkP Int
         deriving via Int instance Show P
         """
-        [("/items/2/value/kind", "\"StandaloneDeriving\"")]
+        [ ("/items/2/value/kind", "\"StandaloneDeriving\""),
+          ("/items/2/value/name", "\"Show P\"")
+        ]
 
     Spec.it s "data deriving" $ do
       check
         s
         "data R deriving Show"
         [ ("/items/0/value/kind", "\"DataType\""),
-          ("/items/1/value/kind", "\"DerivedInstance\"")
+          ("/items/1/value/kind", "\"DerivedInstance\""),
+          ("/items/1/value/name", "\"Show\"")
         ]
 
     Spec.it s "data GADT deriving" $ do


### PR DESCRIPTION
Closes #49

## Summary
- Derived instances (`data T deriving C`) and standalone deriving declarations (`deriving instance C T`) now have a name extracted by pretty-printing the instance type, matching the behavior of regular class instances (`instance C T`).
- Added `extractDerivedTypeName` for deriving clauses and `extractDerivDeclName` for standalone deriving declarations.
- Added name assertions to existing integration tests.

## Test plan
- [x] All 789 existing tests pass
- [x] Pedantic build (`-Werror`) passes
- [x] Ormolu and HLint checks pass
- [x] Manually verified JSON output for `data T deriving C` and `deriving instance Show L`

🤖 Generated with [Claude Code](https://claude.com/claude-code)