### PR TITLE
Add dark mode support to web app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,14 +180,13 @@ jobs:
         with:
           name: ${{ needs.meta.outputs.name }}-${{ github.sha }}-wasm
       - run: tar --extract --file artifact.tar
-      - run: mkdir dist
-      - run: cp extra/github-pages/index.html extra/github-pages/index.js extra/github-pages/worker.js extra/github-pages/style.css dist/
-      - run: cp -r extra/github-pages/vendor dist/
-      - run: cp artifact/${{ needs.meta.outputs.name }}-wasm.wasm dist/scrod-wasm.wasm
-      - run: cp artifact/ghc_wasm_jsffi.js dist/
+      - run: mkdir -p extra/wasm/dist
+      - run: cp artifact/${{ needs.meta.outputs.name }}-wasm.wasm extra/wasm/dist/scrod-wasm.wasm
+      - run: cp artifact/ghc_wasm_jsffi.js extra/wasm/dist/
+      - run: extra/github-pages/build.sh
       - uses: actions/upload-pages-artifact@v4
         with:
-          path: dist/
+          path: extra/github-pages/dist/
       - id: deploy
         uses: actions/deploy-pages@v4
   release:

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@
 /extra/vscode/out/
 /extra/vscode/wasm/
 /extra/vscode/*.vsix
+/extra/github-pages/dist/
 /extra/wasm/dist/

--- a/extra/github-pages/build.sh
+++ b/extra/github-pages/build.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -o errexit -o nounset -o pipefail
+
+dist=extra/github-pages/dist
+
+rm -rf "$dist"
+mkdir -p "$dist"
+
+cp extra/github-pages/index.html "$dist/"
+cp extra/github-pages/index.js "$dist/"
+cp extra/github-pages/worker.js "$dist/"
+cp extra/github-pages/style.css "$dist/"
+cp -r extra/github-pages/vendor "$dist/"
+cp extra/wasm/dist/scrod-wasm.wasm "$dist/"
+cp extra/wasm/dist/ghc_wasm_jsffi.js "$dist/"

--- a/extra/github-pages/index.html
+++ b/extra/github-pages/index.html
@@ -21,6 +21,12 @@
         <option value='json'>JSON</option>
       </select>
       <label><input type='checkbox' id='literate'> Literate</label>
+      <label for='theme' class='sr-only'>Color scheme</label>
+      <select id='theme'>
+        <option value='auto' selected>Auto</option>
+        <option value='light'>Light</option>
+        <option value='dark'>Dark</option>
+      </select>
     </div>
     <div id='output' role='region' aria-live='polite' aria-label='Output'></div>
   </div>

--- a/extra/github-pages/index.js
+++ b/extra/github-pages/index.js
@@ -14,8 +14,52 @@ var ready = false;
 // Dark mode CSS variable overrides for the shadow DOM.
 // These use :host() selectors to override the generated CSS variables
 // when the user manually picks a theme (instead of "auto").
-var darkVars = '--scrod-text: #ddd; --scrod-text-secondary: #aaa; --scrod-text-muted: #888; --scrod-bg: #121212; --scrod-bg-subtle: #2a2a2a; --scrod-metadata-bg: #1e1e1e; --scrod-item-bg: #1a1a1a; --scrod-border: #444; --scrod-accent: #4da6ff; --scrod-code-color: #66cc66; --scrod-module-color: #cc66cc; --scrod-warning-bg: #3d3000; --scrod-warning-border: #ffc107; --scrod-warning-text: #ffd75e; --scrod-examples-bg: #2a2800; --scrod-examples-border: #e6db74; --scrod-property-bg: #1a2233; --scrod-property-border: #6b8ef0; --scrod-extension-bg: #3a3a3a; --scrod-extension-disabled-bg: #3d1a1a; color-scheme: dark';
-var lightVars = '--scrod-text: #333; --scrod-text-secondary: #666; --scrod-text-muted: #999; --scrod-bg: white; --scrod-bg-subtle: #f4f4f4; --scrod-metadata-bg: #f9f9f9; --scrod-item-bg: #fafafa; --scrod-border: #ddd; --scrod-accent: #0066cc; --scrod-code-color: #006600; --scrod-module-color: #660066; --scrod-warning-bg: #fff3cd; --scrod-warning-border: #ffc107; --scrod-warning-text: #856404; --scrod-examples-bg: #fffef0; --scrod-examples-border: #e6db74; --scrod-property-bg: #f0f8ff; --scrod-property-border: #4169e1; --scrod-extension-bg: #e8e8e8; --scrod-extension-disabled-bg: #ffebeb; color-scheme: light';
+var darkVars = [
+  '--scrod-text: #ddd',
+  '--scrod-text-secondary: #aaa',
+  '--scrod-text-muted: #888',
+  '--scrod-bg: #121212',
+  '--scrod-bg-subtle: #2a2a2a',
+  '--scrod-metadata-bg: #1e1e1e',
+  '--scrod-item-bg: #1a1a1a',
+  '--scrod-border: #444',
+  '--scrod-accent: #4da6ff',
+  '--scrod-code-color: #66cc66',
+  '--scrod-module-color: #cc66cc',
+  '--scrod-warning-bg: #3d3000',
+  '--scrod-warning-border: #ffc107',
+  '--scrod-warning-text: #ffd75e',
+  '--scrod-examples-bg: #2a2800',
+  '--scrod-examples-border: #e6db74',
+  '--scrod-property-bg: #1a2233',
+  '--scrod-property-border: #6b8ef0',
+  '--scrod-extension-bg: #3a3a3a',
+  '--scrod-extension-disabled-bg: #3d1a1a',
+  'color-scheme: dark'
+].join('; ');
+var lightVars = [
+  '--scrod-text: #333',
+  '--scrod-text-secondary: #666',
+  '--scrod-text-muted: #999',
+  '--scrod-bg: white',
+  '--scrod-bg-subtle: #f4f4f4',
+  '--scrod-metadata-bg: #f9f9f9',
+  '--scrod-item-bg: #fafafa',
+  '--scrod-border: #ddd',
+  '--scrod-accent: #0066cc',
+  '--scrod-code-color: #006600',
+  '--scrod-module-color: #660066',
+  '--scrod-warning-bg: #fff3cd',
+  '--scrod-warning-border: #ffc107',
+  '--scrod-warning-text: #856404',
+  '--scrod-examples-bg: #fffef0',
+  '--scrod-examples-border: #e6db74',
+  '--scrod-property-bg: #f0f8ff',
+  '--scrod-property-border: #4169e1',
+  '--scrod-extension-bg: #e8e8e8',
+  '--scrod-extension-disabled-bg: #ffebeb',
+  'color-scheme: light'
+].join('; ');
 
 function ensureThemeStyle() {
   if (!shadow.querySelector('#theme-override')) {
@@ -39,7 +83,11 @@ function applyTheme(value) {
     output.classList.add('theme-' + value);
   }
   ensureThemeStyle();
-  localStorage.setItem('scrod-theme', value);
+  if (value === 'auto') {
+    localStorage.removeItem('scrod-theme');
+  } else {
+    localStorage.setItem('scrod-theme', value);
+  }
 }
 
 function showError(message) {

--- a/extra/github-pages/index.js
+++ b/extra/github-pages/index.js
@@ -1,26 +1,59 @@
 'use strict';
 
-const worker = new Worker('worker.js', { type: 'module' });
-const source = document.getElementById('source');
-const output = document.getElementById('output');
-const format = document.getElementById('format');
-const literate = document.getElementById('literate');
-const shadow = output.attachShadow({ mode: 'open' });
+var worker = new Worker('worker.js', { type: 'module' });
+var source = document.getElementById('source');
+var output = document.getElementById('output');
+var format = document.getElementById('format');
+var literate = document.getElementById('literate');
+var theme = document.getElementById('theme');
+var shadow = output.attachShadow({ mode: 'open' });
 shadow.innerHTML = '<p style="color: #888; font-style: italic">Loading WASM module...</p>';
-let debounceTimer;
-let ready = false;
+var debounceTimer;
+var ready = false;
+
+// Dark mode CSS variable overrides for the shadow DOM.
+// These use :host() selectors to override the generated CSS variables
+// when the user manually picks a theme (instead of "auto").
+var darkVars = '--scrod-text: #ddd; --scrod-text-secondary: #aaa; --scrod-text-muted: #888; --scrod-bg: #121212; --scrod-bg-subtle: #2a2a2a; --scrod-metadata-bg: #1e1e1e; --scrod-item-bg: #1a1a1a; --scrod-border: #444; --scrod-accent: #4da6ff; --scrod-code-color: #66cc66; --scrod-module-color: #cc66cc; --scrod-warning-bg: #3d3000; --scrod-warning-border: #ffc107; --scrod-warning-text: #ffd75e; --scrod-examples-bg: #2a2800; --scrod-examples-border: #e6db74; --scrod-property-bg: #1a2233; --scrod-property-border: #6b8ef0; --scrod-extension-bg: #3a3a3a; --scrod-extension-disabled-bg: #3d1a1a; color-scheme: dark';
+var lightVars = '--scrod-text: #333; --scrod-text-secondary: #666; --scrod-text-muted: #999; --scrod-bg: white; --scrod-bg-subtle: #f4f4f4; --scrod-metadata-bg: #f9f9f9; --scrod-item-bg: #fafafa; --scrod-border: #ddd; --scrod-accent: #0066cc; --scrod-code-color: #006600; --scrod-module-color: #660066; --scrod-warning-bg: #fff3cd; --scrod-warning-border: #ffc107; --scrod-warning-text: #856404; --scrod-examples-bg: #fffef0; --scrod-examples-border: #e6db74; --scrod-property-bg: #f0f8ff; --scrod-property-border: #4169e1; --scrod-extension-bg: #e8e8e8; --scrod-extension-disabled-bg: #ffebeb; color-scheme: light';
+
+function ensureThemeStyle() {
+  if (!shadow.querySelector('#theme-override')) {
+    var style = document.createElement('style');
+    style.id = 'theme-override';
+    style.textContent =
+      ':host(.theme-dark) body { ' + darkVars + ' } ' +
+      ':host(.theme-light) body { ' + lightVars + ' }';
+    shadow.appendChild(style);
+  }
+}
+
+function applyTheme(value) {
+  if (value === 'auto') {
+    document.documentElement.removeAttribute('data-theme');
+  } else {
+    document.documentElement.setAttribute('data-theme', value);
+  }
+  output.classList.remove('theme-dark', 'theme-light');
+  if (value !== 'auto') {
+    output.classList.add('theme-' + value);
+  }
+  ensureThemeStyle();
+  localStorage.setItem('scrod-theme', value);
+}
 
 function showError(message) {
   shadow.textContent = '';
-  const pre = document.createElement('pre');
+  var pre = document.createElement('pre');
   pre.style.cssText = 'color: #c00; white-space: pre-wrap; font-family: monospace; font-size: 14px';
   pre.textContent = message;
   shadow.appendChild(pre);
+  ensureThemeStyle();
 }
 
 function showJson(json) {
   shadow.textContent = '';
-  const pre = document.createElement('pre');
+  var pre = document.createElement('pre');
   pre.style.cssText = 'white-space: pre-wrap; font-family: monospace; font-size: 14px';
   try {
     pre.textContent = JSON.stringify(JSON.parse(json), null, 2);
@@ -28,10 +61,11 @@ function showJson(json) {
     pre.textContent = json;
   }
   shadow.appendChild(pre);
+  ensureThemeStyle();
 }
 
 worker.onmessage = function (e) {
-  const msg = e.data;
+  var msg = e.data;
   if (msg.tag === 'ready') {
     ready = true;
     shadow.innerHTML = '';
@@ -41,6 +75,7 @@ worker.onmessage = function (e) {
       showJson(msg.value);
     } else {
       shadow.innerHTML = msg.value;
+      ensureThemeStyle();
     }
   } else if (msg.tag === 'error') {
     showError(msg.message);
@@ -48,7 +83,7 @@ worker.onmessage = function (e) {
 };
 
 worker.onerror = function (e) {
-  showError(`Worker error: ${e.message}`);
+  showError('Worker error: ' + e.message);
 };
 
 function encodeHash(text) {
@@ -73,7 +108,7 @@ function updateHash() {
       params.set('literate', 'true');
     }
     params.set('input', encodeHash(source.value));
-    history.replaceState(null, '', `#${params.toString()}`);
+    history.replaceState(null, '', '#' + params.toString());
   } else {
     history.replaceState(null, '', location.pathname);
   }
@@ -88,7 +123,7 @@ function isUrl(text) {
   }
 }
 
-let fetchController = null;
+var fetchController = null;
 
 function fetchUrl(url) {
   if (fetchController) {
@@ -96,9 +131,10 @@ function fetchUrl(url) {
   }
   fetchController = new AbortController();
   shadow.innerHTML = '<p style="color: #888; font-style: italic">Fetching URL...</p>';
+  ensureThemeStyle();
   fetch(url, { signal: fetchController.signal }).then(function (response) {
     if (!response.ok) {
-      throw new Error(`HTTP ${response.status} ${response.statusText}`);
+      throw new Error('HTTP ' + response.status + ' ' + response.statusText);
     }
     return response.text();
   }).then(function (text) {
@@ -107,7 +143,7 @@ function fetchUrl(url) {
     process(true);
   }).catch(function (err) {
     if (err.name !== 'AbortError') {
-      showError(`Failed to fetch URL: ${err.message}`);
+      showError('Failed to fetch URL: ' + err.message);
     }
   });
 }
@@ -140,6 +176,17 @@ literate.addEventListener('change', function () {
   updateHash();
   process();
 });
+
+theme.addEventListener('change', function () {
+  applyTheme(theme.value);
+});
+
+// Load saved theme preference
+var savedTheme = localStorage.getItem('scrod-theme');
+if (savedTheme === 'light' || savedTheme === 'dark') {
+  theme.value = savedTheme;
+  applyTheme(savedTheme);
+}
 
 // Load content from URL hash on startup
 if (location.hash.length > 1) {

--- a/extra/github-pages/style.css
+++ b/extra/github-pages/style.css
@@ -4,6 +4,43 @@
   padding: 0;
 }
 
+:root {
+  --app-bg: white;
+  --app-text: #333;
+  --app-border: #ccc;
+  --app-input-bg: white;
+  --app-toolbar-bg: white;
+  color-scheme: light dark;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --app-bg: #121212;
+    --app-text: #ddd;
+    --app-border: #444;
+    --app-input-bg: #1e1e1e;
+    --app-toolbar-bg: #1a1a1a;
+  }
+}
+
+[data-theme="dark"] {
+  --app-bg: #121212;
+  --app-text: #ddd;
+  --app-border: #444;
+  --app-input-bg: #1e1e1e;
+  --app-toolbar-bg: #1a1a1a;
+  color-scheme: dark;
+}
+
+[data-theme="light"] {
+  --app-bg: white;
+  --app-text: #333;
+  --app-border: #ccc;
+  --app-input-bg: white;
+  --app-toolbar-bg: white;
+  color-scheme: light;
+}
+
 .sr-only {
   position: absolute;
   width: 1px;
@@ -19,6 +56,8 @@ body {
   display: flex;
   height: 100vh;
   font-family: system-ui, sans-serif;
+  background: var(--app-bg);
+  color: var(--app-text);
 }
 
 .pane {
@@ -28,7 +67,7 @@ body {
 }
 
 .input-pane {
-  border-right: 1px solid #ccc;
+  border-right: 1px solid var(--app-border);
 }
 
 .input-pane textarea {
@@ -41,6 +80,8 @@ body {
   font-family: monospace;
   font-size: 14px;
   tab-size: 2;
+  background: var(--app-input-bg);
+  color: var(--app-text);
 }
 
 .output-pane {
@@ -50,8 +91,9 @@ body {
 
 .toolbar {
   padding: 0.5rem 1rem;
-  border-bottom: 1px solid #ccc;
+  border-bottom: 1px solid var(--app-border);
   flex-shrink: 0;
+  background: var(--app-toolbar-bg);
 }
 
 .toolbar select,
@@ -59,6 +101,13 @@ body {
   font-family: system-ui, sans-serif;
   font-size: 14px;
   padding: 2px 4px;
+}
+
+.toolbar select {
+  background: var(--app-input-bg);
+  color: var(--app-text);
+  border: 1px solid var(--app-border);
+  border-radius: 3px;
 }
 
 #output {

--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -41,6 +41,9 @@ import qualified Scrod.Core.Table as Table
 import qualified Scrod.Core.TableCell as TableCell
 import qualified Scrod.Core.Version as Version
 import qualified Scrod.Core.Warning as Warning
+import qualified Scrod.Css.AtRule as CssAtRule
+import qualified Scrod.Css.Block as CssBlock
+import qualified Scrod.Css.BlockContent as CssBlockContent
 import qualified Scrod.Css.Declaration as CssDeclaration
 import qualified Scrod.Css.Item as CssItem
 import qualified Scrod.Css.Name as CssName
@@ -879,13 +882,43 @@ stylesheet :: CssStylesheet.Stylesheet
 stylesheet =
   CssStylesheet.MkStylesheet
     [ rule ["*", "* ::before", "* ::after"] [("box-sizing", "border-box")],
-      rule ["body"] [("font-family", "system-ui, -apple-system, sans-serif"), ("line-height", "1.6"), ("max-width", "900px"), ("margin", "0 auto"), ("padding", "2rem"), ("color", "#333")],
-      rule ["h1"] [("border-bottom", "2px solid #333"), ("padding-bottom", "0.5rem"), ("margin-top", "0")],
-      rule ["h2"] [("border-bottom", "1px solid #666"), ("padding-bottom", "0.3rem"), ("margin-top", "2rem")],
+      rule
+        ["body"]
+        [ ("--scrod-text", "#333"),
+          ("--scrod-text-secondary", "#666"),
+          ("--scrod-text-muted", "#999"),
+          ("--scrod-bg", "white"),
+          ("--scrod-bg-subtle", "#f4f4f4"),
+          ("--scrod-metadata-bg", "#f9f9f9"),
+          ("--scrod-item-bg", "#fafafa"),
+          ("--scrod-border", "#ddd"),
+          ("--scrod-accent", "#0066cc"),
+          ("--scrod-code-color", "#006600"),
+          ("--scrod-module-color", "#660066"),
+          ("--scrod-warning-bg", "#fff3cd"),
+          ("--scrod-warning-border", "#ffc107"),
+          ("--scrod-warning-text", "#856404"),
+          ("--scrod-examples-bg", "#fffef0"),
+          ("--scrod-examples-border", "#e6db74"),
+          ("--scrod-property-bg", "#f0f8ff"),
+          ("--scrod-property-border", "#4169e1"),
+          ("--scrod-extension-bg", "#e8e8e8"),
+          ("--scrod-extension-disabled-bg", "#ffebeb"),
+          ("font-family", "system-ui, -apple-system, sans-serif"),
+          ("line-height", "1.6"),
+          ("max-width", "900px"),
+          ("margin", "0 auto"),
+          ("padding", "2rem"),
+          ("color", "var(--scrod-text)"),
+          ("background-color", "var(--scrod-bg)"),
+          ("color-scheme", "light dark")
+        ],
+      rule ["h1"] [("border-bottom", "2px solid var(--scrod-text)"), ("padding-bottom", "0.5rem"), ("margin-top", "0")],
+      rule ["h2"] [("border-bottom", "1px solid var(--scrod-text-secondary)"), ("padding-bottom", "0.3rem"), ("margin-top", "2rem")],
       rule ["h3", "h4", "h5", "h6"] [("margin-top", "1.5rem")],
       rule ["p"] [("margin", "1rem 0")],
-      rule ["code"] [("background", "#f4f4f4"), ("padding", "0.2em 0.4em"), ("border-radius", "3px"), ("font-family", "Consolas, Monaco, Menlo, monospace"), ("font-size", "0.9em")],
-      rule ["pre"] [("background", "#f4f4f4"), ("padding", "1rem"), ("border-radius", "5px"), ("overflow-x", "auto"), ("margin", "1rem 0")],
+      rule ["code"] [("background", "var(--scrod-bg-subtle)"), ("padding", "0.2em 0.4em"), ("border-radius", "3px"), ("font-family", "Consolas, Monaco, Menlo, monospace"), ("font-size", "0.9em")],
+      rule ["pre"] [("background", "var(--scrod-bg-subtle)"), ("padding", "1rem"), ("border-radius", "5px"), ("overflow-x", "auto"), ("margin", "1rem 0")],
       rule ["pre > code"] [("background", "transparent"), ("padding", "0")],
       rule ["ul", "ol"] [("margin", "1rem 0"), ("padding-left", "2rem")],
       rule ["li"] [("margin", "0.25rem 0")],
@@ -893,46 +926,72 @@ stylesheet =
       rule ["dt"] [("font-weight", "bold"), ("margin-top", "0.5rem")],
       rule ["dd"] [("margin-left", "2rem"), ("margin-bottom", "0.5rem")],
       rule ["table"] [("border-collapse", "collapse"), ("width", "100%"), ("margin", "1rem 0")],
-      rule ["th", "td"] [("border", "1px solid #ddd"), ("padding", "0.5rem"), ("text-align", "left")],
-      rule ["th"] [("background", "#f4f4f4"), ("font-weight", "bold")],
-      rule ["a"] [("color", "#0066cc"), ("text-decoration", "none")],
+      rule ["th", "td"] [("border", "1px solid var(--scrod-border)"), ("padding", "0.5rem"), ("text-align", "left")],
+      rule ["th"] [("background", "var(--scrod-bg-subtle)"), ("font-weight", "bold")],
+      rule ["a"] [("color", "var(--scrod-accent)"), ("text-decoration", "none")],
       rule ["a:hover"] [("text-decoration", "underline")],
       rule ["img"] [("max-width", "100%"), ("height", "auto")],
       rule [".module-header"] [("margin-bottom", "2rem")],
       rule [".module-doc"] [("margin", "1rem 0")],
-      rule [".metadata"] [("background", "#f9f9f9"), ("border-left", "4px solid #0066cc"), ("padding", "1rem"), ("margin", "1rem 0")],
+      rule [".metadata"] [("background", "var(--scrod-metadata-bg)"), ("border-left", "4px solid var(--scrod-accent)"), ("padding", "1rem"), ("margin", "1rem 0")],
       rule [".metadata > dt"] [("display", "inline")],
       rule [".metadata > dd"] [("display", "inline"), ("margin-left", "0.5rem")],
       rule [".exports"] [("margin", "2rem 0")],
       rule [".export-group"] [("margin", "1.5rem 0")],
-      rule [".export-group-title"] [("font-weight", "bold"), ("color", "#333"), ("margin-bottom", "0.5rem")],
+      rule [".export-group-title"] [("font-weight", "bold"), ("color", "var(--scrod-text)"), ("margin-bottom", "0.5rem")],
       rule [".export-list"] [("list-style-type", "none"), ("padding-left", "0")],
       rule [".export-list > li"] [("padding", "0.25rem 0")],
       rule [".imports"] [("margin", "2rem 0")],
       rule [".import-list"] [("list-style-type", "none"), ("padding-left", "0")],
       rule [".import-list > li"] [("padding", "0.25rem 0"), ("font-family", "Consolas, Monaco, Menlo, monospace"), ("font-size", "0.9em")],
       rule [".items"] [("margin", "2rem 0")],
-      rule [".item"] [("margin", "1.5rem 0"), ("padding", "1rem"), ("background", "#fafafa"), ("border-radius", "5px"), ("border-left", "4px solid #ddd")],
-      rule [".item-name"] [("font-family", "Consolas, Monaco, Menlo, monospace"), ("font-weight", "bold"), ("font-size", "1.1em"), ("color", "#006600")],
-      rule [".item-key"] [("color", "#999"), ("font-size", "0.8em"), ("margin-left", "0.5rem")],
+      rule [".item"] [("margin", "1.5rem 0"), ("padding", "1rem"), ("background", "var(--scrod-item-bg)"), ("border-radius", "5px"), ("border-left", "4px solid var(--scrod-border)")],
+      rule [".item-name"] [("font-family", "Consolas, Monaco, Menlo, monospace"), ("font-weight", "bold"), ("font-size", "1.1em"), ("color", "var(--scrod-code-color)")],
+      rule [".item-key"] [("color", "var(--scrod-text-muted)"), ("font-size", "0.8em"), ("margin-left", "0.5rem")],
       rule [".item-doc"] [("margin-top", "0.5rem")],
-      rule [".item-children"] [("margin-left", "1.5rem"), ("margin-top", "0.5rem"), ("border-left", "2px solid #ddd"), ("padding-left", "1rem")],
-      rule [".identifier"] [("color", "#006600"), ("font-family", "Consolas, Monaco, Menlo, monospace")],
-      rule [".module-link"] [("color", "#660066"), ("font-family", "Consolas, Monaco, Menlo, monospace")],
-      rule [".warning"] [("background", "#fff3cd"), ("border-left", "4px solid #ffc107"), ("padding", "1rem"), ("margin", "1rem 0")],
-      rule [".warning-category"] [("font-weight", "bold"), ("color", "#856404")],
-      rule [".since"] [("color", "#666"), ("font-size", "0.9em")],
-      rule [".examples"] [("background", "#fffef0"), ("border-left", "4px solid #e6db74"), ("padding", "1rem"), ("margin", "1rem 0")],
+      rule [".item-children"] [("margin-left", "1.5rem"), ("margin-top", "0.5rem"), ("border-left", "2px solid var(--scrod-border)"), ("padding-left", "1rem")],
+      rule [".identifier"] [("color", "var(--scrod-code-color)"), ("font-family", "Consolas, Monaco, Menlo, monospace")],
+      rule [".module-link"] [("color", "var(--scrod-module-color)"), ("font-family", "Consolas, Monaco, Menlo, monospace")],
+      rule [".warning"] [("background", "var(--scrod-warning-bg)"), ("border-left", "4px solid var(--scrod-warning-border)"), ("padding", "1rem"), ("margin", "1rem 0")],
+      rule [".warning-category"] [("font-weight", "bold"), ("color", "var(--scrod-warning-text)")],
+      rule [".since"] [("color", "var(--scrod-text-secondary)"), ("font-size", "0.9em")],
+      rule [".examples"] [("background", "var(--scrod-examples-bg)"), ("border-left", "4px solid var(--scrod-examples-border)"), ("padding", "1rem"), ("margin", "1rem 0")],
       rule [".example"] [("margin", "0.5rem 0")],
       rule [".example-expression"] [("font-family", "Consolas, Monaco, Menlo, monospace")],
-      rule [".example-result"] [("font-family", "Consolas, Monaco, Menlo, monospace"), ("color", "#666"), ("padding-left", "1rem")],
-      rule [".property"] [("background", "#f0f8ff"), ("border-left", "4px solid #4169e1"), ("padding", "1rem"), ("margin", "1rem 0")],
+      rule [".example-result"] [("font-family", "Consolas, Monaco, Menlo, monospace"), ("color", "var(--scrod-text-secondary)"), ("padding-left", "1rem")],
+      rule [".property"] [("background", "var(--scrod-property-bg)"), ("border-left", "4px solid var(--scrod-property-border)"), ("padding", "1rem"), ("margin", "1rem 0")],
       rule [".math-inline"] [("font-style", "italic")],
       rule [".math-display"] [("display", "block"), ("text-align", "center"), ("margin", "1rem 0"), ("font-style", "italic")],
       rule [".extensions"] [("margin", "1rem 0")],
-      rule [".extension"] [("display", "inline-block"), ("margin", "0.25rem"), ("padding", "0.25rem 0.5rem"), ("background", "#e8e8e8"), ("border-radius", "3px"), ("font-family", "Consolas, Monaco, Menlo, monospace"), ("font-size", "0.85em")],
-      rule [".extension-disabled"] [("background", "#ffebeb"), ("text-decoration", "line-through")],
-      rule [".generated-by"] [("margin-top", "3rem"), ("padding-top", "1rem"), ("border-top", "1px solid #ddd"), ("color", "#999"), ("font-size", "0.85em")]
+      rule [".extension"] [("display", "inline-block"), ("margin", "0.25rem"), ("padding", "0.25rem 0.5rem"), ("background", "var(--scrod-extension-bg)"), ("border-radius", "3px"), ("font-family", "Consolas, Monaco, Menlo, monospace"), ("font-size", "0.85em")],
+      rule [".extension-disabled"] [("background", "var(--scrod-extension-disabled-bg)"), ("text-decoration", "line-through")],
+      rule [".generated-by"] [("margin-top", "3rem"), ("padding-top", "1rem"), ("border-top", "1px solid var(--scrod-border)"), ("color", "var(--scrod-text-muted)"), ("font-size", "0.85em")],
+      mediaRule
+        "(prefers-color-scheme: dark)"
+        [ rule
+            ["body"]
+            [ ("--scrod-text", "#ddd"),
+              ("--scrod-text-secondary", "#aaa"),
+              ("--scrod-text-muted", "#888"),
+              ("--scrod-bg", "#121212"),
+              ("--scrod-bg-subtle", "#2a2a2a"),
+              ("--scrod-metadata-bg", "#1e1e1e"),
+              ("--scrod-item-bg", "#1a1a1a"),
+              ("--scrod-border", "#444"),
+              ("--scrod-accent", "#4da6ff"),
+              ("--scrod-code-color", "#66cc66"),
+              ("--scrod-module-color", "#cc66cc"),
+              ("--scrod-warning-bg", "#3d3000"),
+              ("--scrod-warning-border", "#ffc107"),
+              ("--scrod-warning-text", "#ffd75e"),
+              ("--scrod-examples-bg", "#2a2800"),
+              ("--scrod-examples-border", "#e6db74"),
+              ("--scrod-property-bg", "#1a2233"),
+              ("--scrod-property-border", "#6b8ef0"),
+              ("--scrod-extension-bg", "#3a3a3a"),
+              ("--scrod-extension-disabled-bg", "#3d1a1a")
+            ]
+        ]
     ]
 
 rule :: [String] -> [(String, String)] -> CssItem.Item
@@ -941,3 +1000,11 @@ rule selectors declarations =
     CssRule.MkRule
       (fmap (CssSelector.MkSelector . Text.pack) selectors)
       (fmap (\(p, v) -> CssDeclaration.MkDeclaration (CssName.MkName $ Text.pack p) (Text.pack v) False) declarations)
+
+mediaRule :: String -> [CssItem.Item] -> CssItem.Item
+mediaRule query items =
+  CssItem.ItemAtRule $
+    CssAtRule.MkAtRule
+      (CssName.MkName $ Text.pack "media")
+      (Text.pack query)
+      (Just $ CssBlock.MkBlock (fmap CssBlockContent.ContentItem items))


### PR DESCRIPTION
## Summary

Fixes #58.

- Replaces all hardcoded colors in the generated CSS (`ToHtml.hs`) with CSS custom properties (e.g. `--scrod-text`, `--scrod-bg`, `--scrod-accent`), defined on `body` with light-mode defaults
- Adds a `@media (prefers-color-scheme: dark)` block that overrides those variables with a dark color palette — this gives automatic dark mode to standalone HTML output, the VSCode extension preview, and the web app
- Adds a **light / auto / dark** theme toggle (`<select>`) to the web app toolbar
  - *Auto* respects the OS/browser preference via the media query
  - *Light* and *Dark* override by setting a `data-theme` attribute on `<html>` (for the web app UI) and adding `theme-dark`/`theme-light` classes to the shadow DOM host (for the generated documentation)
  - The override works via `:host(.theme-dark) body { ... }` selectors injected into the shadow DOM, which have higher specificity than the `body` rules inside the media query
  - Theme preference is persisted in `localStorage`
- Updates `style.css` to use CSS variables for the web app's own UI elements (textarea, toolbar, borders) with matching light/dark palettes

## Test plan

- [x] `cabal build` succeeds
- [x] `cabal build --flags=pedantic` succeeds (no warnings)
- [x] All 796 tests pass
- [x] `ormolu --mode check` passes
- [x] `hlint` reports no hints
- [x] Manual: open web app, verify light theme is default
- [x] Manual: set OS to dark mode, verify auto dark mode activates
- [x] Manual: use theme toggle to force dark/light, verify override works
- [x] Manual: refresh page, verify saved theme preference is restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)