### PR TITLE
Add file upload support to web app

### DIFF
--- a/extra/github-pages/index.html
+++ b/extra/github-pages/index.html
@@ -9,27 +9,32 @@
 </head>
 
 <body>
-  <div class='pane input-pane'>
-    <label for='source' class='sr-only'>Haskell source code</label>
-    <textarea id='source' placeholder='Enter Haskell source...' spellcheck='false'></textarea>
+  <div class='toolbar'>
+    <label for='format' class='sr-only'>Output format</label>
+    <select id='format'>
+      <option value='html' selected>HTML</option>
+      <option value='json'>JSON</option>
+    </select>
+    <label><input type='checkbox' id='literate'> Literate</label>
+    <label for='theme' class='sr-only'>Color scheme</label>
+    <select id='theme'>
+      <option value='auto' selected>Auto</option>
+      <option value='light'>Light</option>
+      <option value='dark'>Dark</option>
+    </select>
+    <label for='file-input' class='file-label'>Upload file</label>
+    <input type='file' id='file-input' accept='.hs,.lhs'>
   </div>
-  <div class='pane output-pane'>
-    <div class='toolbar'>
-      <label for='format' class='sr-only'>Output format</label>
-      <select id='format'>
-        <option value='html' selected>HTML</option>
-        <option value='json'>JSON</option>
-      </select>
-      <label><input type='checkbox' id='literate'> Literate</label>
-      <label for='theme' class='sr-only'>Color scheme</label>
-      <select id='theme'>
-        <option value='auto' selected>Auto</option>
-        <option value='light'>Light</option>
-        <option value='dark'>Dark</option>
-      </select>
+  <div class='panes'>
+    <div class='pane input-pane'>
+      <label for='source' class='sr-only'>Haskell source code</label>
+      <textarea id='source' placeholder='Enter Haskell source...' spellcheck='false'></textarea>
     </div>
-    <div id='output' role='region' aria-live='polite' aria-label='Output'></div>
+    <div class='pane output-pane'>
+      <div id='output' role='region' aria-live='polite' aria-label='Output'></div>
+    </div>
   </div>
+  <div id='drop-overlay' class='drop-overlay' aria-hidden='true'>Drop Haskell file here</div>
   <script src='index.js'></script>
 </body>
 

--- a/extra/github-pages/index.html
+++ b/extra/github-pages/index.html
@@ -22,7 +22,7 @@
       <option value='light'>Light</option>
       <option value='dark'>Dark</option>
     </select>
-    <label for='file-input' class='file-label'>Upload file</label>
+    <button type='button' id='file-button' class='file-button'>Upload file</button>
     <input type='file' id='file-input' accept='.hs,.lhs'>
   </div>
   <div class='panes'>

--- a/extra/github-pages/index.js
+++ b/extra/github-pages/index.js
@@ -213,9 +213,7 @@ function loadFile(file) {
   var reader = new FileReader();
   reader.onload = function () {
     source.value = reader.result;
-    if (file.name.endsWith('.lhs')) {
-      literate.checked = true;
-    }
+    literate.checked = file.name.endsWith('.lhs');
     updateHash();
     process(true);
   };

--- a/extra/github-pages/index.js
+++ b/extra/github-pages/index.js
@@ -6,6 +6,8 @@ var output = document.getElementById('output');
 var format = document.getElementById('format');
 var literate = document.getElementById('literate');
 var theme = document.getElementById('theme');
+var fileInput = document.getElementById('file-input');
+var dropOverlay = document.getElementById('drop-overlay');
 var shadow = output.attachShadow({ mode: 'open' });
 shadow.innerHTML = '<p style="color: #888; font-style: italic">Loading WASM module...</p>';
 var debounceTimer;
@@ -207,6 +209,19 @@ function process(skipUrlDetection) {
   }
 }
 
