### PR TITLE
Fix LaTeX rendering on GitHub Pages

### DIFF
--- a/extra/github-pages/index.js
+++ b/extra/github-pages/index.js
@@ -77,11 +77,10 @@ function showError(message) {
 }
 
 function renderMath() {
-  var el = shadow.firstElementChild;
-  if (!el) return;
+  if (!shadow.firstElementChild) return;
   import('https://esm.sh/katex@0.16.22/dist/contrib/auto-render.min.js')
     .then(function (m) {
-      m.default(el, { delimiters: [
+      m.default(shadow, { delimiters: [
         { left: '\\(', right: '\\)', display: false },
         { left: '\\[', right: '\\]', display: true }
       ]});

--- a/extra/github-pages/index.js
+++ b/extra/github-pages/index.js
@@ -84,6 +84,9 @@ function renderMath() {
         { left: '\\(', right: '\\)', display: false },
         { left: '\\[', right: '\\]', display: true }
       ]});
+    })
+    .catch(function (e) {
+      console.error('Failed to load KaTeX:', e);
     });
 }
 


### PR DESCRIPTION
## Summary

Fixes #135.

When `shadow.innerHTML` is set with the full HTML document from the WASM worker, the browser's HTML fragment parser strips `<html>`, `<head>`, and `<body>` wrapper tags, flattening all their children as direct children of the shadow root. This caused `shadow.firstElementChild` to return a `<meta charset="utf-8">` element instead of the content `<div>`, so `renderMathInElement` never found any math delimiters to render.

The fix passes the shadow root itself to KaTeX auto-render, which correctly traverses all child nodes and finds `\(...\)` and `\[...\]` delimiters in the content.

## Test plan

- [ ] Manual: open https://scrod.fyi/#input=LS0gfCBcKG5eMlwpCmZvbyA9IGJhcg%3D%3D and confirm `n²` renders as formatted math instead of raw `\(n^2\)`
- [x] `cabal build` succeeds
- [x] `cabal test` — all 880 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)