### PR TITLE
Fix missing space between type name and variables

### DIFF
--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -722,7 +722,7 @@ itemToHtml (Located.MkLocated loc (Item.MkItem key itemKind _parentKey maybeName
     signatureContents = case maybeSig of
       Nothing -> []
       Just sig ->
-        let prefix = if isTypeVarSignature then Text.pack " " else Text.pack " :: "
+        let prefix = if isTypeVarSignature then Text.pack "\x00a0" else Text.pack " :: "
          in [ Content.Element $
                 Xml.element
                   "span"


### PR DESCRIPTION
## Summary
- Replace the regular space prefix with a non-breaking space (U+00A0) between the type constructor name and type variables in the card header
- The card header uses flexbox (`d-flex`), which creates a block formatting context for each flex item, causing leading whitespace in the type variable span to be collapsed
- Affects data types, newtypes, type data, type synonyms, and classes with type parameters

Fixes #159

## Test plan
- Parse `data A b` and verify a visible space appears between "A" and "b" in the rendered HTML
- Also check `newtype A b = ...`, `type A b = ...`, `class A b where` etc.
- `cabal build --flags=pedantic` passes
- `cabal test` passes (688 tests)
- Verified the output contains UTF-8 bytes `c2 a0` (U+00A0) instead of `20` (regular space)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>