### PR TITLE
Sync scroll position in VSCode extension preview

### DIFF
--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -117,7 +117,9 @@ headerSection :: Module.Module -> Element.Element
 headerSection m =
   Xml.element
     "header"
-    [Xml.attribute "class" "module-header"]
+    ( [Xml.attribute "class" "module-header"]
+        <> foldMap (\(Located.MkLocated loc _) -> [lineAttribute loc]) (Module.name m)
+    )
     ( [Content.Element $ Xml.element "h1" [] [Xml.text (moduleTitle m)]]
         <> warningContents (Module.warning m)
         <> moduleDocContents (Module.documentation m)
@@ -399,7 +401,8 @@ itemToHtml (Located.MkLocated loc (Item.MkItem key itemKind _parentKey maybeName
   Xml.element
     "div"
     [ Xml.attribute "class" "item",
-      Xml.attribute "id" ("item-" <> show (ItemKey.unwrap key))
+      Xml.attribute "id" ("item-" <> show (ItemKey.unwrap key)),
+      lineAttribute loc
     ]
     ( nameContents
         <> [Content.Element kindElement]
@@ -444,6 +447,10 @@ itemToHtml (Located.MkLocated loc (Item.MkItem key itemKind _parentKey maybeName
     docContents' = case doc of
       Doc.Empty -> []
       _ -> [Content.Element $ Xml.element "div" [Xml.attribute "class" "item-doc"] (docToContents doc)]
+
+lineAttribute :: Location.Location -> Attribute.Attribute
+lineAttribute loc =
+  Xml.attribute "data-line" (show (Line.unwrap (Location.line loc)))
 
 locationElement :: Location.Location -> Element.Element
 locationElement (Location.MkLocation (Line.MkLine l) (Column.MkColumn c)) =


### PR DESCRIPTION
Fixes #60.

## Summary

- **Haskell (`ToHtml.hs`)**: Added `data-line` attributes to module header and declaration item elements in the generated HTML, using existing source location information from the `Located` wrapper.

- **VSCode extension (`extension.ts`)**: Replaced direct `panel.webview.html` assignment with a persistent wrapper page that receives content updates via `postMessage`. This preserves scroll position across edits (no full page reload). Added `onDidChangeTextEditorVisibleRanges` listener that syncs the preview scroll to the editor's top visible line by finding the nearest `data-line` element.

## How it works

1. The wrapper HTML page is set once when the preview panel is created.
2. Content updates are delivered via `postMessage` — the webview JavaScript parses the incoming HTML with `DOMParser`, extracts styles and body content, and applies them while preserving scroll position.
3. When the editor scrolls, the extension sends the top visible line number to the webview, which finds the closest `[data-line]` element at or before that line and scrolls it into view.

## Test plan

- [x] Open a Haskell file, run "Scrod: Open Documentation Preview"
- [x] Scroll the editor — preview should follow to the corresponding declaration
- [x] Edit the file — preview content should update without losing scroll position
- [ ] Verify error display still works (e.g., open a file with syntax errors)
- [x] `cabal build` and `cabal test` pass (789 tests)
- [x] `tsc --noEmit` passes for the extension
- [x] `ormolu --mode check` passes on modified Haskell file

🤖 Generated with [Claude Code](https://claude.com/claude-code)