### PR TITLE
Update placeholder to indicate URL inputs are allowed

### DIFF
--- a/extra/github-pages/index.html
+++ b/extra/github-pages/index.html
@@ -29,7 +29,7 @@
   <div class='panes'>
     <div class='pane input-pane'>
       <label for='source' class='sr-only'>Haskell source code</label>
-      <textarea id='source' placeholder='Enter Haskell source...' spellcheck='false'></textarea>
+      <textarea id='source' placeholder='Enter Haskell source or a URL...' spellcheck='false'></textarea>
     </div>
     <div class='pane output-pane'>
       <div id='output' role='region' aria-live='polite' aria-label='Output'></div>

--- a/extra/github-pages/index.html
+++ b/extra/github-pages/index.html
@@ -28,7 +28,7 @@
   </div>
   <div class='panes'>
     <div class='pane input-pane'>
-      <label for='source' class='sr-only'>Haskell source code</label>
+      <label for='source' class='sr-only'>Haskell source code or URL</label>
       <textarea id='source' placeholder='Enter Haskell source or a URL...' spellcheck='false'></textarea>
     </div>
     <div class='pane output-pane'>


### PR DESCRIPTION
Fixes #91.

## Summary

Updates the web app textarea placeholder from "Enter Haskell source..." to "Enter Haskell source or a URL..." so users know they can paste a URL to fetch remote Haskell source code.

## Test plan

- [ ] Open the web app and verify the placeholder text reads "Enter Haskell source or a URL..."
- [ ] Confirm pasting a URL still fetches and displays the source
- [ ] Confirm typing Haskell source directly still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)