### PR TITLE
Handle multiple GADT constructor names

### DIFF
--- a/source/library/Scrod/Convert/FromGhc/Names.hs
+++ b/source/library/Scrod/Convert/FromGhc/Names.hs
@@ -148,9 +148,10 @@ extractDerivDeclName =
     . Syntax.hswc_body
     . Syntax.deriv_type
 
--- | Extract name from a constructor declaration.
-extractConDeclName :: Syntax.ConDecl Ghc.GhcPs -> ItemName.ItemName
-extractConDeclName conDecl = case conDecl of
-  Syntax.ConDeclH98 {Syntax.con_name = lName} -> Internal.extractIdPName lName
+-- | Extract names from a constructor declaration.
+-- GADT constructors can declare multiple names (e.g. @A, B :: Int -> T@).
+extractConDeclNames :: Syntax.ConDecl Ghc.GhcPs -> NonEmpty.NonEmpty ItemName.ItemName
+extractConDeclNames conDecl = case conDecl of
+  Syntax.ConDeclH98 {Syntax.con_name = lName} -> pure $ Internal.extractIdPName lName
   Syntax.ConDeclGADT {Syntax.con_names = lNames} ->
-    Internal.extractIdPName $ NonEmpty.head lNames
+    fmap Internal.extractIdPName lNames

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -1042,6 +1042,20 @@ spec s = Spec.describe s "integration" $ do
           ("/items/1/value/kind/type", "\"GADTConstructor\"")
         ]
 
+    Spec.it s "GADT with multiple constructor names" $ do
+      check
+        s
+        "data T where A, B :: Int -> T"
+        [ ("/items/0/value/kind/type", "\"DataType\""),
+          ("/items/0/value/name", "\"T\""),
+          ("/items/1/value/kind/type", "\"GADTConstructor\""),
+          ("/items/1/value/name", "\"A\""),
+          ("/items/1/value/signature", "\"Int -> T\""),
+          ("/items/2/value/kind/type", "\"GADTConstructor\""),
+          ("/items/2/value/name", "\"B\""),
+          ("/items/2/value/signature", "\"Int -> T\"")
+        ]
+
     Spec.it s "data constructor GADT with doc" $ do
       check
         s


### PR DESCRIPTION
Fixes #140.

## Summary

- Changed `extractConDeclName` → `extractConDeclNames` in `Scrod.Convert.FromGhc.Names` to return `NonEmpty ItemName` instead of a single `ItemName`, so all names from a multi-name GADT declaration (e.g. `A, B :: Int -> T`) are preserved.
- Updated `convertConDeclM` in `Scrod.Convert.FromGhc.Constructors` to iterate over all returned names and emit one constructor item (plus any record fields) per name.
- Added an integration test for multi-name GADT constructors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)