### PR TITLE
Handle signatures (Backpack)

### DIFF
--- a/extra/github-pages/index.html
+++ b/extra/github-pages/index.html
@@ -16,6 +16,7 @@
       <option value='json'>JSON</option>
     </select>
     <label><input type='checkbox' id='literate'> Literate</label>
+    <label><input type='checkbox' id='signature'> Signature</label>
     <label for='theme' class='sr-only'>Color scheme</label>
     <select id='theme'>
       <option value='auto' selected>Auto</option>
@@ -23,7 +24,7 @@
       <option value='dark'>Dark</option>
     </select>
     <button type='button' id='file-button' class='file-button'>Upload file</button>
-    <input type='file' id='file-input' accept='.hs,.lhs'>
+    <input type='file' id='file-input' accept='.hs,.lhs,.hsig,.lhsig'>
   </div>
   <div class='panes'>
     <div class='pane input-pane'>

--- a/extra/github-pages/index.js
+++ b/extra/github-pages/index.js
@@ -5,6 +5,7 @@ var source = document.getElementById('source');
 var output = document.getElementById('output');
 var format = document.getElementById('format');
 var literate = document.getElementById('literate');
+var signature = document.getElementById('signature');
 var theme = document.getElementById('theme');
 var fileButton = document.getElementById('file-button');
 var fileInput = document.getElementById('file-input');
@@ -158,6 +159,9 @@ function updateHash() {
     if (literate.checked) {
       params.set('literate', 'true');
     }
+    if (signature.checked) {
+      params.set('signature', 'true');
+    }
     params.set('input', encodeHash(source.value));
     history.replaceState(null, '', '#' + params.toString());
   } else {
@@ -206,7 +210,7 @@ function process(skipUrlDetection) {
       fetchUrl(trimmed);
       return;
     }
-    worker.postMessage({ source: source.value, format: format.value, literate: literate.checked });
+    worker.postMessage({ source: source.value, format: format.value, literate: literate.checked, signature: signature.checked });
   }
 }
 
