### PR TITLE
Display identifier namespaces as badges

### DIFF
--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -911,13 +911,26 @@ docToContents doc = case doc of
 
 identifierToHtml :: Identifier.Identifier -> Element.Element
 identifierToHtml (Identifier.MkIdentifier ns val) =
-  Xml.element "code" [Xml.attribute "class" "font-monospace text-success"] [Xml.text (prefix <> val)]
+  Xml.element
+    "span"
+    []
+    ( [Content.Element $ Xml.element "code" [Xml.attribute "class" "font-monospace text-success"] [Xml.text val]]
+        <> namespaceBadge ns
+    )
   where
-    prefix :: Text.Text
-    prefix = case ns of
-      Nothing -> Text.empty
-      Just Namespace.Value -> Text.pack "v'"
-      Just Namespace.Type -> Text.pack "t'"
+    namespaceBadge :: Maybe Namespace.Namespace -> [Content.Content Element.Element]
+    namespaceBadge Nothing = []
+    namespaceBadge (Just n) =
+      [ Content.Element $
+          Xml.element
+            "span"
+            [Xml.attribute "class" "badge bg-secondary-subtle text-body ms-1"]
+            [Xml.text (namespaceToText n)]
+      ]
+
+    namespaceToText :: Namespace.Namespace -> Text.Text
+    namespaceToText Namespace.Value = Text.pack "value"
+    namespaceToText Namespace.Type = Text.pack "type"
 
 modLinkToHtml :: ModLink.ModLink Doc.Doc -> Element.Element
 modLinkToHtml (ModLink.MkModLink (ModuleName.MkModuleName modName) maybeLabel) =


### PR DESCRIPTION
## Summary
- Replace Haddock-syntax `v'...'` and `t'...'` prefixes with small "value" and "type" badges after the identifier name
- Unqualified identifiers (`'...'`) render the same as before — just the name with no badge
- Uses the same `bg-secondary-subtle` badge style used for extensions

Fixes #154

## Test plan
- Parse a file with `'a'`, `v'b'`, and `t'C'` identifiers in doc comments
- Verify `a` has no badge, `b` has a "value" badge, `C` has a "type" badge
- `cabal build --flags=pedantic` passes
- `cabal test` passes (688 tests)
- `ormolu --mode check` and `hlint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>