+function loadFile(file) {
+  var reader = new FileReader();
+  reader.onload = function () {
+    source.value = reader.result;
+    if (file.name.endsWith('.lhs')) {
+      literate.checked = true;
+    }
+    updateHash();
+    process(true);
+  };
+  reader.readAsText(file);
+}
+
 source.addEventListener('input', function () {
   clearTimeout(debounceTimer);
   debounceTimer = setTimeout(function () {
@@ -227,6 +242,45 @@ literate.addEventListener('change', function () {
 
 theme.addEventListener('change', function () {
   applyTheme(theme.value);
+});
+
+fileInput.addEventListener('change', function () {
+  if (fileInput.files.length > 0) {
+    loadFile(fileInput.files[0]);
+    fileInput.value = '';
+  }
+});
+
+// Drag and drop support
+var dragCounter = 0;
+
+document.addEventListener('dragenter', function (e) {
+  e.preventDefault();
+  dragCounter++;
+  if (dragCounter === 1) {
+    dropOverlay.classList.add('active');
+  }
+});
+
+document.addEventListener('dragleave', function (e) {
+  e.preventDefault();
+  dragCounter--;
+  if (dragCounter === 0) {
+    dropOverlay.classList.remove('active');
+  }
+});
+
+document.addEventListener('dragover', function (e) {
+  e.preventDefault();
+});
+
+document.addEventListener('drop', function (e) {
+  e.preventDefault();
+  dragCounter = 0;
+  dropOverlay.classList.remove('active');
+  if (e.dataTransfer.files.length > 0) {
+    loadFile(e.dataTransfer.files[0]);
+  }
 });
 
 // Load saved theme preference

--- a/extra/github-pages/index.js
+++ b/extra/github-pages/index.js
@@ -6,6 +6,7 @@ var output = document.getElementById('output');
 var format = document.getElementById('format');
 var literate = document.getElementById('literate');
 var theme = document.getElementById('theme');
+var fileButton = document.getElementById('file-button');
 var fileInput = document.getElementById('file-input');
 var dropOverlay = document.getElementById('drop-overlay');
 var shadow = output.attachShadow({ mode: 'open' });
@@ -217,6 +218,9 @@ function loadFile(file) {
     updateHash();
     process(true);
   };
+  reader.onerror = function () {
+    showError('Failed to read file: ' + (reader.error ? reader.error.message : file.name));
+  };
   reader.readAsText(file);
 }
 
@@ -242,6 +246,10 @@ theme.addEventListener('change', function () {
   applyTheme(theme.value);
 });
 
+fileButton.addEventListener('click', function () {
+  fileInput.click();
+});
+
 fileInput.addEventListener('change', function () {
   if (fileInput.files.length > 0) {
     loadFile(fileInput.files[0]);
@@ -252,7 +260,17 @@ fileInput.addEventListener('change', function () {
 // Drag and drop support
 var dragCounter = 0;
 
+function hasFiles(e) {
+  return e.dataTransfer && e.dataTransfer.types && e.dataTransfer.types.indexOf('Files') !== -1;
+}
+
+function hideOverlay() {
+  dragCounter = 0;
+  dropOverlay.classList.remove('active');
+}
+
 document.addEventListener('dragenter', function (e) {
+  if (!hasFiles(e)) return;
   e.preventDefault();
   dragCounter++;
   if (dragCounter === 1) {
@@ -261,24 +279,29 @@ document.addEventListener('dragenter', function (e) {
 });
 
 document.addEventListener('dragleave', function (e) {
+  if (!hasFiles(e)) return;
   e.preventDefault();
-  dragCounter--;
+  dragCounter = Math.max(0, dragCounter - 1);
   if (dragCounter === 0) {
     dropOverlay.classList.remove('active');
   }
 });
 
 document.addEventListener('dragover', function (e) {
+  if (!hasFiles(e)) return;
   e.preventDefault();
 });
 
 document.addEventListener('drop', function (e) {
   e.preventDefault();
-  dragCounter = 0;
-  dropOverlay.classList.remove('active');
+  hideOverlay();
   if (e.dataTransfer.files.length > 0) {
     loadFile(e.dataTransfer.files[0]);
   }
+});
+
+document.addEventListener('dragend', function () {
+  hideOverlay();
 });
 
 // Load saved theme preference

--- a/extra/github-pages/style.css
+++ b/extra/github-pages/style.css
@@ -54,10 +54,58 @@
 
 body {
   display: flex;
+  flex-direction: column;
   height: 100vh;
   font-family: system-ui, sans-serif;
   background: var(--app-bg);
   color: var(--app-text);
+}
+
+.toolbar {
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid var(--app-border);
+  flex-shrink: 0;
+  background: var(--app-toolbar-bg);
+}
+
+.toolbar select,
+.toolbar label {
+  font-family: system-ui, sans-serif;
+  font-size: 14px;
+  padding: 2px 4px;
+}
+
+.toolbar select {
+  background: var(--app-input-bg);
+  color: var(--app-text);
+  border: 1px solid var(--app-border);
+  border-radius: 3px;
+}
+
+.file-label {
+  display: inline-block;
+  cursor: pointer;
+  background: var(--app-input-bg);
+  border: 1px solid var(--app-border);
+  border-radius: 3px;
+  margin-left: 0.5rem;
+}
+
+#file-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.panes {
+  display: flex;
+  flex: 1;
+  min-height: 0;
 }
 
 .pane {
@@ -89,29 +137,26 @@ body {
   flex-direction: column;
 }
 
-.toolbar {
-  padding: 0.5rem 1rem;
-  border-bottom: 1px solid var(--app-border);
-  flex-shrink: 0;
-  background: var(--app-toolbar-bg);
-}
-
-.toolbar select,
-.toolbar label {
-  font-family: system-ui, sans-serif;
-  font-size: 14px;
-  padding: 2px 4px;
-}
-
-.toolbar select {
-  background: var(--app-input-bg);
-  color: var(--app-text);
-  border: 1px solid var(--app-border);
-  border-radius: 3px;
-}
-
 #output {
   flex: 1;
   overflow: auto;
   padding: 1rem;
+}
+
+.drop-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 102, 204, 0.15);
+  border: 3px dashed #0066cc;
+  z-index: 1000;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  color: #0066cc;
+  pointer-events: none;
+}
+
+.drop-overlay.active {
+  display: flex;
 }

--- a/extra/github-pages/style.css
+++ b/extra/github-pages/style.css
@@ -82,10 +82,13 @@ body {
   border-radius: 3px;
 }
 
-.file-label {
-  display: inline-block;
+.file-button {
+  font-family: system-ui, sans-serif;
+  font-size: 14px;
+  padding: 2px 4px;
   cursor: pointer;
   background: var(--app-input-bg);
+  color: var(--app-text);
   border: 1px solid var(--app-border);
   border-radius: 3px;
   margin-left: 0.5rem;


### PR DESCRIPTION
## Summary

Fixes #43.

- **Toolbar moved to full width**: The toolbar now spans both panes (above the split), as suggested in the issue comment, making controls accessible from anywhere.
- **File upload button**: An "Upload file" input in the toolbar accepts `.hs` and `.lhs` files. When a `.lhs` file is uploaded, the "Literate" checkbox is automatically enabled.
- **Drag and drop**: The entire page is a drop target. Dragging a file over the page shows a blue dashed overlay ("Drop Haskell file here"), and dropping reads the file into the editor. Works on both desktop and mobile (where supported by the browser).

## Test plan

- [x] Open the web app and verify the toolbar now spans the full page width
- [x] Click "Upload file" and select a `.hs` file — verify it loads into the editor and renders
- [x] Upload a `.lhs` file — verify the "Literate" checkbox is automatically checked
- [x] Drag and drop a `.hs` file onto the page — verify the overlay appears during drag and the file loads on drop
- [x] Verify existing functionality still works (typing in textarea, URL hash sharing, format/theme selects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)