### PR TITLE
Add tasty-bench benchmark for pipeline overhead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - run: mkdir artifact
       - run: ghc-pkg list
       - run: cabal sdist --output-dir artifact
-      - run: cabal configure --enable-tests --flags=pedantic --jobs
+      - run: cabal configure --enable-tests --enable-benchmarks --flags=pedantic --jobs
       - run: cat cabal.project.local
       - run: cp cabal.project.local artifact
       - run: cabal freeze
@@ -44,6 +44,7 @@ jobs:
       - run: cabal build
       - run: cp $( cabal list-bin ${{ needs.meta.outputs.name }} ) artifact
       - run: cp $( cabal list-bin ${{ needs.meta.outputs.name }}-test-suite ) artifact
+      - run: cp $( cabal list-bin ${{ needs.meta.outputs.name }}-benchmark ) artifact
       - run: artifact/${{ needs.meta.outputs.name }}${{ runner.os == 'Windows' && '.exe' || '' }} --schema > artifact/schema.json
         shell: bash
       - run: tar --create --file artifact.tar --verbose artifact
@@ -107,6 +108,23 @@ jobs:
           name: ${{ needs.meta.outputs.name }}-${{ github.sha }}-${{ runner.os }}
       - run: tar --extract --file artifact.tar --verbose
       - run: artifact/${{ needs.meta.outputs.name }}-test-suite
+  bench:
+    name: Bench
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - meta
+    steps:
+      - uses: actions/download-artifact@v7
+        with:
+          name: ${{ needs.meta.outputs.name }}-${{ github.sha }}-${{ runner.os }}
+      - run: tar --extract --file artifact.tar --verbose
+      - run: chmod +x artifact/${{ needs.meta.outputs.name }}-benchmark
+      - run: artifact/${{ needs.meta.outputs.name }}-benchmark --csv bench.csv +RTS -T
+      - uses: actions/upload-artifact@v6
+        with:
+          name: ${{ needs.meta.outputs.name }}-${{ github.sha }}-bench
+          path: bench.csv
   wasm:
     name: WASM
     runs-on: ubuntu-latest

--- a/scrod.cabal
+++ b/scrod.cabal
@@ -208,6 +208,16 @@ library
   hs-source-dirs: source/library
   other-modules: PackageInfo_scrod
 
+benchmark scrod-benchmark
+  import: executable
+  build-depends:
+    bytestring ^>=0.12.2,
+    tasty-bench ^>=0.5,
+
+  hs-source-dirs: source/benchmark
+  main-is: Main.hs
+  type: exitcode-stdio-1.0
+
 test-suite scrod-test-suite
   import: executable
   build-depends:

--- a/source/benchmark/Main.hs
+++ b/source/benchmark/Main.hs
@@ -1,0 +1,17 @@
+import qualified Data.ByteString.Builder as Builder
+import qualified Data.ByteString.Lazy as LazyByteString
+import qualified Scrod.Executable.Main as Main
+import qualified Test.Tasty.Bench as Bench
+
+main :: IO ()
+main =
+  Bench.defaultMain
+    [ Bench.bench "empty input" . Bench.nfIO $ run
+    ]
+
+run :: IO LazyByteString.ByteString
+run = do
+  result <- Main.mainWith "bench" [] (pure "")
+  case result of
+    Left e -> fail e
+    Right b -> pure $ Builder.toLazyByteString b


### PR DESCRIPTION
## Summary
- Adds a `scrod-benchmark` benchmark suite using `tasty-bench` that measures the full pipeline (parse → convert → JSON) for empty input
- Includes memory allocation reporting via `+RTS -T`
- New CI `Bench` job uploads `bench.csv` as an artifact

## Test plan
- [x] Benchmark builds under `-Werror` (pedantic)
- [x] Benchmark runs locally: ~449 μs, 273 KB allocated, 6 MB peak memory
- [x] CSV output includes Name, Mean, 2*Stdev, Allocated, Copied, Peak Memory
- [x] All 881 existing tests still pass
- [x] ormolu, hlint, cabal check, cabal-gild all pass
- [ ] CI Bench job runs and uploads bench.csv artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)