### PR TITLE
Strip module qualifiers from identifiers in documentation

### DIFF
--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -129,6 +129,19 @@ spec s = Spec.describe s "integration" $ do
           ("/documentation/value/value/value", "\"x\"")
         ]
 
+    Spec.it s "strips module qualifier from identifier" $ do
+      check
+        s
+        """
+        -- | 'A.b'
+        module M where
+        """
+        [ ("/documentation/type", "\"Paragraph\""),
+          ("/documentation/value/type", "\"Identifier\""),
+          ("/documentation/value/value/namespace", "null"),
+          ("/documentation/value/value/value", "\"b\"")
+        ]
+
     Spec.it s "works with a value identifier" $ do
       check
         s


### PR DESCRIPTION
Fixes #90.

## Summary
- Strips module qualifiers from identifiers during Haddock-to-Scrod conversion (e.g., `'A.b'` renders as `b`, `'Data.List.map'` renders as `map`)
- Adds `stripQualifier` helper in `FromHaddock` that extracts the part after the last `.`
- Adds unit tests for qualified and deeply-qualified identifiers
- Adds integration test for qualified identifier rendering

## Test plan
- [x] `cabal build` succeeds
- [x] All 835 tests pass (`cabal test --test-options='--hide-successes'`)
- [x] Ormolu formatting check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)