### PR TITLE
Allow VSCode webview to load stylesheets from esm.sh

### DIFF
--- a/extra/vscode/src/extension.ts
+++ b/extra/vscode/src/extension.ts
@@ -174,7 +174,7 @@ function wrapperHtml(): string {
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline' https://esm.sh; font-src https://esm.sh; script-src 'nonce-${nonce}';">
   <style>.item-location { cursor: pointer; } .item-location:hover { text-decoration: underline; }</style>
 </head>
 <body>
@@ -204,6 +204,14 @@ function wrapperHtml(): string {
             document.head.appendChild(style);
           }
           style.textContent = newStyle.textContent;
+        }
+
+        var newLinks = doc.querySelectorAll('link[rel="stylesheet"]');
+        for (var i = 0; i < newLinks.length; i++) {
+          var href = newLinks[i].getAttribute('href');
+          if (href && !document.querySelector('link[href="' + href + '"]')) {
+            document.head.appendChild(newLinks[i].cloneNode());
+          }
         }
 
         var scrollTop = document.documentElement.scrollTop;


### PR DESCRIPTION
## Summary

Fixes #136.

- Updated the webview Content-Security-Policy to allow `style-src` and `font-src` from `https://esm.sh`, so Bootstrap and KaTeX CSS can load
- Updated `applyUpdate` to transfer `<link rel="stylesheet">` tags from the WASM-generated HTML into the webview `<head>`

Previously, the CSP was `default-src 'none'; style-src 'unsafe-inline'`, which blocked all external resources. The generated HTML includes CDN links for Bootstrap and KaTeX CSS, but the webview never loaded them.

## Test plan

- [ ] Manual: open a `.hs` file in VSCode, run "Scrod: Open Documentation Preview", and confirm the output is styled with Bootstrap
- [x] `cabal build` succeeds
- [x] `cabal test` — all 880 tests pass
- [x] `npx tsc --noEmit` — TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)