@@ -214,7 +218,8 @@ function loadFile(file) {
   var reader = new FileReader();
   reader.onload = function () {
     source.value = reader.result;
-    literate.checked = file.name.endsWith('.lhs');
+    literate.checked = file.name.endsWith('.lhs') || file.name.endsWith('.lhsig');
+    signature.checked = file.name.endsWith('.hsig') || file.name.endsWith('.lhsig');
     updateHash();
     process(true);
   };
@@ -238,6 +243,11 @@ format.addEventListener('change', function () {
 });
 
 literate.addEventListener('change', function () {
+  updateHash();
+  process();
+});
+
+signature.addEventListener('change', function () {
   updateHash();
   process();
 });
@@ -326,6 +336,9 @@ if (location.hash.length > 1) {
       }
       if (params.get('literate') === 'true') {
         literate.checked = true;
+      }
+      if (params.get('signature') === 'true') {
+        signature.checked = true;
       }
     } else {
       // Legacy format: bare base64-encoded source

--- a/extra/github-pages/worker.js
+++ b/extra/github-pages/worker.js
@@ -55,6 +55,7 @@ onmessage = async function (e) {
       const msg = e.data;
       const args = ['--format', msg.format];
       if (msg.literate) args.push('--literate');
+      if (msg.signature) args.push('--signature');
       const result = await scrod(args, msg.source);
       postMessage({ tag: 'result', value: result, format: msg.format });
     } catch (err) {

--- a/extra/vscode/package.json
+++ b/extra/vscode/package.json
@@ -24,11 +24,11 @@
     "languages": [
       {
         "id": "haskell",
-        "extensions": [".hs"]
+        "extensions": [".hs", ".hsig"]
       },
       {
         "id": "literate haskell",
-        "extensions": [".lhs"]
+        "extensions": [".lhs", ".lhsig"]
       }
     ],
     "commands": [
@@ -42,7 +42,7 @@
       "editor/title": [
         {
           "command": "scrod.openPreview",
-          "when": "editorLangId == haskell || editorLangId == 'literate haskell' || resourceExtname == .hs || resourceExtname == .lhs",
+          "when": "editorLangId == haskell || editorLangId == 'literate haskell' || resourceExtname == .hs || resourceExtname == .lhs || resourceExtname == .hsig || resourceExtname == .lhsig",
           "group": "navigation"
         }
       ]

--- a/extra/vscode/src/wasmEngine.ts
+++ b/extra/vscode/src/wasmEngine.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { pathToFileURL } from "url";
 
-type Process = (source: string, literate: boolean) => Promise<string>;
+type Process = (source: string, literate: boolean, signature: boolean) => Promise<string>;
 
 export async function loadWasmEngine(extensionPath: string): Promise<Process> {
   const wasmDir = path.join(extensionPath, "wasm");
@@ -52,9 +52,10 @@ export async function loadWasmEngine(extensionPath: string): Promise<Process> {
     source: string
   ) => Promise<string>;
 
-  return async (source, literate) => {
+  return async (source, literate, signature) => {
     const args = ["--format", "html"];
     if (literate) args.push("--literate");
+    if (signature) args.push("--signature");
     return scrod(args, source);
   };
 }

--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -87,11 +87,12 @@ runConvert = flip State.evalState initialState
 
 -- | Convert a parsed GHC module to the internal 'Module' type.
 fromGhc ::
+  Bool ->
   ( (Maybe Session.Language, [DynFlags.OnOff GhcExtension.Extension]),
     SrcLoc.Located (Hs.HsModule Ghc.GhcPs)
   ) ->
   Either String Module.Module
-fromGhc ((language, extensions), lHsModule) = do
+fromGhc isSignature ((language, extensions), lHsModule) = do
   version <- maybe (Left "invalid version") Right $ versionFromBase PackageInfo.version
   let (moduleDocumentation, moduleSince) = extractModuleDocAndSince lHsModule
   Right
@@ -105,6 +106,7 @@ fromGhc ((language, extensions), lHsModule) = do
         Module.warning = extractModuleWarning lHsModule,
         Module.exports = extractModuleExports lHsModule,
         Module.imports = extractModuleImports lHsModule,
+        Module.signature = isSignature,
         Module.items = extractItems lHsModule
       }
 

--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -102,11 +102,11 @@ fromGhc isSignature ((language, extensions), lHsModule) = do
         Module.extensions = extensionsToMap extensions,
         Module.documentation = moduleDocumentation,
         Module.since = moduleSince,
+        Module.signature = isSignature,
         Module.name = extractModuleName lHsModule,
         Module.warning = extractModuleWarning lHsModule,
         Module.exports = extractModuleExports lHsModule,
         Module.imports = extractModuleImports lHsModule,
-        Module.signature = isSignature,
         Module.items = extractItems lHsModule
       }
 

--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -124,7 +124,10 @@ headerSection :: Module.Module -> Element.Element
 headerSection m =
   Xml.element
     "header"
-    ( [Xml.attribute "class" (if Module.signature m then "signature-header" else "module-header")]
+    ( [ Xml.attribute
+          "class"
+          (if Module.signature m then "module-header signature-header" else "module-header")
+      ]
         <> foldMap (\(Located.MkLocated loc _) -> [lineAttribute loc]) (Module.name m)
     )
     ( [Content.Element $ Xml.element "h1" [] [Xml.text (moduleTitle m)]]
@@ -972,7 +975,7 @@ stylesheet =
       rule ["a"] [("color", "var(--scrod-accent)"), ("text-decoration", "none")],
       rule ["a:hover"] [("text-decoration", "underline")],
       rule ["img"] [("max-width", "100%"), ("height", "auto")],
-      rule [".module-header", ".signature-header"] [("margin-bottom", "2rem")],
+      rule [".module-header"] [("margin-bottom", "2rem")],
       rule [".module-doc"] [("margin", "1rem 0")],
       rule [".metadata"] [("background", "var(--scrod-metadata-bg)"), ("border-left", "4px solid var(--scrod-accent)"), ("padding", "1rem"), ("margin", "1rem 0")],
       rule [".metadata > dt"] [("display", "inline")],

--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -124,7 +124,7 @@ headerSection :: Module.Module -> Element.Element
 headerSection m =
   Xml.element
     "header"
-    ( [Xml.attribute "class" "module-header"]
+    ( [Xml.attribute "class" (if Module.signature m then "signature-header" else "module-header")]
         <> foldMap (\(Located.MkLocated loc _) -> [lineAttribute loc]) (Module.name m)
     )
     ( [Content.Element $ Xml.element "h1" [] [Xml.text (moduleTitle m)]]
@@ -972,7 +972,7 @@ stylesheet =
       rule ["a"] [("color", "var(--scrod-accent)"), ("text-decoration", "none")],
       rule ["a:hover"] [("text-decoration", "underline")],
       rule ["img"] [("max-width", "100%"), ("height", "auto")],
-      rule [".module-header"] [("margin-bottom", "2rem")],
+      rule [".module-header", ".signature-header"] [("margin-bottom", "2rem")],
       rule [".module-doc"] [("margin", "1rem 0")],
       rule [".metadata"] [("background", "var(--scrod-metadata-bg)"), ("border-left", "4px solid var(--scrod-accent)"), ("padding", "1rem"), ("margin", "1rem 0")],
       rule [".metadata > dt"] [("display", "inline")],

--- a/source/library/Scrod/Convert/ToJson.hs
+++ b/source/library/Scrod/Convert/ToJson.hs
@@ -52,11 +52,11 @@ moduleToJson m =
       ("extensions", extensionsToJson $ Module.extensions m),
       ("documentation", docToJson $ Module.documentation m),
       ("since", Json.optional sinceToJson $ Module.since m),
+      ("signature", Json.boolean $ Module.signature m),
       ("name", Json.optional (locatedToJson moduleNameToJson) $ Module.name m),
       ("warning", Json.optional warningToJson $ Module.warning m),
       ("exports", Json.optional (Json.arrayOf exportToJson) $ Module.exports m),
       ("imports", Json.arrayOf importToJson $ Module.imports m),
-      ("signature", Json.boolean $ Module.signature m),
       ("items", Json.arrayOf (locatedToJson itemToJson) $ Module.items m)
     ]
 

--- a/source/library/Scrod/Convert/ToJson.hs
+++ b/source/library/Scrod/Convert/ToJson.hs
@@ -56,6 +56,7 @@ moduleToJson m =
       ("warning", Json.optional warningToJson $ Module.warning m),
       ("exports", Json.optional (Json.arrayOf exportToJson) $ Module.exports m),
       ("imports", Json.arrayOf importToJson $ Module.imports m),
+      ("signature", Json.boolean $ Module.signature m),
       ("items", Json.arrayOf (locatedToJson itemToJson) $ Module.items m)
     ]
 

--- a/source/library/Scrod/Core/Module.hs
+++ b/source/library/Scrod/Core/Module.hs
@@ -23,6 +23,7 @@ data Module = MkModule
     warning :: Maybe Warning.Warning,
     exports :: Maybe [Export.Export],
     imports :: [Import.Import],
+    signature :: Bool,
     items :: [Located.Located Item.Item]
   }
   deriving (Eq, Ord, Show)

--- a/source/library/Scrod/Core/Module.hs
+++ b/source/library/Scrod/Core/Module.hs
@@ -19,11 +19,11 @@ data Module = MkModule
     extensions :: Map.Map Extension.Extension Bool,
     documentation :: Doc.Doc,
     since :: Maybe Since.Since,
+    signature :: Bool,
     name :: Maybe (Located.Located ModuleName.ModuleName),
     warning :: Maybe Warning.Warning,
     exports :: Maybe [Export.Export],
     imports :: [Import.Import],
-    signature :: Bool,
     items :: [Located.Located Item.Item]
   }
   deriving (Eq, Ord, Show)

--- a/source/library/Scrod/Executable/Config.hs
+++ b/source/library/Scrod/Executable/Config.hs
@@ -14,6 +14,7 @@ data Config = MkConfig
   { format :: Format.Format,
     help :: Bool,
     literate :: Bool,
+    signature :: Bool,
     version :: Bool
   }
   deriving (Eq, Ord, Show)
@@ -36,6 +37,11 @@ applyFlag config flag = case flag of
     Just string -> do
       bool <- Read.readM string
       pure config {literate = bool}
+  Flag.Signature maybeString -> case maybeString of
+    Nothing -> pure config {signature = True}
+    Just string -> do
+      bool <- Read.readM string
+      pure config {signature = bool}
   Flag.Version maybeString -> case maybeString of
     Nothing -> pure config {version = True}
     Just string -> do
@@ -48,6 +54,7 @@ initial =
     { format = Format.Json,
       help = False,
       literate = False,
+      signature = False,
       version = False
     }
 
@@ -82,6 +89,19 @@ spec s = do
 
       Spec.it s "fails with just invalid" $ do
         Spec.assertEq s (fromFlags [Flag.Literate $ Just "invalid"]) Nothing
+
+    Spec.describe s "signature" $ do
+      Spec.it s "works with nothing" $ do
+        Spec.assertEq s (fromFlags [Flag.Signature Nothing]) $ Just initial {signature = True}
+
+      Spec.it s "works with just false" $ do
+        Spec.assertEq s (fromFlags [Flag.Signature $ Just "False"]) $ Just initial
+
+      Spec.it s "works with just true" $ do
+        Spec.assertEq s (fromFlags [Flag.Signature $ Just "True"]) $ Just initial {signature = True}
+
+      Spec.it s "fails with just invalid" $ do
+        Spec.assertEq s (fromFlags [Flag.Signature $ Just "invalid"]) Nothing
 
     Spec.describe s "help" $ do
       Spec.it s "works with nothing" $ do

--- a/source/library/Scrod/Executable/Flag.hs
+++ b/source/library/Scrod/Executable/Flag.hs
@@ -11,6 +11,7 @@ data Flag
   = Format String
   | Help (Maybe String)
   | Literate (Maybe String)
+  | Signature (Maybe String)
   | Version (Maybe String)
   deriving (Eq, Ord, Show)
 
@@ -27,7 +28,8 @@ optDescrs =
   [ GetOpt.Option ['h'] ["help"] (GetOpt.OptArg Help "BOOL") "Shows the help.",
     GetOpt.Option [] ["version"] (GetOpt.OptArg Version "BOOL") "Shows the version.",
     GetOpt.Option [] ["format"] (GetOpt.ReqArg Format "FORMAT") "Sets the output format (json or html).",
-    GetOpt.Option [] ["literate"] (GetOpt.OptArg Literate "BOOL") "Treats the input as Literate Haskell."
+    GetOpt.Option [] ["literate"] (GetOpt.OptArg Literate "BOOL") "Treats the input as Literate Haskell.",
+    GetOpt.Option [] ["signature"] (GetOpt.OptArg Signature "BOOL") "Treats the input as a Backpack signature."
   ]
 
 spec :: (Applicative m, Monad n) => Spec.Spec m n -> n ()
@@ -65,6 +67,13 @@ spec s = do
 
       Spec.it s "works with an argument" $ do
         Spec.assertEq s (fromArguments ["--literate="]) $ Just [Literate $ Just ""]
+
+    Spec.describe s "signature" $ do
+      Spec.it s "works with no argument" $ do
+        Spec.assertEq s (fromArguments ["--signature"]) $ Just [Signature Nothing]
+
+      Spec.it s "works with an argument" $ do
+        Spec.assertEq s (fromArguments ["--signature="]) $ Just [Signature $ Just ""]
 
     Spec.describe s "version" $ do
       Spec.it s "works with no argument" $ do

--- a/source/library/Scrod/Executable/Main.hs
+++ b/source/library/Scrod/Executable/Main.hs
@@ -51,8 +51,9 @@ mainWith name arguments myGetContents = ExceptT.runExceptT $ do
     if Config.literate config
       then Either.throw . Bifunctor.first userError $ Unlit.unlit contents
       else pure contents
-  result <- Either.throw . Bifunctor.first userError $ Parse.parse source
-  module_ <- Either.throw . Bifunctor.first userError $ FromGhc.fromGhc result
+  let isSignature = Config.signature config
+  result <- Either.throw . Bifunctor.first userError $ Parse.parse isSignature source
+  module_ <- Either.throw . Bifunctor.first userError $ FromGhc.fromGhc isSignature result
   let convert = case Config.format config of
         Format.Json -> Json.encode . ToJson.toJson
         Format.Html -> Xml.encode . ToHtml.toHtml


### PR DESCRIPTION
## Summary

Closes #31.

- Adds a `--signature` CLI flag (mirroring `--literate`) that switches the GHC parser from `parseModule` to `parseSignature`, enabling support for Backpack signature files (`.hsig` / `.lhsig`)
- Threads the signature flag through the full pipeline: CLI → parser → conversion → core types → JSON/HTML rendering
- Adds a "Signature" checkbox to the web app with auto-detection for `.hsig`/`.lhsig` file extensions
- Updates the VSCode extension to recognize `.hsig`/`.lhsig` files and pass the signature flag to the WASM engine

## Details

Both `parseModule` and `parseSignature` return the same `HsModule GhcPs` type, so the existing conversion pipeline works as-is — no new item kinds or conversion functions needed. The only change is selecting the right parser and recording a `signature :: Bool` field on `Module`.

**Files changed:**
- `Flag.hs`, `Config.hs` — new `--signature` CLI flag
- `Core/Module.hs` — `signature :: Bool` field
- `Ghc/Parse.hs` — branch between `parseSignature` / `parseModule`
- `Convert/FromGhc.hs` — thread `isSignature` through
- `Executable/Main.hs` — wire flag through pipeline
- `Convert/ToJson.hs` — `"signature"` key in JSON output
- `Convert/ToHtml.hs` — conditional CSS class on header
- `TestSuite/Integration.hs` — 5 new signature integration tests
- `extra/github-pages/` — checkbox, auto-detect, hash persistence
- `extra/vscode/` — file extension support, signature detection

## Test plan

- [x] `cabal build --flags=pedantic` passes
- [x] All 820 tests pass (`cabal test --test-options='--hide-successes'`)
- [x] `hlint source/` clean
- [x] `ormolu --mode check` clean
- [x] End-to-end: `echo 'signature Foo where' | cabal run scrod -- --format json --signature` outputs correct JSON with `"signature": true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)