### PR TITLE
Exclude function name from type signature text

### DIFF
--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -1094,9 +1094,14 @@ extractSigName sig = case sig of
   Syntax.ClassOpSig _ _ (lName : _) _ -> Just $ extractIdPName lName
   _ -> Nothing
 
--- | Extract signature text from a Sig.
+-- | Extract signature text from a Sig. Only returns the type part, not the
+-- name. For example, @x :: Int@ produces @"Int"@.
 extractSigSignature :: Syntax.Sig Ghc.GhcPs -> Maybe Text.Text
-extractSigSignature = Just . Text.pack . Outputable.showSDocUnsafe . Outputable.ppr
+extractSigSignature sig = case sig of
+  Syntax.TypeSig _ _ ty -> Just . Text.pack . Outputable.showSDocUnsafe $ Outputable.ppr ty
+  Syntax.PatSynSig _ _ ty -> Just . Text.pack . Outputable.showSDocUnsafe $ Outputable.ppr ty
+  Syntax.ClassOpSig _ _ _ ty -> Just . Text.pack . Outputable.showSDocUnsafe $ Outputable.ppr ty
+  _ -> Nothing
 
 -- | Extract name from an instance declaration.
 extractInstDeclName :: Syntax.InstDecl Ghc.GhcPs -> Maybe ItemName.ItemName

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -816,7 +816,7 @@ spec s = Spec.describe s "integration" $ do
           x = 0
           """
           [ ("/items/0/value/name", "\"x\""),
-            ("/items/0/value/signature", "\"x :: Int\"")
+            ("/items/0/value/signature", "\"Int\"")
           ]
 
     Spec.it s "open type family" $ do
@@ -1282,7 +1282,7 @@ spec s = Spec.describe s "integration" $ do
             ("/items/1/value/key", "1"),
             ("/items/1/value/kind", "\"ClassMethod\""),
             ("/items/1/value/parentKey", "0"),
-            ("/items/1/value/signature", "\"m :: a\"")
+            ("/items/1/value/signature", "\"a\"")
           ]
 
       Spec.it s "works with documentation" $ do


### PR DESCRIPTION
## Summary

- `extractSigSignature` was using GHC's `ppr` on the entire `Sig` AST node, which rendered both the name and the type (e.g. `"a :: b"`). Since the name is already stored in the item's `name` field, the signature should only contain the type part (e.g. `"b"`).
- Changed `extractSigSignature` to pattern-match on `TypeSig`, `PatSynSig`, and `ClassOpSig`, extracting and pretty-printing only the type component.
- Updated two integration test expectations to match.

Fixes #53.

## Test plan

- [x] All 789 tests pass
- [x] Verified with `echo 'a::b' | cabal run scrod -- --format json` — signature is `"b"` instead of `"a :: b"`
- [x] Verified HTML output shows `:: b` in the signature span, not `:: a :: b`

🤖 Generated with [Claude Code](https://claude.com/claude-code)