### PR TITLE
Show type in constructor signatures

### DIFF
--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -995,7 +995,13 @@ extractConDeclSignature mParentType conDecl = case conDecl of
                   else Outputable.empty
               cxtDoc = case mbCxt of
                 Nothing -> Outputable.empty
-                Just ctx -> Outputable.ppr ctx Outputable.<+> Outputable.text "=>"
+                Just ctx -> case SrcLoc.unLoc ctx of
+                  [] -> Outputable.empty
+                  [c] -> Outputable.ppr c Outputable.<+> Outputable.text "=>"
+                  cs ->
+                    Outputable.parens
+                      (Outputable.hsep (Outputable.punctuate (Outputable.text ",") (fmap Outputable.ppr cs)))
+                      Outputable.<+> Outputable.text "=>"
               argsDoc = h98ArgsToDoc (stripH98DetailsDocs args)
               bodyDoc = case argsDoc of
                 Nothing -> Outputable.text (Text.unpack parentType)
@@ -1033,7 +1039,7 @@ h98ArgsToDoc details = case details of
     Just $
       Outputable.text "{"
         Outputable.<+> Outputable.hsep
-          (List.intersperse (Outputable.text ",") (fmap Outputable.ppr (SrcLoc.unLoc lFields)))
+          (Outputable.punctuate (Outputable.text ",") (fmap Outputable.ppr (SrcLoc.unLoc lFields)))
         Outputable.<+> Outputable.text "}"
 
 -- | Strip documentation from H98 constructor details.

--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -1023,7 +1023,7 @@ h98ArgsToDoc details = case details of
     Just
       . Outputable.hsep
       . List.intersperse (Outputable.text "->")
-      $ fmap (\f -> Outputable.ppr (Syntax.cdf_type f)) fields
+      $ fmap (Outputable.ppr . Syntax.cdf_type) fields
   Syntax.InfixCon l r ->
     Just $
       Outputable.ppr (Syntax.cdf_type l)

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -917,7 +917,7 @@ spec s = Spec.describe s "integration" $ do
           ("/items/1/value/documentation/type", "\"Paragraph\""),
           ("/items/1/value/documentation/value/type", "\"String\""),
           ("/items/1/value/documentation/value/value", "\"x \""),
-          ("/items/1/value/signature", "\"J2\"")
+          ("/items/1/value/signature", "\"I2\"")
         ]
 
     Spec.it s "data constructor GADT" $ do
@@ -941,7 +941,7 @@ spec s = Spec.describe s "integration" $ do
           ("/items/1/value/documentation/type", "\"Paragraph\""),
           ("/items/1/value/documentation/value/type", "\"String\""),
           ("/items/1/value/documentation/value/value", "\"d\""),
-          ("/items/1/value/signature", "\"L2 :: K2\"")
+          ("/items/1/value/signature", "\"K2\"")
         ]
 
     Spec.it s "data constructor with arg doc" $ do
@@ -954,7 +954,7 @@ spec s = Spec.describe s "integration" $ do
             Bool
         """
         [ ("/items/1/value/name", "\"C2\""),
-          ("/items/1/value/signature", "\"C2 Int Bool\"")
+          ("/items/1/value/signature", "\"Int -> Bool -> T2\"")
         ]
 
     Spec.it s "data constructor GADT with arg doc" $ do
@@ -967,7 +967,7 @@ spec s = Spec.describe s "integration" $ do
             -> T3
         """
         [ ("/items/1/value/name", "\"C3\""),
-          ("/items/1/value/signature", "\"C3 :: Int -> T3\"")
+          ("/items/1/value/signature", "\"Int -> T3\"")
         ]
 
     Spec.it s "data constructor with record field doc" $ do
@@ -980,7 +980,7 @@ spec s = Spec.describe s "integration" $ do
           }
         """
         [ ("/items/1/value/name", "\"C4\""),
-          ("/items/1/value/signature", "\"C4 {f4 :: Int}\"")
+          ("/items/1/value/signature", "\"{ f4 :: Int } -> T4\"")
         ]
 
     Spec.it s "type data" $ do

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -983,6 +983,22 @@ spec s = Spec.describe s "integration" $ do
           ("/items/1/value/signature", "\"{ f4 :: Int } -> T4\"")
         ]
 
+    Spec.it s "data constructor with existential" $ do
+      check
+        s
+        "{-# language ExistentialQuantification #-} data T5 = forall a. C5 a"
+        [ ("/items/1/value/name", "\"C5\""),
+          ("/items/1/value/signature", "\"forall a. a -> T5\"")
+        ]
+
+    Spec.it s "data constructor with context" $ do
+      check
+        s
+        "{-# language ExistentialQuantification, FlexibleContexts #-} data T6 = forall a. Show a => C6 a"
+        [ ("/items/1/value/name", "\"C6\""),
+          ("/items/1/value/signature", "\"forall a. Show a => a -> T6\"")
+        ]
+
     Spec.it s "type data" $ do
       check s "{-# language TypeData #-} type data L" [("/items/0/value/kind", "\"TypeData\"")]
 


### PR DESCRIPTION
## Summary

Fixes #54.

- For H98-style constructors, the signature now shows the GADT-equivalent type rather than repeating the constructor declaration
  - `data T = C` → `C :: T` (was `C :: C`)
  - `data T = C Int Bool` → `C :: Int -> Bool -> T` (was `C :: C Int Bool`)
  - `newtype Name = MkName String` → `MkName :: String -> Name`
  - `data T = C { f :: Int }` → `C :: { f :: Int } -> T` (was `C :: C {f :: Int}`)
- For GADT-style constructors, the signature now stores only the type portion (no constructor name or `::`), fixing duplicate `name :: name :: type` rendering in HTML
- Handles existential quantification (`forall`) and contexts (`Show a =>`) on H98 constructors
- Falls back to old behavior when parent type info is unavailable (e.g., data family instances)

## Test plan

- [x] All 796 existing tests pass (5 test expectations updated to match new format)
- [x] Builds with `--flags=pedantic` (no warnings)
- [x] Verified JSON output for `data T=C` and `newtype Name = MkName String` matches issue examples
- [x] Verified HTML output renders `C :: T` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)