### PR TITLE
Replace hand-written ToJsonSchema with ToSchema type class

### DIFF
--- a/scrod.cabal
+++ b/scrod.cabal
@@ -182,11 +182,11 @@ library
     Scrod.Json.Pair
     Scrod.Json.String
     Scrod.Json.ToJson
-    Scrod.Schema
     Scrod.Json.Value
     Scrod.JsonPointer.Evaluate
     Scrod.JsonPointer.Pointer
     Scrod.JsonPointer.Token
+    Scrod.Schema
     Scrod.Spec
     Scrod.TestSuite.All
     Scrod.TestSuite.Integration

--- a/scrod.cabal
+++ b/scrod.cabal
@@ -182,7 +182,7 @@ library
     Scrod.Json.Pair
     Scrod.Json.String
     Scrod.Json.ToJson
-    Scrod.Json.ToSchema
+    Scrod.Schema
     Scrod.Json.Value
     Scrod.JsonPointer.Evaluate
     Scrod.JsonPointer.Pointer

--- a/source/library/Scrod/Convert/ToJson.hs
+++ b/source/library/Scrod/Convert/ToJson.hs
@@ -9,10 +9,7 @@
 -- @deriving via 'Generics.Generically'@ to get instances derived
 -- generically. Other types have hand-written instances. Import this
 -- module to bring all instances into scope.
-module Scrod.Convert.ToJson
-  ( module Scrod.Json.ToJson,
-  )
-where
+module Scrod.Convert.ToJson where
 
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Map as Map

--- a/source/library/Scrod/Convert/ToJson.hs
+++ b/source/library/Scrod/Convert/ToJson.hs
@@ -51,134 +51,134 @@ import qualified Scrod.Core.Table as Table
 import qualified Scrod.Core.TableCell as TableCell
 import qualified Scrod.Core.Version as Version
 import qualified Scrod.Core.Warning as Warning
-import Scrod.Json.ToJson (ToJson (toJson))
+import qualified Scrod.Json.ToJson as ToJson
 import qualified Scrod.Json.Value as Json
 
 -- Simple newtype wrappers use @deriving via@ to get their instances
 -- from the underlying type.
 
-deriving via Text.Text instance ToJson Category.Category
+deriving via Text.Text instance ToJson.ToJson Category.Category
 
-deriving via Natural.Natural instance ToJson Column.Column
+deriving via Natural.Natural instance ToJson.ToJson Column.Column
 
-deriving via Text.Text instance ToJson Extension.Extension
+deriving via Text.Text instance ToJson.ToJson Extension.Extension
 
-deriving via Text.Text instance ToJson ItemName.ItemName
+deriving via Text.Text instance ToJson.ToJson ItemName.ItemName
 
-deriving via Natural.Natural instance ToJson ItemKey.ItemKey
+deriving via Natural.Natural instance ToJson.ToJson ItemKey.ItemKey
 
-deriving via Text.Text instance ToJson Language.Language
+deriving via Text.Text instance ToJson.ToJson Language.Language
 
-deriving via Natural.Natural instance ToJson Line.Line
+deriving via Natural.Natural instance ToJson.ToJson Line.Line
 
-deriving via Text.Text instance ToJson ModuleName.ModuleName
+deriving via Text.Text instance ToJson.ToJson ModuleName.ModuleName
 
-deriving via Text.Text instance ToJson PackageName.PackageName
+deriving via Text.Text instance ToJson.ToJson PackageName.PackageName
 
-deriving via Header.Header Doc.Doc instance ToJson Section.Section
+deriving via Header.Header Doc.Doc instance ToJson.ToJson Section.Section
 
-deriving via NonEmpty.NonEmpty Natural.Natural instance ToJson Version.Version
+deriving via NonEmpty.NonEmpty Natural.Natural instance ToJson.ToJson Version.Version
 
 -- Record types, enum types, and tagged sum types use
 -- @Generics.Generically@ to derive their instances generically.
 
-deriving via Generics.Generically Example.Example instance ToJson Example.Example
+deriving via Generics.Generically Example.Example instance ToJson.ToJson Example.Example
 
-deriving via Generics.Generically ExportIdentifier.ExportIdentifier instance ToJson ExportIdentifier.ExportIdentifier
+deriving via Generics.Generically ExportIdentifier.ExportIdentifier instance ToJson.ToJson ExportIdentifier.ExportIdentifier
 
-deriving via Generics.Generically ExportName.ExportName instance ToJson ExportName.ExportName
+deriving via Generics.Generically ExportName.ExportName instance ToJson.ToJson ExportName.ExportName
 
-deriving via Generics.Generically (Header.Header doc) instance (ToJson doc) => ToJson (Header.Header doc)
+deriving via Generics.Generically (Header.Header doc) instance (ToJson.ToJson doc) => ToJson.ToJson (Header.Header doc)
 
-deriving via Generics.Generically (Hyperlink.Hyperlink doc) instance (ToJson doc) => ToJson (Hyperlink.Hyperlink doc)
+deriving via Generics.Generically (Hyperlink.Hyperlink doc) instance (ToJson.ToJson doc) => ToJson.ToJson (Hyperlink.Hyperlink doc)
 
-deriving via Generics.Generically Identifier.Identifier instance ToJson Identifier.Identifier
+deriving via Generics.Generically Identifier.Identifier instance ToJson.ToJson Identifier.Identifier
 
-deriving via Generics.Generically Import.Import instance ToJson Import.Import
+deriving via Generics.Generically Import.Import instance ToJson.ToJson Import.Import
 
-deriving via Generics.Generically Item.Item instance ToJson Item.Item
+deriving via Generics.Generically Item.Item instance ToJson.ToJson Item.Item
 
-deriving via Generics.Generically (Located.Located a) instance (ToJson a) => ToJson (Located.Located a)
+deriving via Generics.Generically (Located.Located a) instance (ToJson.ToJson a) => ToJson.ToJson (Located.Located a)
 
-deriving via Generics.Generically Location.Location instance ToJson Location.Location
+deriving via Generics.Generically Location.Location instance ToJson.ToJson Location.Location
 
-deriving via Generics.Generically (ModLink.ModLink doc) instance (ToJson doc) => ToJson (ModLink.ModLink doc)
+deriving via Generics.Generically (ModLink.ModLink doc) instance (ToJson.ToJson doc) => ToJson.ToJson (ModLink.ModLink doc)
 
-deriving via Generics.Generically Picture.Picture instance ToJson Picture.Picture
+deriving via Generics.Generically Picture.Picture instance ToJson.ToJson Picture.Picture
 
-deriving via Generics.Generically Since.Since instance ToJson Since.Since
+deriving via Generics.Generically Since.Since instance ToJson.ToJson Since.Since
 
-deriving via Generics.Generically Subordinates.Subordinates instance ToJson Subordinates.Subordinates
+deriving via Generics.Generically Subordinates.Subordinates instance ToJson.ToJson Subordinates.Subordinates
 
-deriving via Generics.Generically (Table.Table doc) instance (ToJson doc) => ToJson (Table.Table doc)
+deriving via Generics.Generically (Table.Table doc) instance (ToJson.ToJson doc) => ToJson.ToJson (Table.Table doc)
 
-deriving via Generics.Generically (TableCell.Cell doc) instance (ToJson doc) => ToJson (TableCell.Cell doc)
+deriving via Generics.Generically (TableCell.Cell doc) instance (ToJson.ToJson doc) => ToJson.ToJson (TableCell.Cell doc)
 
