### PR TITLE
Include aliased type in type synonym signature

### DIFF
--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -656,6 +656,7 @@ itemToHtml (Located.MkLocated loc (Item.MkItem key itemKind _parentKey maybeName
       ItemKind.DataType -> True
       ItemKind.Newtype -> True
       ItemKind.TypeData -> True
+      ItemKind.TypeSynonym -> True
       ItemKind.Class -> True
       _ -> False
 

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -945,7 +945,20 @@ spec s = Spec.describe s "integration" $ do
       check s "{-# language TypeFamilies #-} data family F" [("/items/0/value/kind", "\"DataFamily\"")]
 
     Spec.it s "type synonym" $ do
-      check s "type G = ()" [("/items/0/value/kind", "\"TypeSynonym\"")]
+      check
+        s
+        "type G = ()"
+        [ ("/items/0/value/kind", "\"TypeSynonym\""),
+          ("/items/0/value/signature", "\"= ()\"")
+        ]
+
+    Spec.it s "type synonym with type variable" $ do
+      check
+        s
+        "type G a = [a]"
+        [ ("/items/0/value/kind", "\"TypeSynonym\""),
+          ("/items/0/value/signature", "\"a = [a]\"")
+        ]
 
     Spec.it s "data" $ do
       check s "data H" [("/items/0/value/kind", "\"DataType\"")]


### PR DESCRIPTION
Fixes #89.

## Summary

- Extract the right-hand side (aliased type) from type synonym declarations and include it in the item's signature field
- For `type T = ()`, the signature is `= ()`; for `type T a = [a]`, it's `a = [a]`
- Render the signature before the kind badge in HTML (consistent with data types and classes)
- Add integration tests for type synonyms with and without type variables

## Test plan

- [x] `cabal build` passes
- [x] All 833 tests pass (`cabal test --test-options='--hide-successes'`)
- [x] Verified JSON output: `echo 'type T = ()' | cabal run scrod -- --format json` shows `"signature":"= ()"`
- [x] Verified HTML output renders as `T = () [type]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)