### PR TITLE
Support Literate Haskell in VSCode extension

### DIFF
--- a/extra/vscode/package.json
+++ b/extra/vscode/package.json
@@ -21,6 +21,16 @@
   ],
   "main": "./out/extension.js",
   "contributes": {
+    "languages": [
+      {
+        "id": "haskell",
+        "extensions": [".hs"]
+      },
+      {
+        "id": "literate haskell",
+        "extensions": [".lhs"]
+      }
+    ],
     "commands": [
       {
         "command": "scrod.openPreview",
@@ -32,7 +42,7 @@
       "editor/title": [
         {
           "command": "scrod.openPreview",
-          "when": "editorLangId == haskell || editorLangId == 'literate haskell'",
+          "when": "editorLangId == haskell || editorLangId == 'literate haskell' || resourceExtname == .hs || resourceExtname == .lhs",
           "group": "navigation"
         }
       ]

--- a/extra/vscode/src/extension.ts
+++ b/extra/vscode/src/extension.ts
@@ -70,12 +70,17 @@ export function activate(context: vscode.ExtensionContext): void {
 
 export function deactivate(): void {}
 
+function extname(doc: vscode.TextDocument): string {
+  return path.extname(doc.fileName).toLowerCase();
+}
+
 function isHaskell(doc: vscode.TextDocument): boolean {
+  const ext = extname(doc);
   return (
     doc.languageId === "haskell" ||
     doc.languageId === "literate haskell" ||
-    doc.fileName.endsWith(".hs") ||
-    doc.fileName.endsWith(".lhs")
+    ext === ".hs" ||
+    ext === ".lhs"
   );
 }
 
@@ -98,7 +103,8 @@ function scheduleUpdate(document: vscode.TextDocument): void {
 async function update(document: vscode.TextDocument): Promise<void> {
   if (!panel) return;
   panel.title = `Preview: ${path.basename(document.fileName)}`;
-  const literate = document.fileName.endsWith(".lhs");
+  const literate =
+    document.languageId === "literate haskell" || extname(document) === ".lhs";
   let html: string;
   try {
     const process = await engine;

--- a/extra/vscode/src/extension.ts
+++ b/extra/vscode/src/extension.ts
@@ -71,7 +71,12 @@ export function activate(context: vscode.ExtensionContext): void {
 export function deactivate(): void {}
 
 function isHaskell(doc: vscode.TextDocument): boolean {
-  return doc.languageId === "haskell" || doc.languageId === "literate haskell";
+  return (
+    doc.languageId === "haskell" ||
+    doc.languageId === "literate haskell" ||
+    doc.fileName.endsWith(".hs") ||
+    doc.fileName.endsWith(".lhs")
+  );
 }
 
 function immediateUpdate(document: vscode.TextDocument | undefined): void {


### PR DESCRIPTION
Fixes #72.

## Summary

The VSCode extension relied on another extension (e.g. Haskell Language Server or Haskell Syntax Highlighting) to assign the `literate haskell` language ID to `.lhs` files. Without one of those extensions, `.lhs` files were treated as `plaintext`, so `isHaskell()` returned `false` — causing the preview to be empty and not update when switching from `.hs` to `.lhs` files.

This PR:

- Adds `languages` contributions to `package.json` so the extension itself registers `.hs` → `haskell` and `.lhs` → `literate haskell`
- Adds file extension checks (`.hs`, `.lhs`) to the `isHaskell()` function as a defense-in-depth fallback
- Adds `resourceExtname` conditions to the editor title menu `when` clause so the preview button appears for `.lhs` files regardless of language ID

## Test plan

- [x] Open a `.lhs` file with no other Haskell extension installed — the preview button should appear and the preview should render
- [x] Open a `.hs` file, open preview, then switch to a `.lhs` file — preview should update
- [x] Verify `.hs` files continue to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)