### PR TITLE
Make locations clickable in VSCode extension preview

### DIFF
--- a/extra/vscode/src/extension.ts
+++ b/extra/vscode/src/extension.ts
@@ -141,17 +141,22 @@ function syncScroll(editor: vscode.TextEditor): void {
 
 async function gotoLocation(line: number, col: number): Promise<void> {
   if (!previewDocumentUri) return;
-  const editor = vscode.window.visibleTextEditors.find(
+  const existing = vscode.window.visibleTextEditors.find(
     (e) => e.document.uri.toString() === previewDocumentUri?.toString()
   );
-  if (!editor) return;
+  const document = existing
+    ? existing.document
+    : await vscode.workspace.openTextDocument(previewDocumentUri);
+  const editor = await vscode.window.showTextDocument(
+    document,
+    existing?.viewColumn
+  );
   const position = new vscode.Position(line - 1, col - 1);
   editor.selection = new vscode.Selection(position, position);
   editor.revealRange(
     new vscode.Range(position, position),
     vscode.TextEditorRevealType.InCenterIfOutsideViewport
   );
-  await vscode.window.showTextDocument(editor.document, editor.viewColumn);
 }
 
 function getNonce(): string {

--- a/extra/vscode/src/extension.ts
+++ b/extra/vscode/src/extension.ts
@@ -8,6 +8,7 @@ let panel: vscode.WebviewPanel | undefined;
 let debounceTimer: ReturnType<typeof setTimeout> | undefined;
 let webviewReady = false;
 let pendingHtml: string | undefined;
+let previewDocumentUri: vscode.Uri | undefined;
 
 export function activate(context: vscode.ExtensionContext): void {
   engine = loadWasmEngine(context.extensionPath);
@@ -36,12 +37,15 @@ export function activate(context: vscode.ExtensionContext): void {
                 syncScroll(editor);
               }
             }
+          } else if (msg.type === "goto") {
+            gotoLocation(msg.line, msg.col);
           }
         });
         panel.onDidDispose(() => {
           panel = undefined;
           webviewReady = false;
           pendingHtml = undefined;
+          previewDocumentUri = undefined;
           clearTimeout(debounceTimer);
         });
       }
@@ -102,6 +106,7 @@ function scheduleUpdate(document: vscode.TextDocument): void {
 
 async function update(document: vscode.TextDocument): Promise<void> {
   if (!panel) return;
+  previewDocumentUri = document.uri;
   panel.title = `Preview: ${path.basename(document.fileName)}`;
   const literate =
     document.languageId === "literate haskell" || extname(document) === ".lhs";
@@ -134,6 +139,21 @@ function syncScroll(editor: vscode.TextEditor): void {
   panel.webview.postMessage({ type: "scroll", line: topLine });
 }
 
+async function gotoLocation(line: number, col: number): Promise<void> {
+  if (!previewDocumentUri) return;
+  const editor = vscode.window.visibleTextEditors.find(
+    (e) => e.document.uri.toString() === previewDocumentUri?.toString()
+  );
+  if (!editor) return;
+  const position = new vscode.Position(line - 1, col - 1);
+  editor.selection = new vscode.Selection(position, position);
+  editor.revealRange(
+    new vscode.Range(position, position),
+    vscode.TextEditorRevealType.InCenterIfOutsideViewport
+  );
+  await vscode.window.showTextDocument(editor.document, editor.viewColumn);
+}
+
 function getNonce(): string {
   return crypto.randomBytes(16).toString("hex");
 }
@@ -146,6 +166,7 @@ function wrapperHtml(): string {
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';">
+  <style>.item-location { cursor: pointer; } .item-location:hover { text-decoration: underline; }</style>
 </head>
 <body>
   <script nonce="${nonce}">
@@ -180,6 +201,22 @@ function wrapperHtml(): string {
         document.body.innerHTML = doc.body.innerHTML;
         document.documentElement.scrollTop = scrollTop;
       }
+
+      document.addEventListener('click', function(event) {
+        var target = event.target;
+        while (target && target !== document.body) {
+          if (target.classList && target.classList.contains('item-location')) {
+            var line = parseInt(target.getAttribute('data-line'), 10);
+            var col = parseInt(target.getAttribute('data-col'), 10);
+            if (line && col) {
+              event.preventDefault();
+              vscode.postMessage({ type: 'goto', line: line, col: col });
+            }
+            return;
+          }
+          target = target.parentElement;
+        }
+      });
 
       function scrollToLine(line) {
         var elements = document.querySelectorAll('[data-line]');

--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -658,7 +658,10 @@ locationElement :: Location.Location -> Element.Element
 locationElement (Location.MkLocation (Line.MkLine l) (Column.MkColumn c)) =
   Xml.element
     "span"
-    [Xml.attribute "class" "item-location"]
+    [ Xml.attribute "class" "item-location",
+      Xml.attribute "data-line" (show l),
+      Xml.attribute "data-col" (show c)
+    ]
     [ Xml.text
         ( Text.pack " (line "
             <> Text.pack (show l)

--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -654,19 +654,23 @@ lineAttribute :: Location.Location -> Attribute.Attribute
 lineAttribute loc =
   Xml.attribute "data-line" (show (Line.unwrap (Location.line loc)))
 
+columnAttribute :: Location.Location -> Attribute.Attribute
+columnAttribute loc =
+  Xml.attribute "data-col" (show (Column.unwrap (Location.column loc)))
+
 locationElement :: Location.Location -> Element.Element
-locationElement (Location.MkLocation (Line.MkLine l) (Column.MkColumn c)) =
+locationElement loc =
   Xml.element
     "span"
     [ Xml.attribute "class" "item-location",
-      Xml.attribute "data-line" (show l),
-      Xml.attribute "data-col" (show c)
+      lineAttribute loc,
+      columnAttribute loc
     ]
     [ Xml.text
         ( Text.pack " (line "
-            <> Text.pack (show l)
+            <> Text.pack (show (Line.unwrap (Location.line loc)))
             <> Text.pack ", col "
-            <> Text.pack (show c)
+            <> Text.pack (show (Column.unwrap (Location.column loc)))
             <> Text.pack ")"
         )
     ]


### PR DESCRIPTION
Fixes #55.

## Summary

- Added `data-line` and `data-col` attributes to location `<span>` elements in the HTML output (`ToHtml.hs`), so the line and column numbers are available as structured data
- Added a click event handler in the VSCode extension webview that detects clicks on `.item-location` elements and sends a `goto` message to the extension host
- Added a `gotoLocation` handler in the extension host that finds the previewed document's editor, moves the cursor to the target position, and focuses the editor
- Added cursor/underline hover styling for location elements in the webview

🤖 Generated with [Claude Code](https://claude.com/claude-code)