### PR TITLE
Label examples in HTML output

### DIFF
--- a/source/library/Scrod/Convert/FromHaddock.hs
+++ b/source/library/Scrod/Convert/FromHaddock.hs
@@ -7,6 +7,7 @@
 -- examples, tables, etc.) to the corresponding @Scrod.Core.*@ constructors.
 module Scrod.Convert.FromHaddock where
 
+import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Text as Text
 import qualified Data.Void as Void
 import qualified Documentation.Haddock.Parser as Haddock
@@ -89,7 +90,7 @@ convertDoc doc = case doc of
   Haddock.DocAName s -> Doc.AName $ Text.pack s
   Haddock.DocProperty s -> Doc.Property $ Text.pack s
   Haddock.DocExamples es ->
-    Doc.Examples $
+    Doc.Examples . NonEmpty.fromList $
       fmap
         ( \e ->
             Example.MkExample
@@ -259,7 +260,7 @@ spec s = do
     Spec.it s "works with examples" $ do
       let input :: Haddock.DocH Void.Void Haddock.Identifier
           input = Haddock.DocExamples [Haddock.Example {Haddock.exampleExpression = "1 + 1", Haddock.exampleResult = ["2"]}]
-      let expected = Doc.Examples [Example.MkExample {Example.expression = Text.pack "1 + 1", Example.result = [Text.pack "2"]}]
+      let expected = Doc.Examples (Example.MkExample {Example.expression = Text.pack "1 + 1", Example.result = [Text.pack "2"]} NonEmpty.:| [])
       Spec.assertEq s (fromHaddock input) expected
 
     Spec.it s "works with header" $ do

--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -944,7 +944,14 @@ examplesToHtml examples =
   Xml.element
     "div"
     [Xml.attribute "class" "border-start border-4 border-warning bg-warning-subtle rounded-end p-3 my-3"]
-    (concatMap exampleToContents examples)
+    ( [ Content.Element $
+          Xml.element
+            "div"
+            [Xml.attribute "class" "fw-bold mb-1"]
+            [Xml.string (if length examples == 1 then "Example:" else "Examples:")]
+      ]
+        <> concatMap exampleToContents examples
+    )
 
 exampleToContents :: Example.Example -> [Content.Content Element.Element]
 exampleToContents (Example.MkExample expr results) =

--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -939,7 +939,7 @@ pictureToHtml (Picture.MkPicture uri maybeTitle) =
     )
     []
 
-examplesToHtml :: [Example.Example] -> Element.Element
+examplesToHtml :: NonEmpty.NonEmpty Example.Example -> Element.Element
 examplesToHtml examples =
   Xml.element
     "div"
@@ -948,9 +948,9 @@ examplesToHtml examples =
           Xml.element
             "div"
             [Xml.attribute "class" "fw-bold mb-1"]
-            [Xml.string (if length examples == 1 then "Example:" else "Examples:")]
+            [Xml.string (case examples of _ NonEmpty.:| [] -> "Example:"; _ -> "Examples:")]
       ]
-        <> concatMap exampleToContents examples
+        <> concatMap exampleToContents (NonEmpty.toList examples)
     )
 
 exampleToContents :: Example.Example -> [Content.Content Element.Element]

--- a/source/library/Scrod/Core/Doc.hs
+++ b/source/library/Scrod/Core/Doc.hs
@@ -3,6 +3,7 @@
 
 module Scrod.Core.Doc where
 
+import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Text as Text
 import qualified GHC.Generics as Generics
 import qualified Scrod.Core.Definition as Definition
@@ -38,7 +39,7 @@ data Doc
   | MathDisplay Text.Text
   | AName Text.Text
   | Property Text.Text
-  | Examples [Example.Example]
+  | Examples (NonEmpty.NonEmpty Example.Example)
   | Header (Header.Header Doc)
   | Table (Table.Table Doc)
   deriving (Eq, Generics.Generic, Ord, Show)


### PR DESCRIPTION
## Summary
- Add a bold "Example:" or "Examples:" label above `>>>` prompts in the HTML rendering of doc examples
- Uses singular "Example:" when there is exactly one example, plural "Examples:" otherwise

Fixes #155

## Test plan
- Parse a Haskell file with a single example (`-- | >>> x`) and verify the output shows "Example:" above the prompt
- Parse a file with multiple examples and verify it shows "Examples:"
- `cabal build --flags=pedantic` passes
- `cabal test` passes (688 tests)
- `ormolu --mode check` and `hlint` pass on the modified file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>