### PR TITLE
Associate instances with their parent type in the same module

### DIFF
--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -471,7 +471,9 @@ extractItems ::
   [Located.Located Item.Item]
 extractItems lHsModule =
   let rawItems = runConvert $ extractItemsM lHsModule
-   in mergeItemsByName rawItems
+      instanceHeadTypes = extractInstanceHeadTypeNames lHsModule
+      parentedItems = associateInstanceParents instanceHeadTypes rawItems
+   in mergeItemsByName parentedItems
 
 -- | Extract items in the conversion monad.
 extractItemsM ::
@@ -482,6 +484,112 @@ extractItemsM lHsModule = do
       decls = Syntax.hsmodDecls hsModule
       declsWithDocs = associateDocs decls
   concat <$> traverse (uncurry convertDeclWithDocMaybeM) declsWithDocs
+
+-- | Extract the head type name for each instance or standalone deriving
+-- declaration, keyed by source location.
+extractInstanceHeadTypeNames ::
+  SrcLoc.Located (Syntax.HsModule Ghc.GhcPs) ->
+  Map.Map Location.Location ItemName.ItemName
+extractInstanceHeadTypeNames lHsModule =
+  let hsModule = SrcLoc.unLoc lHsModule
+      decls = Syntax.hsmodDecls hsModule
+   in Map.fromList $ Maybe.mapMaybe extractDeclInstanceHeadType decls
+
+-- | Extract the head type name from a single declaration, if it is an
+-- instance or standalone deriving declaration.
+extractDeclInstanceHeadType ::
+  Syntax.LHsDecl Ghc.GhcPs ->
+  Maybe (Location.Location, ItemName.ItemName)
+extractDeclInstanceHeadType lDecl = case SrcLoc.unLoc lDecl of
+  Syntax.InstD _ inst -> case inst of
+    Syntax.ClsInstD _ clsInst -> do
+      location <- locationFromSrcSpan (Annotation.getLocA lDecl)
+      headType <- extractHeadTypeName . Syntax.sig_body . SrcLoc.unLoc $ Syntax.cid_poly_ty clsInst
+      Just (location, headType)
+    _ -> Nothing
+  Syntax.DerivD _ derivDecl -> do
+    location <- locationFromSrcSpan (Annotation.getLocA lDecl)
+    headType <- extractHeadTypeName . Syntax.sig_body . SrcLoc.unLoc . Syntax.hswc_body $ Syntax.deriv_type derivDecl
+    Just (location, headType)
+  _ -> Nothing
+
+-- | Extract the head type constructor name from the last argument of a
+-- type application. For @C T@ this returns @T@; for @C (Maybe a)@ this
+-- returns @Maybe@.
+extractHeadTypeName :: Syntax.LHsType Ghc.GhcPs -> Maybe ItemName.ItemName
+extractHeadTypeName lTy = case SrcLoc.unLoc lTy of
+  Syntax.HsAppTy _ _ arg -> extractOutermostTyCon arg
+  Syntax.HsQualTy _ _ body -> extractHeadTypeName body
+  Syntax.HsForAllTy _ _ body -> extractHeadTypeName body
+  Syntax.HsParTy _ inner -> extractHeadTypeName inner
+  _ -> Nothing
+
+-- | Extract the outermost type constructor name from a type. For @T@
+-- this returns @T@; for @Maybe a@ this returns @Maybe@.
+extractOutermostTyCon :: Syntax.LHsType Ghc.GhcPs -> Maybe ItemName.ItemName
+extractOutermostTyCon lTy = case SrcLoc.unLoc lTy of
+  Syntax.HsTyVar _ _ lName -> Just . ItemName.MkItemName $ extractRdrName lName
+  Syntax.HsAppTy _ fun _ -> extractOutermostTyCon fun
+  Syntax.HsAppKindTy _ fun _ -> extractOutermostTyCon fun
+  Syntax.HsParTy _ inner -> extractOutermostTyCon inner
+  _ -> Nothing
+
+-- | Associate instances and standalone deriving declarations with their
+-- parent types when those types are defined in the same module.
+associateInstanceParents ::
+  Map.Map Location.Location ItemName.ItemName ->
+  [Located.Located Item.Item] ->
+  [Located.Located Item.Item]
+associateInstanceParents headTypeNames items =
+  let typeNameToKey = buildTypeNameToKeyMap items
+   in fmap (resolveInstanceParent headTypeNames typeNameToKey) items
+
+-- | Build a map from type/class names to their item keys.
+buildTypeNameToKeyMap ::
+  [Located.Located Item.Item] ->
+  Map.Map ItemName.ItemName ItemKey.ItemKey
+buildTypeNameToKeyMap =
+  Map.fromList . Maybe.mapMaybe getTypeNameAndKey
+  where
+    getTypeNameAndKey locItem =
+      let val = Located.value locItem
+       in case Item.parentKey val of
+            Just _ -> Nothing
+            Nothing ->
+              if isTypeOrClassKind (Item.kind val)
+                then fmap (\n -> (n, Item.key val)) (Item.name val)
+                else Nothing
+
+-- | Check if an item kind represents a type or class definition.
+isTypeOrClassKind :: ItemKind.ItemKind -> Bool
+isTypeOrClassKind kind = case kind of
+  ItemKind.DataType -> True
+  ItemKind.Newtype -> True
+  ItemKind.TypeData -> True
+  ItemKind.TypeSynonym -> True
+  ItemKind.Class -> True
+  _ -> False
+
+-- | Try to resolve an instance's parent from the head type maps.
+resolveInstanceParent ::
+  Map.Map Location.Location ItemName.ItemName ->
+  Map.Map ItemName.ItemName ItemKey.ItemKey ->
+  Located.Located Item.Item ->
+  Located.Located Item.Item
+resolveInstanceParent headTypeNames typeNameToKey locItem =
+  let val = Located.value locItem
+   in case Item.parentKey val of
+        Just _ -> locItem
+        Nothing ->
+          if Item.kind val == ItemKind.ClassInstance || Item.kind val == ItemKind.StandaloneDeriving
+            then case Map.lookup (Located.location locItem) headTypeNames of
+              Nothing -> locItem
+              Just headTypeName ->
+                case Map.lookup headTypeName typeNameToKey of
+                  Nothing -> locItem
+                  Just parentKey ->
+                    locItem {Located.value = val {Item.parentKey = Just parentKey}}
+            else locItem
 
 -- | Associate documentation comments with their target declarations.
 associateDocs ::

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -1187,6 +1187,30 @@ spec s = Spec.describe s "integration" $ do
         """
         [("/items/1/value/kind", "\"ClassInstance\"")]
 
+    Spec.it s "class instance parent is local type" $ do
+      check
+        s
+        """
+        class C a
+        data T
+        instance C T
+        """
+        [ ("/items/2/value/kind", "\"ClassInstance\""),
+          ("/items/2/value/name", "\"C T\""),
+          ("/items/2/value/parentKey", "1")
+        ]
+
+    Spec.it s "class instance parent is local class when type is external" $ do
+      check
+        s
+        """
+        class C a
+        instance C Int
+        """
+        [ ("/items/1/value/kind", "\"ClassInstance\""),
+          ("/items/1/value/parentKey", "null")
+        ]
+
     Spec.it s "data instance" $ do
       check
         s
@@ -1267,7 +1291,8 @@ spec s = Spec.describe s "integration" $ do
         deriving instance Show L
         """
         [ ("/items/1/value/kind", "\"StandaloneDeriving\""),
-          ("/items/1/value/name", "\"Show L\"")
+          ("/items/1/value/name", "\"Show L\""),
+          ("/items/1/value/parentKey", "0")
         ]
 
     Spec.it s "standalone deriving stock" $ do
