### PR TITLE
Include schema in release assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
       - run: cabal build
       - run: cp $( cabal list-bin ${{ needs.meta.outputs.name }} ) artifact
       - run: cp $( cabal list-bin ${{ needs.meta.outputs.name }}-test-suite ) artifact
+      - run: artifact/${{ needs.meta.outputs.name }}${{ runner.os == 'Windows' && '.exe' || '' }} --schema > artifact/schema.json
+        shell: bash
       - run: tar --create --file artifact.tar --verbose artifact
       - uses: actions/upload-artifact@v6
         with:
@@ -200,4 +202,4 @@ jobs:
       - run: .github/workflows/release.sh ${{ needs.meta.outputs.name }} ${{ needs.meta.outputs.version }} ${{ github.sha }}
       - env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create ${{ needs.meta.outputs.version }} --draft --generate-notes --target ${{ github.sha }} ${{ needs.meta.outputs.name }}-*.tar.gz *.vsix
+        run: gh release create ${{ needs.meta.outputs.version }} --draft --generate-notes --target ${{ github.sha }} ${{ needs.meta.outputs.name }}-*.tar.gz ${{ needs.meta.outputs.name }}-*.json *.vsix

--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -7,6 +7,8 @@ sha="$3"
 artifact_prefix="${name}-${sha}"
 
 tar --extract --file "${artifact_prefix}-Linux/artifact.tar" --strip-components=1 --wildcards '*.tar.gz'
+tar --extract --file "${artifact_prefix}-Linux/artifact.tar" --strip-components=1 artifact/schema.json
+mv schema.json "${name}-${version}-schema.json"
 
 shopt -s nullglob
 dirs=("${artifact_prefix}"-*/)


### PR DESCRIPTION
Fixes #127.

## Summary

- Generates `schema.json` during the CI build job by running the binary with `--schema`, including it in the build artifact alongside the binary and test suite
- Extracts the schema from the Linux artifact in `release.sh` and renames it to `scrod-VERSION-schema.json`
- Adds the schema JSON file to the `gh release create` command so it is uploaded as a standalone release asset

🤖 Generated with [Claude Code](https://claude.com/claude-code)