### PR TITLE
Render preview on initial load even with empty input

### DIFF
--- a/extra/github-pages/index.js
+++ b/extra/github-pages/index.js
@@ -35,9 +35,7 @@ worker.onmessage = function (e) {
   if (msg.tag === 'ready') {
     ready = true;
     shadow.innerHTML = '';
-    if (source.value) {
-      process();
-    }
+    process();
   } else if (msg.tag === 'result') {
     if (msg.format === 'json') {
       showJson(msg.value);


### PR DESCRIPTION
Fixes #63.

## Summary

The web app preview pane was blank on initial load when the textarea was empty. This happened because the `ready` handler in `index.js` only called `process()` when `source.value` was truthy — so with an empty textarea, no message was ever sent to the WASM worker.

The fix removes that guard so `process()` is always called when the worker becomes ready, ensuring the header and version are rendered even with empty input.

🤖 Generated with [Claude Code](https://claude.ai/code)