### PR TITLE
Add ToSchema type class

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -13,9 +13,11 @@
         - FlexibleContexts
         - FlexibleInstances
         - MultilineStrings
+        - PolyKinds
         - RankNTypes
         - ScopedTypeVariables
         - StandaloneDeriving
+        - StandaloneKindSignatures
         - TemplateHaskell
         - TemplateHaskellQuotes
         - TypeOperators

--- a/scrod.cabal
+++ b/scrod.cabal
@@ -99,6 +99,7 @@ library
     Scrod.Convert.ToHtml
     Scrod.Convert.ToJson
     Scrod.Convert.ToJsonSchema
+    Scrod.Convert.ToSchema
     Scrod.Core.Category
     Scrod.Core.Column
     Scrod.Core.Doc
@@ -181,6 +182,7 @@ library
     Scrod.Json.Pair
     Scrod.Json.String
     Scrod.Json.ToJson
+    Scrod.Json.ToSchema
     Scrod.Json.Value
     Scrod.JsonPointer.Evaluate
     Scrod.JsonPointer.Pointer

--- a/source/library/Scrod/Convert/ToSchema.hs
+++ b/source/library/Scrod/Convert/ToSchema.hs
@@ -1,0 +1,335 @@
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-- | Provide 'ToSchema' instances for Scrod core types.
+--
+-- Simple newtype wrappers use @deriving via@ the underlying type.
+-- Record types, enum types, and tagged sum types all use
+-- @deriving via 'Generics.Generically'@ to get instances derived
+-- generically. Other types have hand-written instances. Import this
+-- module to bring all instances into scope.
+module Scrod.Convert.ToSchema
+  ( module Scrod.Json.ToSchema,
+  )
+where
+
+import qualified Control.Monad.Trans.Accum as Accum
+import qualified Data.List.NonEmpty as NonEmpty
+import qualified Data.Proxy as Proxy
+import qualified Data.Text as Text
+import qualified GHC.Generics as Generics
+import qualified Numeric.Natural as Natural
+import qualified Scrod.Core.Category as Category
+import qualified Scrod.Core.Column as Column
+import qualified Scrod.Core.Doc as Doc
+import qualified Scrod.Core.Example as Example
+import qualified Scrod.Core.Export as Export
+import qualified Scrod.Core.ExportIdentifier as ExportIdentifier
+import qualified Scrod.Core.ExportName as ExportName
+import qualified Scrod.Core.ExportNameKind as ExportNameKind
+import qualified Scrod.Core.Extension as Extension
+import qualified Scrod.Core.Header as Header
+import qualified Scrod.Core.Hyperlink as Hyperlink
+import qualified Scrod.Core.Identifier as Identifier
+import qualified Scrod.Core.Import as Import
+import qualified Scrod.Core.Item as Item
+import qualified Scrod.Core.ItemKey as ItemKey
+import qualified Scrod.Core.ItemKind as ItemKind
+import qualified Scrod.Core.ItemName as ItemName
+import qualified Scrod.Core.Language as Language
+import qualified Scrod.Core.Level as Level
+import qualified Scrod.Core.Line as Line
+import qualified Scrod.Core.Located as Located
+import qualified Scrod.Core.Location as Location
+import qualified Scrod.Core.ModLink as ModLink
+import qualified Scrod.Core.Module as Module
+import qualified Scrod.Core.ModuleName as ModuleName
+import qualified Scrod.Core.Namespace as Namespace
+import qualified Scrod.Core.PackageName as PackageName
+import qualified Scrod.Core.Picture as Picture
+import qualified Scrod.Core.Section as Section
+import qualified Scrod.Core.Since as Since
+import qualified Scrod.Core.Subordinates as Subordinates
+import qualified Scrod.Core.Table as Table
+import qualified Scrod.Core.TableCell as TableCell
+import qualified Scrod.Core.Version as Version
+import qualified Scrod.Core.Warning as Warning
+import Scrod.Json.ToSchema (Schema (MkSchema, unwrap), SchemaM, ToSchema (isOptional, toSchema))
+import qualified Scrod.Json.ToSchema as ToSchema
+import qualified Scrod.Json.Value as Json
+
+-- * Simple newtype wrappers use @deriving via@ to get their instances
+
+-- from the underlying type.
+
+deriving via Text.Text instance ToSchema Category.Category
+
+deriving via Natural.Natural instance ToSchema Column.Column
+
+deriving via Text.Text instance ToSchema Extension.Extension
+
+deriving via Text.Text instance ToSchema ItemName.ItemName
+
+deriving via Natural.Natural instance ToSchema ItemKey.ItemKey
+
+deriving via Text.Text instance ToSchema Language.Language
+
+deriving via Natural.Natural instance ToSchema Line.Line
+
+deriving via Text.Text instance ToSchema ModuleName.ModuleName
+
+deriving via Text.Text instance ToSchema PackageName.PackageName
+
+deriving via Header.Header Doc.Doc instance ToSchema Section.Section
+
+deriving via NonEmpty.NonEmpty Natural.Natural instance ToSchema Version.Version
+
+-- * Record types, enum types, and tagged sum types use
+
+-- @Generics.Generically@ to derive their instances generically.
+
+deriving via Generics.Generically Example.Example instance ToSchema Example.Example
+
+deriving via Generics.Generically ExportIdentifier.ExportIdentifier instance ToSchema ExportIdentifier.ExportIdentifier
+
+deriving via Generics.Generically ExportName.ExportName instance ToSchema ExportName.ExportName
+
+deriving via Generics.Generically (Header.Header doc) instance (ToSchema doc) => ToSchema (Header.Header doc)
+
+deriving via Generics.Generically (Hyperlink.Hyperlink doc) instance (ToSchema doc) => ToSchema (Hyperlink.Hyperlink doc)
+
+deriving via Generics.Generically Identifier.Identifier instance ToSchema Identifier.Identifier
+
+deriving via Generics.Generically Import.Import instance ToSchema Import.Import
+
+deriving via Generics.Generically Item.Item instance ToSchema Item.Item
+
+deriving via Generics.Generically (Located.Located a) instance (ToSchema a) => ToSchema (Located.Located a)
+
+deriving via Generics.Generically Location.Location instance ToSchema Location.Location
+
+deriving via Generics.Generically (ModLink.ModLink doc) instance (ToSchema doc) => ToSchema (ModLink.ModLink doc)
+
+deriving via Generics.Generically Picture.Picture instance ToSchema Picture.Picture
+
+deriving via Generics.Generically Since.Since instance ToSchema Since.Since
+
+deriving via Generics.Generically Subordinates.Subordinates instance ToSchema Subordinates.Subordinates
+
+deriving via Generics.Generically (Table.Table doc) instance (ToSchema doc) => ToSchema (Table.Table doc)
+
+deriving via Generics.Generically (TableCell.Cell doc) instance (ToSchema doc) => ToSchema (TableCell.Cell doc)
+
+deriving via Generics.Generically Warning.Warning instance ToSchema Warning.Warning
+
+deriving via Generics.Generically ExportNameKind.ExportNameKind instance ToSchema ExportNameKind.ExportNameKind
+
+deriving via Generics.Generically ItemKind.ItemKind instance ToSchema ItemKind.ItemKind
+
+deriving via Generics.Generically Namespace.Namespace instance ToSchema Namespace.Namespace
+
+deriving via Generics.Generically Export.Export instance ToSchema Export.Export
+
+-- * Hand-written instances for types that require special encoding.
+
+instance ToSchema Module.Module where
+  toSchema _ = do
+    version <- toSchema (Proxy.Proxy :: Proxy.Proxy Version.Version)
+    language <- toSchema (Proxy.Proxy :: Proxy.Proxy Language.Language)
+    extensions <- extensionsSchema
+    documentation <- toSchema (Proxy.Proxy :: Proxy.Proxy Doc.Doc)
+    since <- toSchema (Proxy.Proxy :: Proxy.Proxy Since.Since)
+    name <- toSchema (Proxy.Proxy :: Proxy.Proxy (Located.Located ModuleName.ModuleName))
+    warning <- toSchema (Proxy.Proxy :: Proxy.Proxy Warning.Warning)
+    exports <- toSchema (Proxy.Proxy :: Proxy.Proxy [Export.Export])
+    imports <- toSchema (Proxy.Proxy :: Proxy.Proxy [Import.Import])
+    items <- toSchema (Proxy.Proxy :: Proxy.Proxy [Located.Located Item.Item])
+    let allProps =
+          [ ("version", unwrap version),
+            ("language", unwrap language),
+            ("extensions", unwrap extensions),
+            ("documentation", unwrap documentation),
+            ("since", unwrap since),
+            ("signature", Json.object [("type", Json.string "boolean")]),
+            ("name", unwrap name),
+            ("warning", unwrap warning),
+            ("exports", unwrap exports),
+            ("imports", unwrap imports),
+            ("items", unwrap items)
+          ]
+    let reqNames =
+          [ Json.string "version",
+            Json.string "extensions",
+            Json.string "documentation",
+            Json.string "signature",
+            Json.string "imports",
+            Json.string "items"
+          ]
+    pure . MkSchema $
+      Json.object
+        [ ("type", Json.string "object"),
+          ("properties", Json.object allProps),
+          ("required", Json.array reqNames),
+          ("additionalProperties", Json.boolean False)
+        ]
+
+extensionsSchema :: SchemaM Schema
+extensionsSchema =
+  pure . MkSchema $
+    Json.object
+      [ ("type", Json.string "object"),
+        ("additionalProperties", Json.object [("type", Json.string "boolean")])
+      ]
+
+-- | 'Doc.Doc' is recursive, so its schema uses @define@ to register a
+-- named definition in @$defs@ and return a @$ref@. The schema value is
+-- built purely with inline sub-schemas and a self-reference for @Doc@.
+instance ToSchema Doc.Doc where
+  toSchema _ = do
+    Accum.add [("doc", docSchemaValue)]
+    pure . MkSchema $ Json.object [("$ref", Json.string "#/$defs/doc")]
+
+-- | Pure schema value for 'Doc.Doc'. Uses @$ref \"#/$defs/doc\"@ for
+-- self-references and inlines all other sub-schemas.
+docSchemaValue :: Json.Value
+docSchemaValue =
+  let self = Json.object [("$ref", Json.string "#/$defs/doc")]
+      str = Json.object [("type", Json.string "string")]
+      nullSchema = Json.object [("type", Json.string "null")]
+      int = Json.object [("type", Json.string "integer")]
+      tagged tag valueSchema =
+        Json.object
+          [ ("type", Json.string "object"),
+            ( "properties",
+              Json.object
+                [ ("type", Json.object [("const", Json.string tag)]),
+                  ("value", valueSchema)
+                ]
+            ),
+            ("required", Json.array [Json.string "type", Json.string "value"]),
+            ("additionalProperties", Json.boolean False)
+          ]
+      tupleOf items =
+        Json.object
+          [ ("type", Json.string "array"),
+            ("prefixItems", Json.array items),
+            ("items", Json.boolean False),
+            ("minItems", Json.integral $ length items),
+            ("maxItems", Json.integral $ length items)
+          ]
+      -- Inline sub-schemas (non-recursive types, computed purely)
+      identifierSchema = pureSchema (Proxy.Proxy :: Proxy.Proxy Identifier.Identifier)
+      pictureSchema = pureSchema (Proxy.Proxy :: Proxy.Proxy Picture.Picture)
+      exampleSchema = pureSchema (Proxy.Proxy :: Proxy.Proxy Example.Example)
+      -- Sub-schemas parameterized by Doc (use self-reference)
+      modLinkSchema =
+        objectSchemaOptPure
+          [("name", str)]
+          [("label", self)]
+      hyperlinkSchema =
+        objectSchemaOptPure
+          [("url", str)]
+          [("label", self)]
+      headerSchema =
+        objectSchemaPure
+          [ ("level", pureSchema (Proxy.Proxy :: Proxy.Proxy Level.Level)),
+            ("title", self)
+          ]
+      cellSchema =
+        objectSchemaPure
+          [ ("colspan", pureSchema (Proxy.Proxy :: Proxy.Proxy Natural.Natural)),
+            ("rowspan", pureSchema (Proxy.Proxy :: Proxy.Proxy Natural.Natural)),
+            ("contents", self)
+          ]
+      tableSchema =
+        objectSchemaPure
+          [ ("headerRows", Json.object [("type", Json.string "array"), ("items", Json.object [("type", Json.string "array"), ("items", cellSchema)])]),
+            ("bodyRows", Json.object [("type", Json.string "array"), ("items", Json.object [("type", Json.string "array"), ("items", cellSchema)])])
+          ]
+   in Json.object
+        [ ( "oneOf",
+            Json.array
+              [ tagged "Empty" nullSchema,
+                tagged "Append" $
+                  Json.object
+                    [ ("type", Json.string "array"),
+                      ("items", self),
+                      ("minItems", Json.integer 2),
+                      ("maxItems", Json.integer 2)
+                    ],
+                tagged "String" str,
+                tagged "Paragraph" self,
+                tagged "Identifier" identifierSchema,
+                tagged "Module" modLinkSchema,
+                tagged "Emphasis" self,
+                tagged "Monospaced" self,
+                tagged "Bold" self,
+                tagged "UnorderedList" $
+                  Json.object
+                    [ ("type", Json.string "array"),
+                      ("items", self)
+                    ],
+                tagged "OrderedList" $
+                  Json.object
+                    [ ("type", Json.string "array"),
+                      ("items", tupleOf [int, self])
+                    ],
+                tagged "DefList" $
+                  Json.object
+                    [ ("type", Json.string "array"),
+                      ("items", tupleOf [self, self])
+                    ],
+                tagged "CodeBlock" self,
+                tagged "Hyperlink" hyperlinkSchema,
+                tagged "Pic" pictureSchema,
+                tagged "MathInline" str,
+                tagged "MathDisplay" str,
+                tagged "AName" str,
+                tagged "Property" str,
+                tagged "Examples" $
+                  Json.object
+                    [ ("type", Json.string "array"),
+                      ("items", exampleSchema)
+                    ],
+                tagged "Header" headerSchema,
+                tagged "Table" tableSchema
+              ]
+          )
+        ]
+
+-- | Extract the schema value from a non-recursive 'ToSchema' instance
+-- without the monadic context. Only safe for types whose 'toSchema'
+-- does not depend on accumulated definitions.
+pureSchema :: (ToSchema a) => Proxy.Proxy a -> Json.Value
+pureSchema p = unwrap . fst $ ToSchema.runSchemaM (toSchema p)
+
+-- | Build an object schema from required properties only (pure helper).
+objectSchemaPure :: [(String, Json.Value)] -> Json.Value
+objectSchemaPure props =
+  Json.object
+    [ ("type", Json.string "object"),
+      ("properties", Json.object props),
+      ("required", Json.array $ fmap (Json.string . fst) props),
+      ("additionalProperties", Json.boolean False)
+    ]
+
+-- | Build an object schema with required and optional properties (pure
+-- helper).
+objectSchemaOptPure :: [(String, Json.Value)] -> [(String, Json.Value)] -> Json.Value
+objectSchemaOptPure required optional =
+  Json.object
+    [ ("type", Json.string "object"),
+      ("properties", Json.object (required <> optional)),
+      ("required", Json.array $ fmap (Json.string . fst) required),
+      ("additionalProperties", Json.boolean False)
+    ]
+
+instance ToSchema Level.Level where
+  toSchema _ =
+    pure . MkSchema $
+      Json.object
+        [ ("type", Json.string "integer"),
+          ("minimum", Json.integer 1),
+          ("maximum", Json.integer 6)
+        ]

