### PR TITLE
Don't HTML-escape CSS inside style elements

### DIFF
--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -101,7 +101,7 @@ headElement m =
       Content.Element $
         Xml.element "title" [] [Xml.text (moduleTitle m)],
       Content.Element $
-        Xml.element "style" [] [Xml.text . Builder.toText $ CssStylesheet.encode stylesheet]
+        Xml.element "style" [] [Xml.raw . Builder.toText $ CssStylesheet.encode stylesheet]
     ]
 
 bodyElement :: Module.Module -> Element.Element

--- a/source/library/Scrod/Xml/Document.hs
+++ b/source/library/Scrod/Xml/Document.hs
@@ -41,6 +41,9 @@ attribute name value =
       Attribute.value = Text.pack value
     }
 
+raw :: Text.Text -> Content.Content a
+raw = Content.Raw
+
 string :: String -> Content.Content a
 string = text . Text.pack
 
@@ -161,3 +164,13 @@ spec s = do
               (mkElement "root" [mkText "hello"])
         )
         "<root>hello</root>"
+
+    Spec.it s "encodes raw content without escaping" $ do
+      Spec.assertEq
+        s
+        ( Builder.toString . encode $
+            MkDocument
+              []
+              (mkElement "style" [Content.Raw $ Text.pack "a > b { color: red; }"])
+        )
+        "<style>a > b { color: red; }</style>"


### PR DESCRIPTION
Fixes #80.

## Summary

The `>` character in CSS selectors like `pre > code` was being HTML-entity-escaped to `&gt;` by the XML text encoder when generating `<style>` element content. Since browsers treat `<style>` content as raw text (not parsed HTML), the CSS parser received `pre &gt; code` as a literal string — an invalid selector that matched nothing.

This caused the `pre > code { padding: 0; }` rule to never apply. Instead, the generic `code { padding: 0.2em 0.4em; }` rule applied to `<code>` inside `<pre>`. Since `<code>` is `display: inline`, its left padding only affected the first line of multi-line code blocks, making it appear indented further than subsequent lines.

## Changes

- Added a `Raw` content variant to the XML library (`Scrod.Xml.Content`) that emits text without entity escaping
- Added a `raw` helper function to `Scrod.Xml.Document`
- Changed `ToHtml` to use `Xml.raw` instead of `Xml.text` for `<style>` element content
- Added tests for the new `Raw` content type

🤖 Generated with [Claude Code](https://claude.com/claude-code)