### PR TITLE
Remove item keys from HTML output

### DIFF
--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -644,7 +644,6 @@ itemToHtml (Located.MkLocated loc (Item.MkItem key itemKind _parentKey maybeName
               <> sigBeforeKind
               <> [Content.Element kindElement]
               <> sigAfterKind
-              <> [Content.Element keyElement]
               <> [Content.Element (locationElement loc)]
               <> docContents'
           )
@@ -691,13 +690,6 @@ itemToHtml (Located.MkLocated loc (Item.MkItem key itemKind _parentKey maybeName
                   [Xml.attribute "class" "font-monospace"]
                   [Xml.text (prefix <> sig)]
             ]
-
-    keyElement :: Element.Element
-    keyElement =
-      Xml.element
-        "span"
-        [Xml.attribute "class" "text-body-tertiary small ms-2"]
-        [Xml.text (Text.pack "#" <> Text.pack (show (ItemKey.unwrap key)))]
 
     docContents' :: [Content.Content Element.Element]
     docContents' = case doc of


### PR DESCRIPTION
## Summary

- Removed the `keyElement` span (e.g. `#0`, `#1`) from the rendered HTML for declaration items
- Item keys are internal identifiers used only to associate child items with parents; they provide no value to the user in the rendered output

Fixes #105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)