### PR TITLE
Add Splice item kind for TH splices and quasi-quotes

### DIFF
--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -552,6 +552,9 @@ convertDeclWithDocMaybeM doc lDecl = case SrcLoc.unLoc lDecl of
     let sig = Just $ extractKindSigSignature kindSig
      in Maybe.maybeToList <$> convertDeclWithDocM Nothing doc (Just $ extractStandaloneKindSigName kindSig) sig lDecl
   Syntax.InstD _ inst -> convertInstDeclWithDocM doc lDecl inst
+  Syntax.SpliceD _ spliceDecl ->
+    let sig = Just . Text.pack . Outputable.showSDocUnsafe . Outputable.ppr $ spliceDecl
+     in Maybe.maybeToList <$> convertDeclWithDocM Nothing doc Nothing sig lDecl
   _ -> Maybe.maybeToList <$> convertDeclWithDocM Nothing doc (extractDeclName lDecl) Nothing lDecl
 
 -- | Convert a type/class declaration with documentation.
@@ -694,7 +697,7 @@ itemKindFromDecl decl = case decl of
   Syntax.WarningD {} -> ItemKind.Function -- Treat as function for now
   Syntax.AnnD {} -> ItemKind.Annotation
   Syntax.RuleD {} -> ItemKind.Rule
-  Syntax.SpliceD {} -> ItemKind.Function -- TH splice
+  Syntax.SpliceD {} -> ItemKind.Splice
   Syntax.DocD {} -> ItemKind.Function -- Doc comment
   Syntax.RoleAnnotD {} -> ItemKind.Function -- Role annotation
   Syntax.DerivD {} -> ItemKind.StandaloneDeriving

--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -721,6 +721,7 @@ kindToText k = case k of
   ItemKind.Rule -> Text.pack "rule"
   ItemKind.Default -> Text.pack "default"
   ItemKind.Annotation -> Text.pack "annotation"
+  ItemKind.Splice -> Text.pack "splice"
 
 -- Doc to HTML conversion
 

--- a/source/library/Scrod/Convert/ToJson.hs
+++ b/source/library/Scrod/Convert/ToJson.hs
@@ -208,6 +208,7 @@ itemKindToJson k = Json.string $ case k of
   ItemKind.TypeData -> "TypeData"
   ItemKind.TypeFamilyInstance -> "TypeFamilyInstance"
   ItemKind.TypeSynonym -> "TypeSynonym"
+  ItemKind.Splice -> "Splice"
 
 itemNameToJson :: ItemName.ItemName -> Json.Value
 itemNameToJson = Json.text . ItemName.unwrap

--- a/source/library/Scrod/Core/ItemKind.hs
+++ b/source/library/Scrod/Core/ItemKind.hs
@@ -60,4 +60,6 @@ data ItemKind
     Default
   | -- | Annotation: @{-# ANN ... #-}@
     Annotation
+  | -- | Template Haskell splice or quasi-quote: @$(expr)@ or @[quoter|...|]@
+    Splice
   deriving (Eq, Ord, Show)

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -1543,7 +1543,21 @@ spec s = Spec.describe s "integration" $ do
         {-# language TemplateHaskell #-}
         $( return [] )
         """
-        []
+        [ ("/items/0/value/kind", "\"Splice\""),
+          ("/items/0/value/name", "null"),
+          ("/items/0/value/signature", "\"$(return [])\"")
+        ]
+
+    Spec.it s "quasi-quote declaration" $ do
+      check
+        s
+        """
+        {-# language QuasiQuotes #-}
+        [x||]
+        """
+        [ ("/items/0/value/kind", "\"Splice\""),
+          ("/items/0/value/name", "null")
+        ]
 
     Spec.it s "role annotation" $ do
       check

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -1548,6 +1548,18 @@ spec s = Spec.describe s "integration" $ do
           ("/items/0/value/signature", "\"$(return [])\"")
         ]
 
+    Spec.it s "typed splice declaration" $ do
+      check
+        s
+        """
+        {-# language TemplateHaskell #-}
+        $$(pure [])
+        """
+        [ ("/items/0/value/kind", "\"Splice\""),
+          ("/items/0/value/name", "null"),
+          ("/items/0/value/signature", "\"$$(pure [])\"")
+        ]
+
     Spec.it s "quasi-quote declaration" $ do
       check
         s
@@ -1556,7 +1568,8 @@ spec s = Spec.describe s "integration" $ do
         [x||]
         """
         [ ("/items/0/value/kind", "\"Splice\""),
-          ("/items/0/value/name", "null")
+          ("/items/0/value/name", "null"),
+          ("/items/0/value/signature", "\"[x||]\"")
         ]
 
     Spec.it s "role annotation" $ do


### PR DESCRIPTION
Fixes #78.

## Summary
- Adds a new `Splice` constructor to `ItemKind` for Template Haskell splices and quasi-quotes
- Maps `SpliceD` declarations to `ItemKind.Splice` instead of `ItemKind.Function`
- Extracts the ppr-rendered source of the splice as the item's signature (e.g. `$(return [])`)
- Adds HTML, JSON rendering for the new kind
- Updates integration tests and adds a quasi-quote test case

## Test plan
- [x] `cabal build` succeeds
- [x] `cabal build --flags=pedantic` succeeds (no warnings)
- [x] All 802 tests pass with `cabal test --test-options='--hide-successes'`