### PR TITLE
Add overflow-wrap to prevent long identifiers from breaking layout

### DIFF
--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -99,6 +99,8 @@ headElement m =
       Content.Element $
         Xml.element "style" [] [Xml.raw Bootstrap.css],
       Content.Element $
+        Xml.element "style" [] [Xml.raw $ Text.pack ".container{overflow-wrap:anywhere}"],
+      Content.Element $
         Xml.element
           "script"
           []

--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -99,8 +99,6 @@ headElement m =
       Content.Element $
         Xml.element "style" [] [Xml.raw Bootstrap.css],
       Content.Element $
-        Xml.element "style" [] [Xml.raw $ Text.pack ".container{overflow-wrap:anywhere}"],
-      Content.Element $
         Xml.element
           "script"
           []
@@ -122,7 +120,7 @@ bodyElement m =
     [ Content.Element $
         Xml.element
           "div"
-          [Xml.attribute "class" "container py-4"]
+          [Xml.attribute "class" "container py-4 text-break"]
           ( [Content.Element (headerSection m)]
               <> metadataContents m
               <> exportsContents (Module.exports m)


### PR DESCRIPTION
Fixes #119.

## Summary

Adds `overflow-wrap: anywhere` on the `.container` element in the HTML output. This forces long identifiers (function names, type signatures, etc.) to wrap at any character when they would otherwise overflow the container, preventing horizontal scrollbar / layout breakage.

The fix is a single custom `<style>` rule injected after the Bootstrap CSS in the `<head>`.