-deriving via Generics.Generically Warning.Warning instance ToJson Warning.Warning
+deriving via Generics.Generically Warning.Warning instance ToJson.ToJson Warning.Warning
 
-deriving via Generics.Generically ExportNameKind.ExportNameKind instance ToJson ExportNameKind.ExportNameKind
+deriving via Generics.Generically ExportNameKind.ExportNameKind instance ToJson.ToJson ExportNameKind.ExportNameKind
 
-deriving via Generics.Generically ItemKind.ItemKind instance ToJson ItemKind.ItemKind
+deriving via Generics.Generically ItemKind.ItemKind instance ToJson.ToJson ItemKind.ItemKind
 
-deriving via Generics.Generically Namespace.Namespace instance ToJson Namespace.Namespace
+deriving via Generics.Generically Namespace.Namespace instance ToJson.ToJson Namespace.Namespace
 
-deriving via Generics.Generically Export.Export instance ToJson Export.Export
+deriving via Generics.Generically Export.Export instance ToJson.ToJson Export.Export
 
 -- Hand-written instances for types that require special encoding.
 
-instance ToJson Module.Module where
+instance ToJson.ToJson Module.Module where
   toJson m =
     Json.object
       . filter (\(_, v) -> v /= Json.null)
-      $ [ ("version", toJson $ Module.version m),
-          ("language", toJson $ Module.language m),
+      $ [ ("version", ToJson.toJson $ Module.version m),
+          ("language", ToJson.toJson $ Module.language m),
           ("extensions", extensionsToJson $ Module.extensions m),
-          ("documentation", toJson $ Module.documentation m),
-          ("since", toJson $ Module.since m),
-          ("signature", toJson $ Module.signature m),
-          ("name", toJson $ Module.name m),
-          ("warning", toJson $ Module.warning m),
-          ("exports", toJson $ Module.exports m),
-          ("imports", toJson $ Module.imports m),
-          ("items", toJson $ Module.items m)
+          ("documentation", ToJson.toJson $ Module.documentation m),
+          ("since", ToJson.toJson $ Module.since m),
+          ("signature", ToJson.toJson $ Module.signature m),
+          ("name", ToJson.toJson $ Module.name m),
+          ("warning", ToJson.toJson $ Module.warning m),
+          ("exports", ToJson.toJson $ Module.exports m),
+          ("imports", ToJson.toJson $ Module.imports m),
+          ("items", ToJson.toJson $ Module.items m)
         ]
 
 extensionsToJson :: Map.Map Extension.Extension Bool -> Json.Value
 extensionsToJson =
   Json.object
-    . fmap (\(k, v) -> (Text.unpack $ Extension.unwrap k, toJson v))
+    . fmap (\(k, v) -> (Text.unpack $ Extension.unwrap k, ToJson.toJson v))
     . Map.toList
 
-instance ToJson Doc.Doc where
+instance ToJson.ToJson Doc.Doc where
   toJson doc = case doc of
     Doc.Empty -> Json.tagged "Empty" Json.null
-    Doc.Append a b -> Json.tagged "Append" $ Json.arrayOf toJson [a, b]
+    Doc.Append a b -> Json.tagged "Append" $ Json.arrayOf ToJson.toJson [a, b]
     Doc.String t -> Json.tagged "String" $ Json.text t
-    Doc.Paragraph d -> Json.tagged "Paragraph" $ toJson d
-    Doc.Identifier i -> Json.tagged "Identifier" $ toJson i
-    Doc.Module ml -> Json.tagged "Module" $ toJson ml
-    Doc.Emphasis d -> Json.tagged "Emphasis" $ toJson d
-    Doc.Monospaced d -> Json.tagged "Monospaced" $ toJson d
-    Doc.Bold d -> Json.tagged "Bold" $ toJson d
-    Doc.UnorderedList ds -> Json.tagged "UnorderedList" $ toJson ds
+    Doc.Paragraph d -> Json.tagged "Paragraph" $ ToJson.toJson d
+    Doc.Identifier i -> Json.tagged "Identifier" $ ToJson.toJson i
+    Doc.Module ml -> Json.tagged "Module" $ ToJson.toJson ml
+    Doc.Emphasis d -> Json.tagged "Emphasis" $ ToJson.toJson d
+    Doc.Monospaced d -> Json.tagged "Monospaced" $ ToJson.toJson d
+    Doc.Bold d -> Json.tagged "Bold" $ ToJson.toJson d
+    Doc.UnorderedList ds -> Json.tagged "UnorderedList" $ ToJson.toJson ds
     Doc.OrderedList items ->
       Json.tagged "OrderedList" $
-        Json.arrayOf (\(n, d) -> Json.array [Json.integral n, toJson d]) items
+        Json.arrayOf (\(n, d) -> Json.array [Json.integral n, ToJson.toJson d]) items
     Doc.DefList defs ->
       Json.tagged "DefList" $
-        Json.arrayOf (\(t, d) -> Json.arrayOf toJson [t, d]) defs
-    Doc.CodeBlock d -> Json.tagged "CodeBlock" $ toJson d
-    Doc.Hyperlink h -> Json.tagged "Hyperlink" $ toJson h
-    Doc.Pic p -> Json.tagged "Pic" $ toJson p
+        Json.arrayOf (\(t, d) -> Json.arrayOf ToJson.toJson [t, d]) defs
+    Doc.CodeBlock d -> Json.tagged "CodeBlock" $ ToJson.toJson d
+    Doc.Hyperlink h -> Json.tagged "Hyperlink" $ ToJson.toJson h
+    Doc.Pic p -> Json.tagged "Pic" $ ToJson.toJson p
     Doc.MathInline t -> Json.tagged "MathInline" $ Json.text t
     Doc.MathDisplay t -> Json.tagged "MathDisplay" $ Json.text t
     Doc.AName t -> Json.tagged "AName" $ Json.text t
     Doc.Property t -> Json.tagged "Property" $ Json.text t
-    Doc.Examples es -> Json.tagged "Examples" $ toJson es
-    Doc.Header h -> Json.tagged "Header" $ toJson h
-    Doc.Table t -> Json.tagged "Table" $ toJson t
+    Doc.Examples es -> Json.tagged "Examples" $ ToJson.toJson es
+    Doc.Header h -> Json.tagged "Header" $ ToJson.toJson h
+    Doc.Table t -> Json.tagged "Table" $ ToJson.toJson t
 
-instance ToJson Level.Level where
+instance ToJson.ToJson Level.Level where
   toJson l = Json.integer $ case l of
     Level.One -> 1
     Level.Two -> 2

--- a/source/library/Scrod/Convert/ToJsonSchema.hs
+++ b/source/library/Scrod/Convert/ToJsonSchema.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
 
 -- | Generate a JSON Schema describing the output of 'ToJson.toJson'.
@@ -9,6 +8,7 @@
 -- prepended and appended.
 module Scrod.Convert.ToJsonSchema where
 
+import qualified Data.Proxy as Proxy
 import Scrod.Convert.ToSchema ()
 import qualified Scrod.Core.Module as Module
 import qualified Scrod.Extra.Builder as Builder
@@ -35,7 +35,7 @@ moduleSchema =
   let (schema, defs) =
         ToSchema.runSchemaM $
           ToSchema.toSchema
-            (undefined :: proxy Module.Module)
+            (Proxy.Proxy :: Proxy.Proxy Module.Module)
    in case ToSchema.unwrap schema of
         Json.Object (Object.MkObject bodyPairs) ->
           Json.Object . Object.MkObject $

--- a/source/library/Scrod/Convert/ToJsonSchema.hs
+++ b/source/library/Scrod/Convert/ToJsonSchema.hs
@@ -1,13 +1,20 @@
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
 
 -- | Generate a JSON Schema describing the output of 'ToJson.toJson'.
 --
--- Produces a JSON Schema (2020-12) as a 'Json.Value'. The root schema
--- describes the module object, and all sub-schemas are defined in @$defs@.
+-- Produces a JSON Schema (2020-12) as a 'Json.Value'. The root schema is
+-- generated from the 'ToSchema.ToSchema' type class instance for
+-- 'Module.Module', with root-level metadata and accumulated @$defs@
+-- prepended and appended.
 module Scrod.Convert.ToJsonSchema where
 
+import Scrod.Convert.ToSchema ()
+import qualified Scrod.Core.Module as Module
 import qualified Scrod.Extra.Builder as Builder
 import qualified Scrod.Extra.Parsec as Parsec
+import qualified Scrod.Json.Object as Object
+import qualified Scrod.Json.ToSchema as ToSchema
 import qualified Scrod.Json.Value as Json
 import qualified Scrod.JsonPointer.Evaluate as Pointer
 import qualified Scrod.JsonPointer.Pointer as Pointer
@@ -17,433 +24,29 @@ import qualified Scrod.Spec as Spec
 toJsonSchema :: Json.Value
 toJsonSchema = moduleSchema
 
--- * Helpers
-
--- | Reference a definition in @$defs@.
-ref :: String -> Json.Value
-ref name = Json.object [("$ref", Json.string $ "#/$defs/" <> name)]
-
--- | Create a tagged-object variant for use in @oneOf@.
---
--- This mirrors the runtime @{"type": tag, "value": ...}@ pattern produced
--- by 'Json.tagged'.
-taggedVariant :: String -> Json.Value -> Json.Value
-taggedVariant tag valueSchema =
-  Json.object
-    [ ("type", Json.string "object"),
-      ( "properties",
-        Json.object
-          [ ("type", Json.object [("const", Json.string tag)]),
-            ("value", valueSchema)
-          ]
-      ),
-      ("required", Json.array [Json.string "type", Json.string "value"]),
-      ("additionalProperties", Json.boolean False)
-    ]
-
--- | Create an object schema with all properties required and no additional
--- properties.
-objectSchema :: [(String, Json.Value)] -> Json.Value
-objectSchema props =
-  Json.object
-    [ ("type", Json.string "object"),
-      ("properties", Json.object props),
-      ("required", Json.array $ fmap (Json.string . fst) props),
-      ("additionalProperties", Json.boolean False)
-    ]
-
--- | Create an object schema where some properties are required and others
--- are optional (omitted when null).
-objectSchemaOpt :: [(String, Json.Value)] -> [(String, Json.Value)] -> Json.Value
-objectSchemaOpt required optional =
-  Json.object
-    [ ("type", Json.string "object"),
-      ("properties", Json.object (required <> optional)),
-      ("required", Json.array $ fmap (Json.string . fst) required),
-      ("additionalProperties", Json.boolean False)
-    ]
-
--- | Create a tagged-object variant for a nullary constructor (no @value@
--- field).
-taggedNullary :: String -> Json.Value
-taggedNullary tag =
-  Json.object
-    [ ("type", Json.string "object"),
-      ( "properties",
-        Json.object
-          [ ("type", Json.object [("const", Json.string tag)])
-          ]
-      ),
-      ("required", Json.array [Json.string "type"]),
-      ("additionalProperties", Json.boolean False)
-    ]
-
--- | Create a fixed-length array (tuple) schema.
-tupleSchema :: [Json.Value] -> Json.Value
-tupleSchema items =
-  Json.object
-    [ ("type", Json.string "array"),
-      ("prefixItems", Json.array items),
-      ("items", Json.boolean False),
-      ("minItems", Json.integral $ length items),
-      ("maxItems", Json.integral $ length items)
-    ]
-
--- * Root
-
 -- | Schema for the top-level module object.
+--
+-- Runs the 'ToSchema.ToSchema' instance for 'Module.Module' in
+-- 'ToSchema.SchemaM', extracts the resulting object schema, and wraps
+-- it with JSON Schema metadata (@$schema@, @$id@, @title@,
+-- @description@) and any accumulated @$defs@.
 moduleSchema :: Json.Value
 moduleSchema =
-  Json.object
-    [ ("$schema", Json.string "https://json-schema.org/draft/2020-12/schema"),
-      ("$id", Json.string "https://scrod.fyi/schema.json"),
-      ("title", Json.string "Scrod"),
-      ("description", Json.string "JSON output of the Scrod Haskell documentation tool."),
-      ("type", Json.string "object"),
-      ( "properties",
-        Json.object
-          [ ("version", ref "version"),
-            ("language", ref "language"),
-            ("extensions", ref "extensions"),
-            ("documentation", ref "doc"),
-            ("since", ref "since"),
-            ("signature", Json.object [("type", Json.string "boolean")]),
-            ("name", ref "locatedModuleName"),
-            ("warning", ref "warning"),
-            ("exports", Json.object [("type", Json.string "array"), ("items", ref "export")]),
-            ("imports", Json.object [("type", Json.string "array"), ("items", ref "import")]),
-            ("items", Json.object [("type", Json.string "array"), ("items", ref "locatedItem")])
-          ]
-      ),
-      ( "required",
-        Json.array
-          [ Json.string "version",
-            Json.string "extensions",
-            Json.string "documentation",
-            Json.string "signature",
-            Json.string "imports",
-            Json.string "items"
-          ]
-      ),
-      ("additionalProperties", Json.boolean False),
-      ("$defs", defs)
-    ]
-
--- * Definitions
-
-defs :: Json.Value
-defs =
-  Json.object
-    [ ("version", versionSchema),
-      ("language", languageSchema),
-      ("extensions", extensionsSchema),
-      ("doc", docSchema),
-      ("since", sinceSchema),
-      ("locatedModuleName", locatedModuleNameSchema),
-      ("location", locationSchema),
-      ("warning", warningSchema),
-      ("export", exportSchema),
-      ("import", importSchema),
-      ("locatedItem", locatedItemSchema),
-      ("item", itemSchema),
-      ("itemKind", itemKindSchema),
-      ("exportIdentifier", exportIdentifierSchema),
-      ("exportName", exportNameSchema),
-      ("exportNameKind", exportNameKindSchema),
-      ("subordinates", subordinatesSchema),
-      ("identifier", identifierSchema),
-      ("namespace", namespaceSchema),
-      ("example", exampleSchema),
-      ("header", headerSchema),
-      ("hyperlink", hyperlinkSchema),
-      ("modLink", modLinkSchema),
-      ("picture", pictureSchema),
-      ("table", tableSchema),
-      ("cell", cellSchema)
-    ]
-
--- | @[integer, ...]@ with at least one element. Corresponds to
--- 'Scrod.Core.Version.Version' (a @NonEmpty Natural@).
-versionSchema :: Json.Value
-versionSchema =
-  Json.object
-    [ ("type", Json.string "array"),
-      ("items", Json.object [("type", Json.string "integer"), ("minimum", Json.integer 0)]),
-      ("minItems", Json.integer 1)
-    ]
-
--- | A Haskell language edition string (e.g. @"Haskell2010"@, @"GHC2024"@).
-languageSchema :: Json.Value
-languageSchema = Json.object [("type", Json.string "string")]
-
--- | An object mapping extension names to booleans.
-extensionsSchema :: Json.Value
-extensionsSchema =
-  Json.object
-    [ ("type", Json.string "object"),
-      ("additionalProperties", Json.object [("type", Json.string "boolean")])
-    ]
-
--- | The documentation AST. This is a tagged union using @{"type": ...,
--- "value": ...}@ and is recursive.
-docSchema :: Json.Value
-docSchema =
-  Json.object
-    [ ( "oneOf",
-        Json.array
-          [ taggedVariant "Empty" $ Json.object [("type", Json.string "null")],
-            taggedVariant "Append" $
-              Json.object
-                [ ("type", Json.string "array"),
-                  ("items", ref "doc"),
-                  ("minItems", Json.integer 2),
-                  ("maxItems", Json.integer 2)
-                ],
-            taggedVariant "String" $ Json.object [("type", Json.string "string")],
-            taggedVariant "Paragraph" $ ref "doc",
-            taggedVariant "Identifier" $ ref "identifier",
-            taggedVariant "Module" $ ref "modLink",
-            taggedVariant "Emphasis" $ ref "doc",
-            taggedVariant "Monospaced" $ ref "doc",
-            taggedVariant "Bold" $ ref "doc",
-            taggedVariant "UnorderedList" $
-              Json.object
-                [ ("type", Json.string "array"),
-                  ("items", ref "doc")
-                ],
-            taggedVariant "OrderedList" $
-              Json.object
-                [ ("type", Json.string "array"),
-                  ("items", tupleSchema [Json.object [("type", Json.string "integer")], ref "doc"])
-                ],
-            taggedVariant "DefList" $
-              Json.object
-                [ ("type", Json.string "array"),
-                  ("items", tupleSchema [ref "doc", ref "doc"])
-                ],
-            taggedVariant "CodeBlock" $ ref "doc",
-            taggedVariant "Hyperlink" $ ref "hyperlink",
-            taggedVariant "Pic" $ ref "picture",
-            taggedVariant "MathInline" $ Json.object [("type", Json.string "string")],
-            taggedVariant "MathDisplay" $ Json.object [("type", Json.string "string")],
-            taggedVariant "AName" $ Json.object [("type", Json.string "string")],
-            taggedVariant "Property" $ Json.object [("type", Json.string "string")],
-            taggedVariant "Examples" $
-              Json.object
-                [ ("type", Json.string "array"),
-                  ("items", ref "example")
-                ],
-            taggedVariant "Header" $ ref "header",
-            taggedVariant "Table" $ ref "table"
-          ]
-      )
-    ]
-
-sinceSchema :: Json.Value
-sinceSchema =
-  objectSchemaOpt
-    [("version", ref "version")]
-    [("package", Json.object [("type", Json.string "string")])]
-
-locatedModuleNameSchema :: Json.Value
-locatedModuleNameSchema =
-  objectSchema
-    [ ("location", ref "location"),
-      ("value", Json.object [("type", Json.string "string")])
-    ]
-
-locationSchema :: Json.Value
-locationSchema =
-  objectSchema
-    [ ("line", Json.object [("type", Json.string "integer"), ("minimum", Json.integer 1)]),
-      ("column", Json.object [("type", Json.string "integer"), ("minimum", Json.integer 1)])
-    ]
-
-warningSchema :: Json.Value
-warningSchema =
-  objectSchema
-    [ ("category", Json.object [("type", Json.string "string")]),
-      ("value", Json.object [("type", Json.string "string")])
-    ]
-
--- | Tagged union: @Identifier@, @Group@, @Doc@, @DocNamed@.
-exportSchema :: Json.Value
-exportSchema =
-  Json.object
-    [ ( "oneOf",
-        Json.array
-          [ taggedVariant "Identifier" $ ref "exportIdentifier",
-            taggedVariant "Group" $ ref "header",
-            taggedVariant "Doc" $ ref "doc",
-            taggedVariant "DocNamed" $ Json.object [("type", Json.string "string")]
-          ]
-      )
-    ]
-
-importSchema :: Json.Value
-importSchema =
-  objectSchemaOpt
-    [("name", Json.object [("type", Json.string "string")])]
-    [ ("package", Json.object [("type", Json.string "string")]),
-      ("alias", Json.object [("type", Json.string "string")])
-    ]
-
-locatedItemSchema :: Json.Value
-locatedItemSchema =
-  objectSchema
-    [ ("location", ref "location"),
-      ("value", ref "item")
-    ]
-
-itemSchema :: Json.Value
-itemSchema =
-  objectSchemaOpt
-    [ ("key", Json.object [("type", Json.string "integer"), ("minimum", Json.integer 0)]),
-      ("kind", ref "itemKind"),
-      ("documentation", ref "doc")
-    ]
-    [ ("parentKey", Json.object [("type", Json.string "integer"), ("minimum", Json.integer 0)]),
-      ("name", Json.object [("type", Json.string "string")]),
-      ("signature", Json.object [("type", Json.string "string")])
-    ]
-
-itemKindSchema :: Json.Value
-itemKindSchema =
-  Json.object
-    [ ( "oneOf",
-        Json.array $
-          fmap
-            taggedNullary
-            [ "Annotation",
-              "Class",
-              "ClassInstance",
-              "ClassMethod",
-              "ClosedTypeFamily",
-              "DataConstructor",
-              "DataFamily",
-              "DataFamilyInstance",
-              "DataType",
-              "Default",
-              "DerivedInstance",
-              "FixitySignature",
-              "ForeignExport",
-              "ForeignImport",
-              "Function",
-              "GADTConstructor",
-              "InlineSignature",
-              "Newtype",
-              "OpenTypeFamily",
-              "PatternBinding",
-              "PatternSynonym",
-              "RecordField",
-              "Rule",
-              "SpecialiseSignature",
-              "Splice",
-              "StandaloneDeriving",
-              "StandaloneKindSig",
-              "TypeData",
-              "TypeFamilyInstance",
-              "TypeSynonym"
+  let (schema, defs) =
+        ToSchema.runSchemaM $
+          ToSchema.toSchema
+            (undefined :: proxy Module.Module)
+   in case ToSchema.unwrap schema of
+        Json.Object (Object.MkObject bodyPairs) ->
+          Json.Object . Object.MkObject $
+            [ Json.pair "$schema" (Json.string "https://json-schema.org/draft/2020-12/schema"),
+              Json.pair "$id" (Json.string "https://scrod.fyi/schema.json"),
+              Json.pair "title" (Json.string "Scrod"),
+              Json.pair "description" (Json.string "JSON output of the Scrod Haskell documentation tool.")
             ]
-      )
-    ]
-
-exportIdentifierSchema :: Json.Value
-exportIdentifierSchema =
-  objectSchemaOpt
-    [("name", ref "exportName")]
-    [ ("subordinates", ref "subordinates"),
-      ("warning", ref "warning"),
-      ("doc", ref "doc")
-    ]
-
-exportNameSchema :: Json.Value
-exportNameSchema =
-  objectSchemaOpt
-    [("name", Json.object [("type", Json.string "string")])]
-    [("kind", ref "exportNameKind")]
-
-exportNameKindSchema :: Json.Value
-exportNameKindSchema =
-  Json.object
-    [ ( "oneOf",
-        Json.array $
-          fmap
-            taggedNullary
-            ["Module", "Pattern", "Type"]
-      )
-    ]
-
-subordinatesSchema :: Json.Value
-subordinatesSchema =
-  objectSchema
-    [ ("wildcard", Json.object [("type", Json.string "boolean")]),
-      ("explicit", Json.object [("type", Json.string "array"), ("items", ref "exportName")])
-    ]
-
-identifierSchema :: Json.Value
-identifierSchema =
-  objectSchemaOpt
-    [("value", Json.object [("type", Json.string "string")])]
-    [("namespace", ref "namespace")]
-
-namespaceSchema :: Json.Value
-namespaceSchema =
-  Json.object
-    [ ( "oneOf",
-        Json.array $
-          fmap
-            taggedNullary
-            ["Type", "Value"]
-      )
-    ]
-
-exampleSchema :: Json.Value
-exampleSchema =
-  objectSchema
-    [ ("expression", Json.object [("type", Json.string "string")]),
-      ("result", Json.object [("type", Json.string "array"), ("items", Json.object [("type", Json.string "string")])])
-    ]
-
-headerSchema :: Json.Value
-headerSchema =
-  objectSchema
-    [ ("level", Json.object [("type", Json.string "integer"), ("minimum", Json.integer 1), ("maximum", Json.integer 6)]),
-      ("title", ref "doc")
-    ]
-
-hyperlinkSchema :: Json.Value
-hyperlinkSchema =
-  objectSchemaOpt
-    [("url", Json.object [("type", Json.string "string")])]
-    [("label", ref "doc")]
-
-modLinkSchema :: Json.Value
-modLinkSchema =
-  objectSchemaOpt
-    [("name", Json.object [("type", Json.string "string")])]
-    [("label", ref "doc")]
-
-pictureSchema :: Json.Value
-pictureSchema =
-  objectSchemaOpt
-    [("uri", Json.object [("type", Json.string "string")])]
-    [("title", Json.object [("type", Json.string "string")])]
-
-tableSchema :: Json.Value
-tableSchema =
-  objectSchema
-    [ ("headerRows", Json.object [("type", Json.string "array"), ("items", Json.object [("type", Json.string "array"), ("items", ref "cell")])]),
-      ("bodyRows", Json.object [("type", Json.string "array"), ("items", Json.object [("type", Json.string "array"), ("items", ref "cell")])])
-    ]
-
-cellSchema :: Json.Value
-cellSchema =
-  objectSchema
-    [ ("colspan", Json.object [("type", Json.string "integer"), ("minimum", Json.integer 1)]),
-      ("rowspan", Json.object [("type", Json.string "integer"), ("minimum", Json.integer 1)]),
-      ("contents", ref "doc")
-    ]
+              <> bodyPairs
+              <> [Json.pair "$defs" (Json.object defs)]
+        _ -> Json.null
 
 -- * Tests
 
@@ -466,14 +69,11 @@ spec s = do
     Spec.it s "defines doc" $ do
       at s "/$defs/doc/oneOf" Json.null
 
-    Spec.it s "defines version" $ do
-      at s "/$defs/version/type" $ Json.string "array"
+    Spec.it s "has version property" $ do
+      at s "/properties/version/type" $ Json.string "array"
 
-    Spec.it s "defines itemKind" $ do
-      at s "/$defs/itemKind/oneOf" Json.null
-
-    Spec.it s "defines location" $ do
-      at s "/$defs/location/type" $ Json.string "object"
+    Spec.it s "has items property" $ do
+      at s "/properties/items/type" $ Json.string "array"
 
 -- | Assert that a JSON Pointer path resolves to the expected value in the
 -- schema.

--- a/source/library/Scrod/Convert/ToJsonSchema.hs
+++ b/source/library/Scrod/Convert/ToJsonSchema.hs
@@ -14,10 +14,10 @@ import qualified Scrod.Core.Module as Module
 import qualified Scrod.Extra.Builder as Builder
 import qualified Scrod.Extra.Parsec as Parsec
 import qualified Scrod.Json.Object as Object
-import qualified Scrod.Schema as ToSchema
 import qualified Scrod.Json.Value as Json
 import qualified Scrod.JsonPointer.Evaluate as Pointer
 import qualified Scrod.JsonPointer.Pointer as Pointer
+import qualified Scrod.Schema as ToSchema
 import qualified Scrod.Spec as Spec
 
 -- | See 'moduleSchema'.

--- a/source/library/Scrod/Convert/ToJsonSchema.hs
+++ b/source/library/Scrod/Convert/ToJsonSchema.hs
@@ -14,7 +14,7 @@ import qualified Scrod.Core.Module as Module
 import qualified Scrod.Extra.Builder as Builder
 import qualified Scrod.Extra.Parsec as Parsec
 import qualified Scrod.Json.Object as Object
-import qualified Scrod.Json.ToSchema as ToSchema
+import qualified Scrod.Schema as ToSchema
 import qualified Scrod.Json.Value as Json
 import qualified Scrod.JsonPointer.Evaluate as Pointer
 import qualified Scrod.JsonPointer.Pointer as Pointer

--- a/source/library/Scrod/Convert/ToSchema.hs
+++ b/source/library/Scrod/Convert/ToSchema.hs
@@ -10,7 +10,7 @@
 -- generically. Other types have hand-written instances. Import this
 -- module to bring all instances into scope.
 module Scrod.Convert.ToSchema
-  ( module Scrod.Json.ToSchema,
+  ( module Scrod.Schema,
   )
 where
 
@@ -54,8 +54,8 @@ import qualified Scrod.Core.Table as Table
 import qualified Scrod.Core.TableCell as TableCell
 import qualified Scrod.Core.Version as Version
 import qualified Scrod.Core.Warning as Warning
-import Scrod.Json.ToSchema (Schema (MkSchema, unwrap), SchemaM, ToSchema (isOptional, toSchema), define)
-import qualified Scrod.Json.ToSchema as ToSchema
+import Scrod.Schema (Schema (MkSchema, unwrap), SchemaM, ToSchema (isOptional, toSchema), define)
+import qualified Scrod.Schema as ToSchema
 import qualified Scrod.Json.Value as Json
 
 -- * Simple newtype wrappers use @deriving via@ to get their instances

--- a/source/library/Scrod/Convert/ToSchema.hs
+++ b/source/library/Scrod/Convert/ToSchema.hs
@@ -54,9 +54,9 @@ import qualified Scrod.Core.Table as Table
 import qualified Scrod.Core.TableCell as TableCell
 import qualified Scrod.Core.Version as Version
 import qualified Scrod.Core.Warning as Warning
+import qualified Scrod.Json.Value as Json
 import Scrod.Schema (Schema (MkSchema, unwrap), SchemaM, ToSchema (isOptional, toSchema), define)
 import qualified Scrod.Schema as ToSchema
-import qualified Scrod.Json.Value as Json
 
 -- * Simple newtype wrappers use @deriving via@ to get their instances
 

--- a/source/library/Scrod/Convert/ToSchema.hs
+++ b/source/library/Scrod/Convert/ToSchema.hs
@@ -9,10 +9,7 @@
 -- @deriving via 'Generics.Generically'@ to get instances derived
 -- generically. Other types have hand-written instances. Import this
 -- module to bring all instances into scope.
-module Scrod.Convert.ToSchema
-  ( module Scrod.Schema,
-  )
-where
+module Scrod.Convert.ToSchema where
 
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Proxy as Proxy
@@ -55,7 +52,7 @@ import qualified Scrod.Core.TableCell as TableCell
 import qualified Scrod.Core.Version as Version
 import qualified Scrod.Core.Warning as Warning
 import qualified Scrod.Json.Value as Json
-import Scrod.Schema (Schema (MkSchema, unwrap), SchemaM, ToSchema (isOptional, toSchema), define)
+import Scrod.Schema (Schema (MkSchema, unwrap), SchemaM, ToSchema (toSchema), define)
 import qualified Scrod.Schema as ToSchema
 
 -- * Simple newtype wrappers use @deriving via@ to get their instances

--- a/source/library/Scrod/Convert/ToSchema.hs
+++ b/source/library/Scrod/Convert/ToSchema.hs
@@ -52,107 +52,106 @@ import qualified Scrod.Core.TableCell as TableCell
 import qualified Scrod.Core.Version as Version
 import qualified Scrod.Core.Warning as Warning
 import qualified Scrod.Json.Value as Json
-import Scrod.Schema (Schema (MkSchema, unwrap), SchemaM, ToSchema (toSchema), define)
-import qualified Scrod.Schema as ToSchema
+import qualified Scrod.Schema as Schema
 
 -- * Simple newtype wrappers use @deriving via@ to get their instances
 
 -- from the underlying type.
 
-deriving via Text.Text instance ToSchema Category.Category
+deriving via Text.Text instance Schema.ToSchema Category.Category
 
-deriving via Natural.Natural instance ToSchema Column.Column
+deriving via Natural.Natural instance Schema.ToSchema Column.Column
 
-deriving via Text.Text instance ToSchema Extension.Extension
+deriving via Text.Text instance Schema.ToSchema Extension.Extension
 
-deriving via Text.Text instance ToSchema ItemName.ItemName
+deriving via Text.Text instance Schema.ToSchema ItemName.ItemName
 
-deriving via Natural.Natural instance ToSchema ItemKey.ItemKey
+deriving via Natural.Natural instance Schema.ToSchema ItemKey.ItemKey
 
-deriving via Text.Text instance ToSchema Language.Language
+deriving via Text.Text instance Schema.ToSchema Language.Language
 
-deriving via Natural.Natural instance ToSchema Line.Line
+deriving via Natural.Natural instance Schema.ToSchema Line.Line
 
-deriving via Text.Text instance ToSchema ModuleName.ModuleName
+deriving via Text.Text instance Schema.ToSchema ModuleName.ModuleName
 
-deriving via Text.Text instance ToSchema PackageName.PackageName
+deriving via Text.Text instance Schema.ToSchema PackageName.PackageName
 
-deriving via Header.Header Doc.Doc instance ToSchema Section.Section
+deriving via Header.Header Doc.Doc instance Schema.ToSchema Section.Section
 
-deriving via NonEmpty.NonEmpty Natural.Natural instance ToSchema Version.Version
+deriving via NonEmpty.NonEmpty Natural.Natural instance Schema.ToSchema Version.Version
 
 -- * Record types, enum types, and tagged sum types use
 
 -- @Generics.Generically@ to derive their instances generically.
 
-deriving via Generics.Generically Example.Example instance ToSchema Example.Example
+deriving via Generics.Generically Example.Example instance Schema.ToSchema Example.Example
 
-deriving via Generics.Generically ExportIdentifier.ExportIdentifier instance ToSchema ExportIdentifier.ExportIdentifier
+deriving via Generics.Generically ExportIdentifier.ExportIdentifier instance Schema.ToSchema ExportIdentifier.ExportIdentifier
 
-deriving via Generics.Generically ExportName.ExportName instance ToSchema ExportName.ExportName
+deriving via Generics.Generically ExportName.ExportName instance Schema.ToSchema ExportName.ExportName
 
-deriving via Generics.Generically (Header.Header doc) instance (ToSchema doc) => ToSchema (Header.Header doc)
+deriving via Generics.Generically (Header.Header doc) instance (Schema.ToSchema doc) => Schema.ToSchema (Header.Header doc)
 
-deriving via Generics.Generically (Hyperlink.Hyperlink doc) instance (ToSchema doc) => ToSchema (Hyperlink.Hyperlink doc)
+deriving via Generics.Generically (Hyperlink.Hyperlink doc) instance (Schema.ToSchema doc) => Schema.ToSchema (Hyperlink.Hyperlink doc)
 
-deriving via Generics.Generically Identifier.Identifier instance ToSchema Identifier.Identifier
+deriving via Generics.Generically Identifier.Identifier instance Schema.ToSchema Identifier.Identifier
 
-deriving via Generics.Generically Import.Import instance ToSchema Import.Import
+deriving via Generics.Generically Import.Import instance Schema.ToSchema Import.Import
 
-deriving via Generics.Generically Item.Item instance ToSchema Item.Item
+deriving via Generics.Generically Item.Item instance Schema.ToSchema Item.Item
 
-deriving via Generics.Generically (Located.Located a) instance (ToSchema a) => ToSchema (Located.Located a)
+deriving via Generics.Generically (Located.Located a) instance (Schema.ToSchema a) => Schema.ToSchema (Located.Located a)
 
-deriving via Generics.Generically Location.Location instance ToSchema Location.Location
+deriving via Generics.Generically Location.Location instance Schema.ToSchema Location.Location
 
-deriving via Generics.Generically (ModLink.ModLink doc) instance (ToSchema doc) => ToSchema (ModLink.ModLink doc)
+deriving via Generics.Generically (ModLink.ModLink doc) instance (Schema.ToSchema doc) => Schema.ToSchema (ModLink.ModLink doc)
 
-deriving via Generics.Generically Picture.Picture instance ToSchema Picture.Picture
+deriving via Generics.Generically Picture.Picture instance Schema.ToSchema Picture.Picture
 
-deriving via Generics.Generically Since.Since instance ToSchema Since.Since
+deriving via Generics.Generically Since.Since instance Schema.ToSchema Since.Since
 
-deriving via Generics.Generically Subordinates.Subordinates instance ToSchema Subordinates.Subordinates
+deriving via Generics.Generically Subordinates.Subordinates instance Schema.ToSchema Subordinates.Subordinates
 
-deriving via Generics.Generically (Table.Table doc) instance (ToSchema doc) => ToSchema (Table.Table doc)
+deriving via Generics.Generically (Table.Table doc) instance (Schema.ToSchema doc) => Schema.ToSchema (Table.Table doc)
 
-deriving via Generics.Generically (TableCell.Cell doc) instance (ToSchema doc) => ToSchema (TableCell.Cell doc)
+deriving via Generics.Generically (TableCell.Cell doc) instance (Schema.ToSchema doc) => Schema.ToSchema (TableCell.Cell doc)
 
-deriving via Generics.Generically Warning.Warning instance ToSchema Warning.Warning
+deriving via Generics.Generically Warning.Warning instance Schema.ToSchema Warning.Warning
 
-deriving via Generics.Generically ExportNameKind.ExportNameKind instance ToSchema ExportNameKind.ExportNameKind
+deriving via Generics.Generically ExportNameKind.ExportNameKind instance Schema.ToSchema ExportNameKind.ExportNameKind
 
-deriving via Generics.Generically ItemKind.ItemKind instance ToSchema ItemKind.ItemKind
+deriving via Generics.Generically ItemKind.ItemKind instance Schema.ToSchema ItemKind.ItemKind
 
-deriving via Generics.Generically Namespace.Namespace instance ToSchema Namespace.Namespace
+deriving via Generics.Generically Namespace.Namespace instance Schema.ToSchema Namespace.Namespace
 
-deriving via Generics.Generically Export.Export instance ToSchema Export.Export
+deriving via Generics.Generically Export.Export instance Schema.ToSchema Export.Export
 
 -- * Hand-written instances for types that require special encoding.
 
-instance ToSchema Module.Module where
+instance Schema.ToSchema Module.Module where
   toSchema _ = do
-    version <- toSchema (Proxy.Proxy :: Proxy.Proxy Version.Version)
-    language <- toSchema (Proxy.Proxy :: Proxy.Proxy Language.Language)
+    version <- Schema.toSchema (Proxy.Proxy :: Proxy.Proxy Version.Version)
+    language <- Schema.toSchema (Proxy.Proxy :: Proxy.Proxy Language.Language)
     extensions <- extensionsSchema
-    documentation <- toSchema (Proxy.Proxy :: Proxy.Proxy Doc.Doc)
-    since <- toSchema (Proxy.Proxy :: Proxy.Proxy Since.Since)
-    name <- toSchema (Proxy.Proxy :: Proxy.Proxy (Located.Located ModuleName.ModuleName))
-    warning <- toSchema (Proxy.Proxy :: Proxy.Proxy Warning.Warning)
-    exports <- toSchema (Proxy.Proxy :: Proxy.Proxy [Export.Export])
-    imports <- toSchema (Proxy.Proxy :: Proxy.Proxy [Import.Import])
-    items <- toSchema (Proxy.Proxy :: Proxy.Proxy [Located.Located Item.Item])
+    documentation <- Schema.toSchema (Proxy.Proxy :: Proxy.Proxy Doc.Doc)
+    since <- Schema.toSchema (Proxy.Proxy :: Proxy.Proxy Since.Since)
+    name <- Schema.toSchema (Proxy.Proxy :: Proxy.Proxy (Located.Located ModuleName.ModuleName))
+    warning <- Schema.toSchema (Proxy.Proxy :: Proxy.Proxy Warning.Warning)
+    exports <- Schema.toSchema (Proxy.Proxy :: Proxy.Proxy [Export.Export])
+    imports <- Schema.toSchema (Proxy.Proxy :: Proxy.Proxy [Import.Import])
+    items <- Schema.toSchema (Proxy.Proxy :: Proxy.Proxy [Located.Located Item.Item])
     let allProps =
-          [ ("version", unwrap version),
-            ("language", unwrap language),
-            ("extensions", unwrap extensions),
-            ("documentation", unwrap documentation),
-            ("since", unwrap since),
+          [ ("version", Schema.unwrap version),
+            ("language", Schema.unwrap language),
+            ("extensions", Schema.unwrap extensions),
+            ("documentation", Schema.unwrap documentation),
+            ("since", Schema.unwrap since),
             ("signature", Json.object [("type", Json.string "boolean")]),
-            ("name", unwrap name),
-            ("warning", unwrap warning),
-            ("exports", unwrap exports),
-            ("imports", unwrap imports),
-            ("items", unwrap items)
+            ("name", Schema.unwrap name),
+            ("warning", Schema.unwrap warning),
+            ("exports", Schema.unwrap exports),
+            ("imports", Schema.unwrap imports),
+            ("items", Schema.unwrap items)
           ]
     let reqNames =
           [ Json.string "version",
@@ -162,7 +161,7 @@ instance ToSchema Module.Module where
             Json.string "imports",
             Json.string "items"
           ]
-    pure . MkSchema $
+    pure . Schema.MkSchema $
       Json.object
         [ ("type", Json.string "object"),
           ("properties", Json.object allProps),
@@ -170,9 +169,9 @@ instance ToSchema Module.Module where
           ("additionalProperties", Json.boolean False)
         ]
 
-extensionsSchema :: SchemaM Schema
+extensionsSchema :: Schema.SchemaM Schema.Schema
 extensionsSchema =
-  pure . MkSchema $
+  pure . Schema.MkSchema $
     Json.object
       [ ("type", Json.string "object"),
         ("additionalProperties", Json.object [("type", Json.string "boolean")])
@@ -181,8 +180,8 @@ extensionsSchema =
 -- | 'Doc.Doc' is recursive, so its schema uses 'define' to register a
 -- named definition in @$defs@ and return a @$ref@. The schema value is
 -- built purely with inline sub-schemas and a self-reference for @Doc@.
-instance ToSchema Doc.Doc where
-  toSchema _ = define "doc" $ pure (MkSchema docSchemaValue)
+instance Schema.ToSchema Doc.Doc where
+  toSchema _ = Schema.define "doc" $ pure (Schema.MkSchema docSchemaValue)
 
 -- | Pure schema value for 'Doc.Doc'. Uses @$ref \"#/$defs/doc\"@ for
 -- self-references and inlines all other sub-schemas.
@@ -295,8 +294,8 @@ docSchemaValue =
 -- | Extract the schema value from a non-recursive 'ToSchema' instance
 -- without the monadic context. Only safe for types whose 'toSchema'
 -- does not depend on accumulated definitions.
-pureSchema :: (ToSchema a) => Proxy.Proxy a -> Json.Value
-pureSchema p = unwrap . fst $ ToSchema.runSchemaM (toSchema p)
+pureSchema :: (Schema.ToSchema a) => Proxy.Proxy a -> Json.Value
+pureSchema p = Schema.unwrap . fst $ Schema.runSchemaM (Schema.toSchema p)
 
 -- | Build an object schema from required properties only (pure helper).
 objectSchemaPure :: [(String, Json.Value)] -> Json.Value
@@ -319,9 +318,9 @@ objectSchemaOptPure required optional =
       ("additionalProperties", Json.boolean False)
     ]
 
-instance ToSchema Level.Level where
+instance Schema.ToSchema Level.Level where
   toSchema _ =
-    pure . MkSchema $
+    pure . Schema.MkSchema $
       Json.object
         [ ("type", Json.string "integer"),
           ("minimum", Json.integer 1),

--- a/source/library/Scrod/Executable/Main.hs
+++ b/source/library/Scrod/Executable/Main.hs
@@ -14,7 +14,8 @@ import qualified GHC.Stack as Stack
 import qualified PackageInfo_scrod as PackageInfo
 import qualified Scrod.Convert.FromGhc as FromGhc
 import qualified Scrod.Convert.ToHtml as ToHtml
-import qualified Scrod.Convert.ToJson as ToJson
+import qualified Scrod.Convert.ToJson ()
+import qualified Scrod.Json.ToJson as ToJson
 import qualified Scrod.Convert.ToJsonSchema as ToJsonSchema
 import qualified Scrod.Executable.Config as Config
 import qualified Scrod.Executable.Flag as Flag

--- a/source/library/Scrod/Executable/Main.hs
+++ b/source/library/Scrod/Executable/Main.hs
@@ -15,7 +15,6 @@ import qualified PackageInfo_scrod as PackageInfo
 import qualified Scrod.Convert.FromGhc as FromGhc
 import qualified Scrod.Convert.ToHtml as ToHtml
 import qualified Scrod.Convert.ToJson ()
-import qualified Scrod.Json.ToJson as ToJson
 import qualified Scrod.Convert.ToJsonSchema as ToJsonSchema
 import qualified Scrod.Executable.Config as Config
 import qualified Scrod.Executable.Flag as Flag
@@ -24,6 +23,7 @@ import qualified Scrod.Extra.Builder as Builder
 import qualified Scrod.Extra.Either as Either
 import qualified Scrod.Extra.Semigroup as Semigroup
 import qualified Scrod.Ghc.Parse as Parse
+import qualified Scrod.Json.ToJson as ToJson
 import qualified Scrod.Json.Value as Json
 import qualified Scrod.Unlit as Unlit
 import qualified Scrod.Version as Version

--- a/source/library/Scrod/Json/ToSchema.hs
+++ b/source/library/Scrod/Json/ToSchema.hs
@@ -1,8 +1,11 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE StandaloneKindSignatures #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
 {-# LANGUAGE TypeOperators #-}
@@ -215,6 +218,27 @@ instance
 instance (GToSchema (Generics.Rep a)) => ToSchema (Generics.Generically a) where
   toSchema _ = gToSchema (Proxy.Proxy :: Proxy.Proxy (Generics.Rep a))
 
+-- * Test types for generic deriving
+
+data TestRecord = MkTestRecord
+  { testBool :: Bool,
+    testName :: Text.Text,
+    testOptional :: Maybe Bool
+  }
+  deriving (Generics.Generic)
+
+deriving via Generics.Generically TestRecord instance ToSchema TestRecord
+
+data TestEnum = TestEnumA | TestEnumB
+  deriving (Generics.Generic)
+
+deriving via Generics.Generically TestEnum instance ToSchema TestEnum
+
+data TestTagged = TestTaggedX Bool | TestTaggedY Text.Text
+  deriving (Generics.Generic)
+
+deriving via Generics.Generically TestTagged instance ToSchema TestTagged
+
 -- * Tests
 
 spec :: (Applicative m, Monad n) => Spec.Spec m n -> n ()
@@ -271,3 +295,73 @@ spec s = do
             runSchemaM . define "myBool" $
               toSchema (Proxy.Proxy :: Proxy.Proxy Bool)
       Spec.assertEq s defs [("myBool", Json.object [("type", Json.string "boolean")])]
+
+    Spec.it s "record type via Generically produces object schema" $ do
+      let (MkSchema v, _) = runSchemaM $ toSchema (Proxy.Proxy :: Proxy.Proxy TestRecord)
+      Spec.assertEq s v $
+        Json.object
+          [ ("type", Json.string "object"),
+            ( "properties",
+              Json.object
+                [ ("testBool", Json.object [("type", Json.string "boolean")]),
+                  ("testName", Json.object [("type", Json.string "string")]),
+                  ("testOptional", Json.object [("type", Json.string "boolean")])
+                ]
+            ),
+            ("required", Json.array [Json.string "testBool", Json.string "testName"]),
+            ("additionalProperties", Json.boolean False)
+          ]
+
+    Spec.it s "enum type via Generically produces oneOf schema" $ do
+      let (MkSchema v, _) = runSchemaM $ toSchema (Proxy.Proxy :: Proxy.Proxy TestEnum)
+      Spec.assertEq s v $
+        Json.object
+          [ ( "oneOf",
+              Json.array
+                [ Json.object
+                    [ ("type", Json.string "object"),
+                      ("properties", Json.object [("type", Json.object [("const", Json.string "TestEnumA")])]),
+                      ("required", Json.array [Json.string "type"]),
+                      ("additionalProperties", Json.boolean False)
+                    ],
+                  Json.object
+                    [ ("type", Json.string "object"),
+                      ("properties", Json.object [("type", Json.object [("const", Json.string "TestEnumB")])]),
+                      ("required", Json.array [Json.string "type"]),
+                      ("additionalProperties", Json.boolean False)
+                    ]
+                ]
+            )
+          ]
+
+    Spec.it s "tagged sum type via Generically produces oneOf schema" $ do
+      let (MkSchema v, _) = runSchemaM $ toSchema (Proxy.Proxy :: Proxy.Proxy TestTagged)
+      Spec.assertEq s v $
+        Json.object
+          [ ( "oneOf",
+              Json.array
+                [ Json.object
+                    [ ("type", Json.string "object"),
+                      ( "properties",
+                        Json.object
+                          [ ("type", Json.object [("const", Json.string "TestTaggedX")]),
+                            ("value", Json.object [("type", Json.string "boolean")])
+                          ]
+                      ),
+                      ("required", Json.array [Json.string "type", Json.string "value"]),
+                      ("additionalProperties", Json.boolean False)
+                    ],
+                  Json.object
+                    [ ("type", Json.string "object"),
+                      ( "properties",
+                        Json.object
+                          [ ("type", Json.object [("const", Json.string "TestTaggedY")]),
+                            ("value", Json.object [("type", Json.string "string")])
+                          ]
+                      ),
+                      ("required", Json.array [Json.string "type", Json.string "value"]),
+                      ("additionalProperties", Json.boolean False)
+                    ]
+                ]
+            )
+          ]

--- a/source/library/Scrod/Schema.hs
+++ b/source/library/Scrod/Schema.hs
@@ -14,7 +14,7 @@
 -- than values: each instance describes the JSON Schema for the type's
 -- 'ToJson' encoding. An 'Control.Monad.Trans.Accum.Accum' monad
 -- accumulates named definitions (for @$defs@).
-module Scrod.Json.ToSchema where
+module Scrod.Schema where
 
 import qualified Control.Monad.Trans.Accum as Accum
 import qualified Data.Kind as Kind

--- a/source/library/Scrod/TestSuite/All.hs
+++ b/source/library/Scrod/TestSuite/All.hs
@@ -36,11 +36,11 @@ import qualified Scrod.Json.Number
 import qualified Scrod.Json.Object
 import qualified Scrod.Json.Pair
 import qualified Scrod.Json.String
-import qualified Scrod.Schema
 import qualified Scrod.Json.Value
 import qualified Scrod.JsonPointer.Evaluate
 import qualified Scrod.JsonPointer.Pointer
 import qualified Scrod.JsonPointer.Token
+import qualified Scrod.Schema
 import qualified Scrod.Spec as Spec
 import qualified Scrod.TestSuite.Integration
 import qualified Scrod.Unlit

--- a/source/library/Scrod/TestSuite/All.hs
+++ b/source/library/Scrod/TestSuite/All.hs
@@ -36,7 +36,7 @@ import qualified Scrod.Json.Number
 import qualified Scrod.Json.Object
 import qualified Scrod.Json.Pair
 import qualified Scrod.Json.String
-import qualified Scrod.Json.ToSchema
+import qualified Scrod.Schema
 import qualified Scrod.Json.Value
 import qualified Scrod.JsonPointer.Evaluate
 import qualified Scrod.JsonPointer.Pointer
@@ -94,7 +94,7 @@ spec s = do
   Scrod.Json.Object.spec s
   Scrod.Json.Pair.spec s
   Scrod.Json.String.spec s
-  Scrod.Json.ToSchema.spec s
+  Scrod.Schema.spec s
   Scrod.Json.Value.spec s
   Scrod.JsonPointer.Evaluate.spec s
   Scrod.JsonPointer.Pointer.spec s


### PR DESCRIPTION
Fixes #125.

## Summary

Replace the ~450-line hand-written `Scrod.Convert.ToJsonSchema` module with a ~90-line module that generates the JSON Schema from the `ToSchema` type class instances (which derive via `Generically`).

The new `ToJsonSchema.moduleSchema` runs the `ToSchema` instance for `Module` in `SchemaM`, extracts the resulting object schema, and wraps it with root-level JSON Schema metadata (`$schema`, `$id`, `title`, `description`) and the accumulated `$defs`.

The generated schema is structurally different from before: sub-type schemas are inlined rather than referenced via `$ref`/`$defs`, except for the recursive `Doc` type which still uses `define`. Both forms are valid JSON Schema.

**Note:** The generic deriving infrastructure for `ToSchema` via `Generically` was already implemented in #129. This PR puts it to use by replacing the hand-written schema with the derived one.

## Test plan

- [x] `cabal build` succeeds
- [x] `cabal build --flags=pedantic` succeeds (no warnings)
- [x] `cabal test --test-options='--hide-successes'` — all 880 tests pass
- [x] `scrod --schema` outputs valid JSON Schema with correct metadata, properties, required fields, and `$defs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)