### PR TITLE
Only debounce text edits in VSCode extension

### DIFF
--- a/extra/vscode/src/extension.ts
+++ b/extra/vscode/src/extension.ts
@@ -25,11 +25,17 @@ export function activate(context: vscode.ExtensionContext): void {
           clearTimeout(debounceTimer);
         });
       }
-      immediateUpdate();
+      immediateUpdate(vscode.window.activeTextEditor?.document);
     }),
-    vscode.window.onDidChangeActiveTextEditor(() => immediateUpdate()),
-    vscode.workspace.onDidChangeTextDocument(() => scheduleUpdate()),
-    vscode.workspace.onDidSaveTextDocument(() => immediateUpdate())
+    vscode.window.onDidChangeActiveTextEditor((editor) =>
+      immediateUpdate(editor?.document)
+    ),
+    vscode.workspace.onDidChangeTextDocument((event) =>
+      scheduleUpdate(event.document)
+    ),
+    vscode.workspace.onDidSaveTextDocument((document) =>
+      immediateUpdate(document)
+    )
   );
 }
 
@@ -39,21 +45,19 @@ function isHaskell(doc: vscode.TextDocument): boolean {
   return doc.languageId === "haskell" || doc.languageId === "literate haskell";
 }
 
-function immediateUpdate(): void {
+function immediateUpdate(document: vscode.TextDocument | undefined): void {
   if (!panel) return;
   clearTimeout(debounceTimer);
-  const editor = vscode.window.activeTextEditor;
-  if (!editor || !isHaskell(editor.document)) return;
-  update(editor.document);
+  if (!document || !isHaskell(document)) return;
+  update(document);
 }
 
-function scheduleUpdate(): void {
+function scheduleUpdate(document: vscode.TextDocument): void {
   if (!panel) return;
   clearTimeout(debounceTimer);
   debounceTimer = setTimeout(() => {
-    const editor = vscode.window.activeTextEditor;
-    if (!editor || !isHaskell(editor.document)) return;
-    update(editor.document);
+    if (!isHaskell(document)) return;
+    update(document);
   }, 300);
 }
 

--- a/extra/vscode/src/extension.ts
+++ b/extra/vscode/src/extension.ts
@@ -25,11 +25,11 @@ export function activate(context: vscode.ExtensionContext): void {
           clearTimeout(debounceTimer);
         });
       }
-      scheduleUpdate();
+      immediateUpdate();
     }),
-    vscode.window.onDidChangeActiveTextEditor(() => scheduleUpdate()),
+    vscode.window.onDidChangeActiveTextEditor(() => immediateUpdate()),
     vscode.workspace.onDidChangeTextDocument(() => scheduleUpdate()),
-    vscode.workspace.onDidSaveTextDocument(() => scheduleUpdate())
+    vscode.workspace.onDidSaveTextDocument(() => immediateUpdate())
   );
 }
 
@@ -37,6 +37,14 @@ export function deactivate(): void {}
 
 function isHaskell(doc: vscode.TextDocument): boolean {
   return doc.languageId === "haskell" || doc.languageId === "literate haskell";
+}
+
+function immediateUpdate(): void {
+  if (!panel) return;
+  clearTimeout(debounceTimer);
+  const editor = vscode.window.activeTextEditor;
+  if (!editor || !isHaskell(editor.document)) return;
+  update(editor.document);
 }
 
 function scheduleUpdate(): void {


### PR DESCRIPTION
Fixes #56.

## Summary

The VSCode extension was debouncing all update triggers with a 300ms delay, including file switches and saves. This made the preview feel sluggish when switching between files.

This PR adds an `immediateUpdate()` function that bypasses the debounce timer and uses it for:
- **`onDidChangeActiveTextEditor`** — switching files should be instant
- **`onDidSaveTextDocument`** — saving is a discrete action, no need to debounce
- **`scrod.openPreview` command** — opening the preview panel

Only **`onDidChangeTextDocument`** (typing) continues to use the 300ms debounce via `scheduleUpdate()`.

🤖 Generated with [Claude Code](https://claude.ai/code)