### PR TITLE
Sync Bootstrap dark mode with VSCode theme in webview

### DIFF
--- a/extra/vscode/src/extension.ts
+++ b/extra/vscode/src/extension.ts
@@ -218,6 +218,8 @@ function wrapperHtml(): string {
         document.documentElement.setAttribute('data-bs-theme', isDark ? 'dark' : 'light');
       }
 
+      syncTheme();
+
       new MutationObserver(function() { syncTheme(); })
         .observe(document.body, { attributes: true, attributeFilter: ['class'] });
 

--- a/extra/vscode/src/extension.ts
+++ b/extra/vscode/src/extension.ts
@@ -209,7 +209,17 @@ function wrapperHtml(): string {
         var scrollTop = document.documentElement.scrollTop;
         document.body.innerHTML = doc.body.innerHTML;
         document.documentElement.scrollTop = scrollTop;
+        syncTheme();
       }
+
+      function syncTheme() {
+        var isDark = document.body.classList.contains('vscode-dark')
+          || document.body.classList.contains('vscode-high-contrast');
+        document.documentElement.setAttribute('data-bs-theme', isDark ? 'dark' : 'light');
+      }
+
+      new MutationObserver(function() { syncTheme(); })
+        .observe(document.body, { attributes: true, attributeFilter: ['class'] });
 
       document.addEventListener('click', function(event) {
         var target = event.target;


### PR DESCRIPTION
Fixes #97.

## Summary

- After #94 switched to Bootstrap 5.3.8, the generated HTML includes a `<script>` that detects `prefers-color-scheme` and sets `data-bs-theme` on the document root. However, the VSCode extension's `applyUpdate()` uses `DOMParser.parseFromString()` to inject HTML, which does not execute scripts — so the Bootstrap dark mode attribute was never set in the webview.
- Added a `syncTheme()` function that reads the VSCode theme from body classes (`vscode-dark`, `vscode-high-contrast`) and sets `data-bs-theme` accordingly on `<html>`.
- A `MutationObserver` watches for class changes on `<body>` so switching themes in VSCode is reflected immediately.

## Test plan

- [ ] Open the Scrod preview panel in a dark VSCode theme — documentation should render with Bootstrap dark mode colors
- [ ] Switch between light and dark VSCode themes — the preview should update automatically
- [ ] High-contrast themes should also trigger dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)