### PR TITLE
Extract name and signature from foreign declarations

### DIFF
--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -561,6 +561,10 @@ convertDeclWithDocMaybeM doc lDecl = case SrcLoc.unLoc lDecl of
     let sig = Just $ extractKindSigSignature kindSig
      in Maybe.maybeToList <$> convertDeclWithDocM Nothing doc (Just $ extractStandaloneKindSigName kindSig) sig lDecl
   Syntax.InstD _ inst -> convertInstDeclWithDocM doc lDecl inst
+  Syntax.ForD _ foreignDecl ->
+    let name = Just $ extractForeignDeclName foreignDecl
+        sig = Just $ extractForeignDeclSignature foreignDecl
+     in Maybe.maybeToList <$> convertDeclWithDocM Nothing doc name sig lDecl
   Syntax.SpliceD _ spliceDecl ->
     let sig = Just . Text.pack . Outputable.showSDocUnsafe . Outputable.ppr $ spliceDecl
      in Maybe.maybeToList <$> convertDeclWithDocM Nothing doc Nothing sig lDecl
@@ -1156,6 +1160,7 @@ extractDeclName lDecl = case SrcLoc.unLoc lDecl of
   Syntax.InstD _ inst -> extractInstDeclName inst
   Syntax.DerivD _ derivDecl -> extractDerivDeclName derivDecl
   Syntax.KindSigD _ kindSig -> Just $ extractStandaloneKindSigName kindSig
+  Syntax.ForD _ foreignDecl -> Just $ extractForeignDeclName foreignDecl
   _ -> Nothing
 
 -- | Extract name from a standalone kind signature.
@@ -1216,6 +1221,15 @@ extractSynDeclSignature tyClDecl = case tyClDecl of
 -- | Extract name from a family declaration.
 extractFamilyDeclName :: Syntax.FamilyDecl Ghc.GhcPs -> ItemName.ItemName
 extractFamilyDeclName famDecl = extractIdPName $ Syntax.fdLName famDecl
+
+-- | Extract name from a foreign declaration.
+extractForeignDeclName :: Syntax.ForeignDecl Ghc.GhcPs -> ItemName.ItemName
+extractForeignDeclName foreignDecl = extractIdPName $ Syntax.fd_name foreignDecl
+
+-- | Extract signature from a foreign declaration.
+extractForeignDeclSignature :: Syntax.ForeignDecl Ghc.GhcPs -> Text.Text
+extractForeignDeclSignature foreignDecl =
+  Text.pack . Outputable.showSDocUnsafe . Outputable.ppr $ Syntax.fd_sig_ty foreignDecl
 
 -- | Extract name from a binding.
 extractBindName :: Syntax.HsBindLR Ghc.GhcPs Ghc.GhcPs -> Maybe ItemName.ItemName

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -1648,13 +1648,22 @@ spec s = Spec.describe s "integration" $ do
       check s "default ()" []
 
     Spec.it s "foreign import" $ do
-      check s "{-# language ForeignFunctionInterface #-} foreign import ccall \"\" p :: ()" []
+      check
+        s
+        "{-# language ForeignFunctionInterface #-} foreign import ccall \"\" p :: ()"
+        [ ("/items/0/value/kind", "\"ForeignImport\""),
+          ("/items/0/value/name", "\"p\""),
+          ("/items/0/value/signature", "\"()\"")
+        ]
 
     Spec.it s "foreign export" $ do
       check
         s
         "{-# language ForeignFunctionInterface #-} foreign export ccall q :: IO ()"
-        [("/items/0/value/kind", "\"ForeignExport\"")]
+        [ ("/items/0/value/kind", "\"ForeignExport\""),
+          ("/items/0/value/name", "\"q\""),
+          ("/items/0/value/signature", "\"IO ()\"")
+        ]
 
     Spec.it s "warning pragma" $ do
       check


### PR DESCRIPTION
Fixes #104.

## Summary
- Added explicit handling for `ForD` (foreign import/export) in `convertDeclWithDocMaybeM` to extract the name (`fd_name`) and type signature (`fd_sig_ty`) from `ForeignDecl`
- Added `extractForeignDeclName` and `extractForeignDeclSignature` helper functions
- Added `ForD` case to `extractDeclName` for completeness
- Updated integration tests for foreign import and foreign export to verify name and signature are present

Previously, foreign declarations fell through to the default case which passed `Nothing` for both name and signature, so they appeared without either in the rendered documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)