### PR TITLE
Show helpful CORS error message when URL fetch fails

### DIFF
--- a/extra/github-pages/index.js
+++ b/extra/github-pages/index.js
@@ -170,7 +170,7 @@ function fetchUrl(url) {
   }).catch(function (err) {
     if (err.name !== 'AbortError') {
       if (err instanceof TypeError) {
-        showError('Failed to fetch URL (possible CORS issue). Try a proxy: https://corsproxy.io/?url=' + encodeURIComponent(url));
+        showError('Failed to fetch URL: ' + err.message + ' (possible CORS issue). Try a proxy: https://corsproxy.io/?url=' + encodeURIComponent(url));
       } else {
         showError('Failed to fetch URL: ' + err.message);
       }

--- a/extra/github-pages/index.js
+++ b/extra/github-pages/index.js
@@ -170,7 +170,7 @@ function fetchUrl(url) {
   }).catch(function (err) {
     if (err.name !== 'AbortError') {
       if (err instanceof TypeError) {
-        showError('Failed to fetch URL (possible CORS issue). Try prepending a proxy: https://corsproxy.io/?');
+        showError('Failed to fetch URL (possible CORS issue). Try a proxy: https://corsproxy.io/?url=' + encodeURIComponent(url));
       } else {
         showError('Failed to fetch URL: ' + err.message);
       }

--- a/extra/github-pages/index.js
+++ b/extra/github-pages/index.js
@@ -169,7 +169,11 @@ function fetchUrl(url) {
     process(true);
   }).catch(function (err) {
     if (err.name !== 'AbortError') {
-      showError('Failed to fetch URL: ' + err.message);
+      if (err instanceof TypeError) {
+        showError('Failed to fetch URL (possible CORS issue). Try prepending a proxy: https://corsproxy.io/?');
+      } else {
+        showError('Failed to fetch URL: ' + err.message);
+      }
     }
   });
 }


### PR DESCRIPTION
Suggest corsproxy.io workaround when a fetch fails due to cross-origin restrictions (e.g. hackage-content.haskell.org).