### PR TITLE
Add ToJson type class

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -7,9 +7,11 @@
 - extensions:
     - default: false
     - name:
+        - DerivingVia
         - FlexibleContexts
         - MultilineStrings
         - RankNTypes
         - ScopedTypeVariables
+        - StandaloneDeriving
         - TemplateHaskell
         - TemplateHaskellQuotes

--- a/scrod.cabal
+++ b/scrod.cabal
@@ -177,6 +177,7 @@ library
     Scrod.Json.Object
     Scrod.Json.Pair
     Scrod.Json.String
+    Scrod.Json.ToJson
     Scrod.Json.Value
     Scrod.JsonPointer.Evaluate
     Scrod.JsonPointer.Pointer

--- a/source/library/Scrod/Json/ToJson.hs
+++ b/source/library/Scrod/Json/ToJson.hs
@@ -1,0 +1,29 @@
+-- | Type class for converting values into JSON.
+module Scrod.Json.ToJson where
+
+import qualified Data.List.NonEmpty as NonEmpty
+import qualified Data.Text as Text
+import qualified Numeric.Natural as Natural
+import qualified Scrod.Json.Value as Json
+
+-- | Convert a value to a JSON 'Json.Value'.
+class ToJson a where
+  toJson :: a -> Json.Value
+
+instance ToJson Bool where
+  toJson = Json.boolean
+
+instance ToJson Text.Text where
+  toJson = Json.text
+
+instance ToJson Natural.Natural where
+  toJson = Json.integral
+
+instance (ToJson a) => ToJson (Maybe a) where
+  toJson = maybe Json.null toJson
+
+instance (ToJson a) => ToJson [a] where
+  toJson = Json.arrayOf toJson
+
+instance (ToJson a) => ToJson (NonEmpty.NonEmpty a) where
+  toJson = toJson . NonEmpty.toList


### PR DESCRIPTION
## Summary

- Introduces a `ToJson` class in `Scrod.Json.ToJson` with basic instances for `Bool`, `Text`, `Natural`, `Maybe`, `[]`, and `NonEmpty`
- Converts all standalone `*ToJson` functions in `Scrod.Convert.ToJson` into `ToJson` class instances
- Simple newtype wrappers (Category, Column, Extension, ItemKey, ItemName, Language, Line, ModuleName, PackageName, Section, Version) use `deriving via` to get their instances for free

Fixes #112.

## Test plan

- [x] `cabal build` succeeds
- [x] `cabal build --flags=pedantic` succeeds (no warnings)
- [x] All 836 tests pass (`cabal test --test-options='--hide-successes'`)
- [x] JSON output is unchanged (integration tests verify exact JSON structure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)