### PR TITLE
Make GitHub Pages assets content addressable

### DIFF
--- a/extra/github-pages/build.sh
+++ b/extra/github-pages/build.sh
@@ -31,7 +31,8 @@ hash_asset() {
   new="${base}.${hash}.${ext}"
   mv "$dist/$file" "$dist/$new"
   for ref in "$@"; do
-    sed -i "s|$file|$new|g" "$dist/$ref"
+    sed "s|$file|$new|g" "$dist/$ref" > "$dist/$ref.tmp"
+    mv "$dist/$ref.tmp" "$dist/$ref"
   done
 }
 

--- a/extra/github-pages/build.sh
+++ b/extra/github-pages/build.sh
@@ -14,3 +14,34 @@ cp -r extra/github-pages/vendor "$dist/"
 cp extra/bootstrap/bootstrap.min.css "$dist/vendor/"
 cp extra/wasm/dist/scrod-wasm.wasm "$dist/"
 cp extra/wasm/dist/ghc_wasm_jsffi.js "$dist/"
+
+# Make assets content addressable by embedding a hash in each filename.
+# Files are processed bottom-up so that a parent's hash reflects the
+# hashed names it references.
+
+# hash_asset FILE REF_FILES...
+# Renames dist/FILE to include a content hash and updates all references
+# in the given REF_FILES (also relative to dist).
+hash_asset() {
+  file=$1
+  shift
+  hash=$(sha256sum "$dist/$file" | head -c 16)
+  base=${file%.*}
+  ext=${file##*.}
+  new="${base}.${hash}.${ext}"
+  mv "$dist/$file" "$dist/$new"
+  for ref in "$@"; do
+    sed -i "s|$file|$new|g" "$dist/$ref"
+  done
+}
+
+# Phase 1: leaf assets (no outgoing references to other hashed assets)
+hash_asset vendor/browser_wasi_shim.js worker.js
+hash_asset ghc_wasm_jsffi.js           worker.js
+hash_asset scrod-wasm.wasm              worker.js
+hash_asset vendor/bootstrap.min.css     index.html index.js
+hash_asset style.css                    index.html
+
+# Phase 2: files that reference leaf assets (content now includes hashed names)
+hash_asset worker.js                    index.js
+hash_asset index.js                     index.html


### PR DESCRIPTION
## Summary

- Extends `extra/github-pages/build.sh` to embed a truncated SHA-256 content hash in every asset filename (e.g. `style.0d81d09d7bfd20c4.css`, `scrod-wasm.0849e9dadf42704c.wasm`)
- Processes files bottom-up so parent hashes reflect the hashed names they reference
- `index.html` (the entry point) keeps its original name; all other assets get hashed

Fixes #113.

## Test plan

- [x] `build.sh` runs cleanly and produces correctly hashed filenames
- [x] All cross-file references (HTML → JS/CSS, JS → Worker, Worker → WASM/FFI) updated to hashed names
- [x] Build is idempotent (same hashes on repeated runs)
- [x] `cabal build` and `cabal test` pass (836 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)