### PR TITLE
Label properties in HTML output

### DIFF
--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -904,7 +904,14 @@ docToContents doc = case doc of
   Doc.AName t ->
     [Content.Element $ Xml.element "a" [Xml.attribute "id" (Text.unpack t)] []]
   Doc.Property t ->
-    [Content.Element $ Xml.element "pre" [Xml.attribute "class" "border-start border-4 border-primary bg-primary-subtle rounded-end p-3 my-3 font-monospace"] [Xml.text t]]
+    [ Content.Element $
+        Xml.element
+          "div"
+          [Xml.attribute "class" "border-start border-4 border-primary bg-primary-subtle rounded-end p-3 my-3"]
+          [ Content.Element $ Xml.element "div" [Xml.attribute "class" "fw-bold mb-1"] [Xml.string "Property:"],
+            Content.Element $ Xml.element "pre" [Xml.attribute "class" "mb-0 bg-transparent font-monospace"] [Xml.text t]
+          ]
+    ]
   Doc.Examples es -> [Content.Element (examplesToHtml es)]
   Doc.Header h -> [Content.Element (headerToHtml h)]
   Doc.Table t -> [Content.Element (tableToHtml t)]


### PR DESCRIPTION
## Summary
- Add a bold "Property:" label above property text in the HTML rendering of doc properties
- Wrap the existing `<pre>` in a container `<div>` with the label, keeping the same blue-bordered styling

Fixes #156

## Test plan
- Parse a Haskell file with a property (`-- | prop> x`) and verify the output shows "Property:" above the property text
- `cabal build --flags=pedantic` passes
- `cabal test` passes (688 tests)
- `ormolu --mode check` and `hlint` pass on the modified file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>