@@ -1279,7 +1304,8 @@ spec s = Spec.describe s "integration" $ do
         deriving stock instance Show M
         """
         [ ("/items/1/value/kind", "\"StandaloneDeriving\""),
-          ("/items/1/value/name", "\"Show M\"")
+          ("/items/1/value/name", "\"Show M\""),
+          ("/items/1/value/parentKey", "0")
         ]
 
     Spec.it s "standalone deriving newtype" $ do
@@ -1291,7 +1317,8 @@ spec s = Spec.describe s "integration" $ do
         deriving newtype instance Show N
         """
         [ ("/items/2/value/kind", "\"StandaloneDeriving\""),
-          ("/items/2/value/name", "\"Show N\"")
+          ("/items/2/value/name", "\"Show N\""),
+          ("/items/2/value/parentKey", "0")
         ]
 
     Spec.it s "standalone deriving anyclass" $ do
@@ -1304,7 +1331,8 @@ spec s = Spec.describe s "integration" $ do
         deriving anyclass instance O W2
         """
         [ ("/items/2/value/kind", "\"StandaloneDeriving\""),
-          ("/items/2/value/name", "\"O W2\"")
+          ("/items/2/value/name", "\"O W2\""),
+          ("/items/2/value/parentKey", "1")
         ]
 
     Spec.it s "standalone deriving via" $ do
@@ -1316,7 +1344,8 @@ spec s = Spec.describe s "integration" $ do
         deriving via Int instance Show P
         """
         [ ("/items/2/value/kind", "\"StandaloneDeriving\""),
-          ("/items/2/value/name", "\"Show P\"")
+          ("/items/2/value/name", "\"Show P\""),
+          ("/items/2/value/parentKey", "0")
         ]
 
     Spec.it s "data deriving" $ do


### PR DESCRIPTION
## Summary

Fixes #120.

- When a class instance (`instance C T`) or standalone deriving declaration (`deriving instance Show T`) references a type defined in the same module, the instance is now parented under that type (its `parentKey` points to the local type).
- Previously only derived instances from deriving clauses (`data T deriving Show`) were associated with their parent type.
- The implementation adds a post-processing step in `extractItems` that walks the GHC AST to extract the head type name for each instance, then resolves parent keys against locally-defined types.

## Test plan

- [x] Added integration test for `class C a; data T; instance C T` — verifies `parentKey` is set to the `data T` item
- [x] Added integration test for `class C a; instance C Int` — verifies `parentKey` stays `null` when the type is external
- [x] Updated 5 existing standalone deriving tests to assert the new `parentKey` values
- [x] All 838 tests pass
- [x] Builds cleanly with `--flags=pedantic` (`-Werror`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)