--- a/source/library/Scrod/Convert/ToSchema.hs
+++ b/source/library/Scrod/Convert/ToSchema.hs
@@ -14,7 +14,6 @@ module Scrod.Convert.ToSchema
   )
 where
 
-import qualified Control.Monad.Trans.Accum as Accum
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Proxy as Proxy
 import qualified Data.Text as Text
@@ -55,7 +54,7 @@ import qualified Scrod.Core.Table as Table
 import qualified Scrod.Core.TableCell as TableCell
 import qualified Scrod.Core.Version as Version
 import qualified Scrod.Core.Warning as Warning
-import Scrod.Json.ToSchema (Schema (MkSchema, unwrap), SchemaM, ToSchema (isOptional, toSchema))
+import Scrod.Json.ToSchema (Schema (MkSchema, unwrap), SchemaM, ToSchema (isOptional, toSchema), define)
 import qualified Scrod.Json.ToSchema as ToSchema
 import qualified Scrod.Json.Value as Json
 
@@ -182,13 +181,11 @@ extensionsSchema =
         ("additionalProperties", Json.object [("type", Json.string "boolean")])
       ]
 
--- | 'Doc.Doc' is recursive, so its schema uses @define@ to register a
+-- | 'Doc.Doc' is recursive, so its schema uses 'define' to register a
 -- named definition in @$defs@ and return a @$ref@. The schema value is
 -- built purely with inline sub-schemas and a self-reference for @Doc@.
 instance ToSchema Doc.Doc where
