### PR TITLE
Fix image loading in VSCode extension

### DIFF
--- a/extra/vscode/src/extension.ts
+++ b/extra/vscode/src/extension.ts
@@ -174,7 +174,7 @@ function wrapperHtml(): string {
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline' https://esm.sh; font-src https://esm.sh; script-src 'nonce-${nonce}' https://esm.sh;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src https:; style-src 'unsafe-inline' https://esm.sh; font-src https://esm.sh; script-src 'nonce-${nonce}' https://esm.sh;">
   <style>.item-location { cursor: pointer; } .item-location:hover { text-decoration: underline; }</style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Add `img-src https:` to the Content Security Policy in the VSCode extension webview
- The CSP had `default-src 'none'` with no `img-src` directive, which blocked all image loads from Haddock doc comments

Fixes #151

## Test plan
- Open a Haskell file with an image in a doc comment (e.g. `-- | ![haskell](https://www.haskell.org/img/haskell-logo.svg)`)
- Open the Scrod preview pane
- Verify the image loads and displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>