### PR TITLE
Add copy permalink button to web app

### DIFF
--- a/extra/github-pages/index.html
+++ b/extra/github-pages/index.html
@@ -26,6 +26,7 @@
     </select>
     <button type='button' id='file-button' class='btn btn-outline-secondary btn-sm'>Upload file</button>
     <input type='file' id='file-input' class='visually-hidden' accept='.hs,.lhs,.hsig,.lhsig'>
+    <button type='button' id='copy-link' class='btn btn-outline-secondary btn-sm'>Copy link</button>
   </div>
   <div class='d-flex flex-grow-1 overflow-hidden'>
     <div class='w-50 h-100 overflow-auto border-end'>

--- a/extra/github-pages/index.js
+++ b/extra/github-pages/index.js
@@ -260,10 +260,18 @@ fileInput.addEventListener('change', function () {
   }
 });
 
+var copyLinkResetTimer;
+
 copyLink.addEventListener('click', function () {
   navigator.clipboard.writeText(location.href).then(function () {
     copyLink.textContent = 'Copied!';
-    setTimeout(function () { copyLink.textContent = 'Copy link'; }, 1500);
+  }).catch(function () {
+    copyLink.textContent = 'Copy failed';
+  }).finally(function () {
+    if (copyLinkResetTimer !== undefined) {
+      clearTimeout(copyLinkResetTimer);
+    }
+    copyLinkResetTimer = setTimeout(function () { copyLink.textContent = 'Copy link'; }, 1500);
   });
 });
 

--- a/extra/github-pages/index.js
+++ b/extra/github-pages/index.js
@@ -9,6 +9,7 @@ var signature = document.getElementById('signature');
 var theme = document.getElementById('theme');
 var fileButton = document.getElementById('file-button');
 var fileInput = document.getElementById('file-input');
+var copyLink = document.getElementById('copy-link');
 var dropOverlay = document.getElementById('drop-overlay');
 var shadow = output.attachShadow({ mode: 'open' });
 var debounceTimer;
@@ -257,6 +258,13 @@ fileInput.addEventListener('change', function () {
     loadFile(fileInput.files[0]);
     fileInput.value = '';
   }
+});
+
+copyLink.addEventListener('click', function () {
+  navigator.clipboard.writeText(location.href).then(function () {
+    copyLink.textContent = 'Copied!';
+    setTimeout(function () { copyLink.textContent = 'Copy link'; }, 1500);
+  });
 });
 
 // Drag and drop support


### PR DESCRIPTION
## Summary
- Add a "Copy link" button to the scrod.fyi toolbar that copies the current URL to the clipboard
- The URL already includes the hash fragment with base64-encoded input, format, and options, so the copied link is a shareable permalink
- Button shows brief "Copied!" feedback after clicking

Fixes #164

## Test plan
- Open https://scrod.fyi, enter some Haskell source
- Click "Copy link" — button text should change to "Copied!" for ~1.5 seconds
- Paste the clipboard contents into a new tab — should load the same input
- Verify the button works with different format/literate/signature combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>