-  toSchema _ = do
-    Accum.add [("doc", docSchemaValue)]
-    pure . MkSchema $ Json.object [("$ref", Json.string "#/$defs/doc")]
+  toSchema _ = define "doc" $ pure (MkSchema docSchemaValue)
 
 -- | Pure schema value for 'Doc.Doc'. Uses @$ref \"#/$defs/doc\"@ for
 -- self-references and inlines all other sub-schemas.

--- a/source/library/Scrod/Json/ToSchema.hs
+++ b/source/library/Scrod/Json/ToSchema.hs
@@ -1,0 +1,259 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE TemplateHaskellQuotes #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | Type class for generating JSON Schema descriptions of types.
+--
+-- This parallels 'Scrod.Json.ToJson.ToJson' but operates on types rather
+-- than values: each instance describes the JSON Schema for the type's
+-- 'ToJson' encoding. An 'Control.Monad.Trans.Accum.Accum' monad
+-- accumulates named definitions (for @$defs@).
+module Scrod.Json.ToSchema where
+
+import qualified Control.Monad.Trans.Accum as Accum
+import qualified Data.Kind as Kind
+import qualified Data.List.NonEmpty as NonEmpty
+import qualified Data.Proxy as Proxy
+import qualified Data.Text as Text
+import qualified GHC.Generics as Generics
+import qualified GHC.TypeLits as TypeLits
+import qualified Numeric.Natural as Natural
+import qualified Scrod.Json.Value as Json
+import qualified Scrod.Spec as Spec
+
+-- | A JSON Schema value.
+newtype Schema = MkSchema
+  { unwrap :: Json.Value
+  }
+  deriving (Eq, Ord, Show)
+
+-- | Monad for schema generation. Accumulates @(name, schema)@ pairs
+-- that become entries in the @$defs@ section of a root schema.
+type SchemaM = Accum.Accum [(String, Json.Value)]
+
+-- | Run a schema computation, returning the result and accumulated
+-- definitions.
+runSchemaM :: SchemaM a -> (a, [(String, Json.Value)])
+runSchemaM m = Accum.runAccum m []
+
+-- | Register a named schema definition and return a @$ref@ pointing to
+-- it. The definition is added to the accumulated @$defs@.
+define :: String -> SchemaM Schema -> SchemaM Schema
+define name m = do
+  MkSchema s <- m
+  Accum.add [(name, s)]
+  pure . MkSchema $ Json.object [("$ref", Json.string $ "#/$defs/" <> name)]
+
+-- | Convert a type to its JSON Schema representation.
+--
+-- Use @deriving via 'Generics.Generically'@ with a 'Generics.Generic'
+-- instance to derive 'ToSchema' for record types, enum types, and tagged
+-- sum types.
+type ToSchema :: Kind.Type -> Kind.Constraint
+class ToSchema a where
+  toSchema :: Proxy.Proxy a -> SchemaM Schema
+
+  -- | Whether the type represents an optional (omit-when-absent) field.
+  -- Returns 'True' for 'Maybe', 'False' for everything else. Used by
+  -- the generic record schema to separate required from optional
+  -- properties.
+  isOptional :: Proxy.Proxy a -> Bool
+  isOptional _ = False
+
+instance ToSchema Bool where
+  toSchema _ = pure . MkSchema $ Json.object [("type", Json.string "boolean")]
+
+instance ToSchema Text.Text where
+  toSchema _ = pure . MkSchema $ Json.object [("type", Json.string "string")]
+
+instance ToSchema Natural.Natural where
+  toSchema _ =
+    pure . MkSchema $
+      Json.object [("type", Json.string "integer"), ("minimum", Json.integer 0)]
+
+instance (ToSchema a) => ToSchema (Maybe a) where
+  toSchema _ = toSchema (Proxy.Proxy :: Proxy.Proxy a)
+  isOptional _ = True
+
+instance (ToSchema a) => ToSchema [a] where
+  toSchema _ = do
+    MkSchema items <- toSchema (Proxy.Proxy :: Proxy.Proxy a)
+    pure . MkSchema $ Json.object [("type", Json.string "array"), ("items", items)]
+
+instance (ToSchema a) => ToSchema (NonEmpty.NonEmpty a) where
+  toSchema _ = do
+    MkSchema items <- toSchema (Proxy.Proxy :: Proxy.Proxy a)
+    pure . MkSchema $
+      Json.object
+        [("type", Json.string "array"), ("items", items), ("minItems", Json.integer 1)]
+
+-- * Generic schema encoding
+
+-- | Generic JSON Schema encoding. Dispatches between record encoding
+-- (single constructor produces an object schema) and tagged encoding
+-- (sum type produces a @oneOf@ schema with tagged variants).
+type GToSchema :: (Kind.Type -> Kind.Type) -> Kind.Constraint
+class GToSchema f where
+  gToSchema :: Proxy.Proxy f -> SchemaM Schema
+
+instance (GToSchema f) => GToSchema (Generics.M1 Generics.D c f) where
+  gToSchema _ = gToSchema (Proxy.Proxy :: Proxy.Proxy f)
+
+instance (GToSchemaFields f) => GToSchema (Generics.M1 Generics.C c f) where
+  gToSchema _ = do
+    fields <- gToSchemaFields (Proxy.Proxy :: Proxy.Proxy f)
+    let allProps = fmap (\(n, MkSchema s, _) -> (n, s)) fields
+    let reqNames = fmap (\(n, _, _) -> Json.string n) $ filter (\(_, _, r) -> r) fields
+    pure . MkSchema $
+      Json.object
+        [ ("type", Json.string "object"),
+          ("properties", Json.object allProps),
+          ("required", Json.array reqNames),
+          ("additionalProperties", Json.boolean False)
+        ]
+
+instance (GToSchemaSum f, GToSchemaSum g) => GToSchema (f Generics.:+: g) where
+  gToSchema _ = do
+    variants <- gToSchemaSum (Proxy.Proxy :: Proxy.Proxy (f Generics.:+: g))
+    pure . MkSchema $ Json.object [("oneOf", Json.array $ fmap unwrap variants)]
+
+-- | Extract record fields as @(name, schema, required)@ triples.
+type GToSchemaFields :: (Kind.Type -> Kind.Type) -> Kind.Constraint
+class GToSchemaFields f where
+  gToSchemaFields :: Proxy.Proxy f -> SchemaM [(String, Schema, Bool)]
+
+instance
+  (TypeLits.KnownSymbol name, ToSchema a) =>
+  GToSchemaFields (Generics.M1 Generics.S ('Generics.MetaSel ('Just name) su ss ds) (Generics.K1 i a))
+  where
+  gToSchemaFields _ = do
+    s <- toSchema (Proxy.Proxy :: Proxy.Proxy a)
+    let n = TypeLits.symbolVal (Proxy.Proxy :: Proxy.Proxy name)
+    let req = not $ isOptional (Proxy.Proxy :: Proxy.Proxy a)
+    pure [(n, s, req)]
+
+instance (GToSchemaFields f, GToSchemaFields g) => GToSchemaFields (f Generics.:*: g) where
+  gToSchemaFields _ = do
+    l <- gToSchemaFields (Proxy.Proxy :: Proxy.Proxy f)
+    r <- gToSchemaFields (Proxy.Proxy :: Proxy.Proxy g)
+    pure $ l <> r
+
+instance GToSchemaFields Generics.U1 where
+  gToSchemaFields _ = pure []
+
+-- | Tagged encoding for sum type constructors.
+type GToSchemaSum :: (Kind.Type -> Kind.Type) -> Kind.Constraint
+class GToSchemaSum f where
+  gToSchemaSum :: Proxy.Proxy f -> SchemaM [Schema]
+
+instance (GToSchemaSum f, GToSchemaSum g) => GToSchemaSum (f Generics.:+: g) where
+  gToSchemaSum _ = do
+    l <- gToSchemaSum (Proxy.Proxy :: Proxy.Proxy f)
+    r <- gToSchemaSum (Proxy.Proxy :: Proxy.Proxy g)
+    pure $ l <> r
+
+instance
+  (TypeLits.KnownSymbol name) =>
+  GToSchemaSum (Generics.M1 Generics.C ('Generics.MetaCons name fix rec) Generics.U1)
+  where
+  gToSchemaSum _ =
+    let n = TypeLits.symbolVal (Proxy.Proxy :: Proxy.Proxy name)
+     in pure
+          [ MkSchema $
+              Json.object
+                [ ("type", Json.string "object"),
+                  ("properties", Json.object [("type", Json.object [("const", Json.string n)])]),
+                  ("required", Json.array [Json.string "type"]),
+                  ("additionalProperties", Json.boolean False)
+                ]
+          ]
+
+instance
+  (TypeLits.KnownSymbol name, ToSchema a) =>
+  GToSchemaSum (Generics.M1 Generics.C ('Generics.MetaCons name fix rec) (Generics.M1 Generics.S sel (Generics.K1 i a)))
+  where
+  gToSchemaSum _ = do
+    MkSchema valueSchema <- toSchema (Proxy.Proxy :: Proxy.Proxy a)
+    let n = TypeLits.symbolVal (Proxy.Proxy :: Proxy.Proxy name)
+    pure
+      [ MkSchema $
+          Json.object
+            [ ("type", Json.string "object"),
+              ( "properties",
+                Json.object
+                  [ ("type", Json.object [("const", Json.string n)]),
+                    ("value", valueSchema)
+                  ]
+              ),
+              ("required", Json.array [Json.string "type", Json.string "value"]),
+              ("additionalProperties", Json.boolean False)
+            ]
+      ]
+
+instance (GToSchema (Generics.Rep a)) => ToSchema (Generics.Generically a) where
+  toSchema _ = gToSchema (Proxy.Proxy :: Proxy.Proxy (Generics.Rep a))
+
+-- * Tests
+
+spec :: (Applicative m, Monad n) => Spec.Spec m n -> n ()
+spec s = do
+  Spec.named s 'toSchema $ do
+    Spec.it s "Bool schema has type boolean" $ do
+      let (MkSchema v, _) = runSchemaM $ toSchema (Proxy.Proxy :: Proxy.Proxy Bool)
+      Spec.assertEq s v $ Json.object [("type", Json.string "boolean")]
+
+    Spec.it s "Natural schema has type integer with minimum 0" $ do
+      let (MkSchema v, _) = runSchemaM $ toSchema (Proxy.Proxy :: Proxy.Proxy Natural.Natural)
+      Spec.assertEq s v $
+        Json.object [("type", Json.string "integer"), ("minimum", Json.integer 0)]
+
+    Spec.it s "Text schema has type string" $ do
+      let (MkSchema v, _) = runSchemaM $ toSchema (Proxy.Proxy :: Proxy.Proxy Text.Text)
+      Spec.assertEq s v $ Json.object [("type", Json.string "string")]
+
+    Spec.it s "[Bool] schema is array of boolean" $ do
+      let (MkSchema v, _) = runSchemaM $ toSchema (Proxy.Proxy :: Proxy.Proxy [Bool])
+      Spec.assertEq s v $
+        Json.object
+          [ ("type", Json.string "array"),
+            ("items", Json.object [("type", Json.string "boolean")])
+          ]
+
+    Spec.it s "NonEmpty Natural schema has minItems 1" $ do
+      let (MkSchema v, _) = runSchemaM $ toSchema (Proxy.Proxy :: Proxy.Proxy (NonEmpty.NonEmpty Natural.Natural))
+      Spec.assertEq s v $
+        Json.object
+          [ ("type", Json.string "array"),
+            ("items", Json.object [("type", Json.string "integer"), ("minimum", Json.integer 0)]),
+            ("minItems", Json.integer 1)
+          ]
+
+    Spec.it s "Maybe is optional" $ do
+      Spec.assertEq s (isOptional (Proxy.Proxy :: Proxy.Proxy (Maybe Bool))) True
+
+    Spec.it s "Bool is not optional" $ do
+      Spec.assertEq s (isOptional (Proxy.Proxy :: Proxy.Proxy Bool)) False
+
+    Spec.it s "Maybe strips to inner schema" $ do
+      let (MkSchema v, _) = runSchemaM $ toSchema (Proxy.Proxy :: Proxy.Proxy (Maybe Bool))
+      Spec.assertEq s v $ Json.object [("type", Json.string "boolean")]
+
+    Spec.it s "define returns a $ref" $ do
+      let (MkSchema v, _) =
+            runSchemaM $
+              define "myBool" $
+                toSchema (Proxy.Proxy :: Proxy.Proxy Bool)
+      Spec.assertEq s v $ Json.object [("$ref", Json.string "#/$defs/myBool")]
+
+    Spec.it s "define accumulates the definition" $ do
+      let (_, defs) =
+            runSchemaM $
+              define "myBool" $
+                toSchema (Proxy.Proxy :: Proxy.Proxy Bool)
+      Spec.assertEq s defs [("myBool", Json.object [("type", Json.string "boolean")])]

--- a/source/library/Scrod/TestSuite/All.hs
+++ b/source/library/Scrod/TestSuite/All.hs
@@ -36,6 +36,7 @@ import qualified Scrod.Json.Number
 import qualified Scrod.Json.Object
 import qualified Scrod.Json.Pair
 import qualified Scrod.Json.String
+import qualified Scrod.Json.ToSchema
 import qualified Scrod.Json.Value
 import qualified Scrod.JsonPointer.Evaluate
 import qualified Scrod.JsonPointer.Pointer
@@ -93,6 +94,7 @@ spec s = do
   Scrod.Json.Object.spec s
   Scrod.Json.Pair.spec s
   Scrod.Json.String.spec s
+  Scrod.Json.ToSchema.spec s
   Scrod.Json.Value.spec s
   Scrod.JsonPointer.Evaluate.spec s
   Scrod.JsonPointer.Pointer.spec s


### PR DESCRIPTION
## Summary

Fixes #124.

- Adds `Scrod.Json.ToSchema` with a `ToSchema` type class for generating JSON Schema descriptions of types, paralleling `ToJson`. Uses an `Accum` monad (`SchemaM`) to accumulate named `$defs` entries for schema references.
- Adds `Scrod.Convert.ToSchema` with concrete instances for all core types: `deriving via` for newtypes, `Generically` for records/enums/sums, and hand-written instances for `Module`, `Doc` (recursive, uses `$ref` for self-references), and `Level`.
- Includes a `define` helper for registering named schema definitions and returning `$ref` pointers.
- Generic deriving correctly separates required vs optional fields based on `Maybe` (via `isOptional`).
- 10 new unit tests covering base instances, `Maybe` optionality, and `define`.

## Test plan

- [x] `cabal build` succeeds
- [x] `cabal build --flags=pedantic` succeeds (no warnings)
- [x] `cabal test --test-options='--hide-successes'` — all 881 tests pass
- [x] `ormolu --mode check` passes
- [x] `cabal-gild --mode check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)