### PR TITLE
Show `@since` annotations on items

### DIFF
--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -13,8 +13,6 @@ import qualified Data.Maybe as Maybe
 import qualified Data.Text as Text
 import qualified Data.Tuple as Tuple
 import qualified Data.Version
-import qualified Documentation.Haddock.Parser as Haddock
-import qualified Documentation.Haddock.Types as Haddock
 import qualified GHC.Data.FastString as FastString
 import qualified GHC.Driver.DynFlags as DynFlags
 import qualified GHC.Driver.Session as Session
@@ -29,7 +27,6 @@ import qualified GHC.Types.SourceText as SourceText
 import qualified GHC.Types.SrcLoc as SrcLoc
 import qualified GHC.Utils.Outputable as Outputable
 import qualified Language.Haskell.Syntax as Syntax
-import qualified Numeric.Natural as Natural
 import qualified PackageInfo_scrod as PackageInfo
 import qualified Scrod.Convert.FromGhc.Constructors as Constructors
 import qualified Scrod.Convert.FromGhc.Doc as GhcDoc
@@ -39,7 +36,6 @@ import qualified Scrod.Convert.FromGhc.Internal as Internal
 import qualified Scrod.Convert.FromGhc.ItemKind as ItemKindFrom
 import qualified Scrod.Convert.FromGhc.Merge as Merge
 import qualified Scrod.Convert.FromGhc.Names as Names
-import qualified Scrod.Convert.FromHaddock as FromHaddock
 import qualified Scrod.Core.Doc as Doc
 import qualified Scrod.Core.Extension as Extension
 import qualified Scrod.Core.Import as Import
@@ -125,19 +121,11 @@ extractModuleName lHsModule = do
   Internal.locatedFromGhc $ SrcLoc.L srcSpan moduleName
 
 -- | Extract module documentation and @since information from the parsed module.
--- Parses the Haddock MetaDoc once and extracts both the Doc and Since.
 extractModuleDocAndSince ::
   SrcLoc.Located (Syntax.HsModule Ghc.GhcPs) ->
   (Doc.Doc, Maybe Since.Since)
 extractModuleDocAndSince lHsModule =
-  case extractRawDocString lHsModule of
-    Nothing -> (Doc.Empty, Nothing)
-    Just rawDocString ->
-      let metaDoc :: Haddock.MetaDoc m Haddock.Identifier
-          metaDoc = Haddock.parseParas Nothing rawDocString
-          doc = FromHaddock.fromHaddock $ Haddock._doc metaDoc
-          since = Haddock._metaSince (Haddock._meta metaDoc) >>= metaSinceToSince
-       in (doc, since)
+  maybe (Doc.Empty, Nothing) GhcDoc.parseDoc (extractRawDocString lHsModule)
 
 -- | Extract raw documentation string from the module header.
 extractRawDocString ::
@@ -150,19 +138,6 @@ extractRawDocString lHsModule = do
   let hsDoc = SrcLoc.unLoc lHsDoc
       hsDocString = HsDoc.hsDocString hsDoc
   Just $ DocString.renderHsDocString hsDocString
-
--- | Convert a Haddock MetaSince to our 'Since'.
-metaSinceToSince :: Haddock.MetaSince -> Maybe Since.Since
-metaSinceToSince metaSince = do
-  versionNE <- NonEmpty.nonEmpty $ Haddock.sinceVersion metaSince
-  Just
-    Since.MkSince
-      { Since.package =
-          PackageName.MkPackageName . Text.pack
-            <$> Haddock.sincePackage metaSince,
-        Since.version =
-          Version.MkVersion $ fmap (fromIntegral :: Int -> Natural.Natural) versionNE
-      }
 
 -- | Extract module deprecation warning.
 extractModuleWarning ::
@@ -220,114 +195,120 @@ extractItemsM lHsModule = do
   let hsModule = SrcLoc.unLoc lHsModule
       decls = Syntax.hsmodDecls hsModule
       declsWithDocs = GhcDoc.associateDocs decls
-  concat <$> traverse (uncurry convertDeclWithDocMaybeM) declsWithDocs
+  concat <$> traverse (\(doc, docSince, lDecl) -> convertDeclWithDocMaybeM doc docSince lDecl) declsWithDocs
 
 -- | Convert a declaration with documentation.
 convertDeclWithDocMaybeM ::
   Doc.Doc ->
+  Maybe Since.Since ->
   Syntax.LHsDecl Ghc.GhcPs ->
   Internal.ConvertM [Located.Located Item.Item]
-convertDeclWithDocMaybeM doc lDecl = case SrcLoc.unLoc lDecl of
-  Syntax.TyClD _ tyClDecl -> convertTyClDeclWithDocM doc lDecl tyClDecl
+convertDeclWithDocMaybeM doc docSince lDecl = case SrcLoc.unLoc lDecl of
+  Syntax.TyClD _ tyClDecl -> convertTyClDeclWithDocM doc docSince lDecl tyClDecl
   Syntax.RuleD _ ruleDecls -> convertRuleDeclsM ruleDecls
   Syntax.DocD {} -> Maybe.maybeToList <$> convertDeclSimpleM lDecl
-  Syntax.SigD _ sig -> convertSigDeclM doc lDecl sig
+  Syntax.SigD _ sig -> convertSigDeclM doc docSince lDecl sig
   Syntax.KindSigD _ kindSig ->
     let sig = Just $ Names.extractKindSigSignature kindSig
-     in Maybe.maybeToList <$> convertDeclWithDocM Nothing doc (Just $ Names.extractStandaloneKindSigName kindSig) sig lDecl
-  Syntax.InstD _ inst -> convertInstDeclWithDocM doc lDecl inst
+     in Maybe.maybeToList <$> convertDeclWithDocM Nothing doc docSince (Just $ Names.extractStandaloneKindSigName kindSig) sig lDecl
+  Syntax.InstD _ inst -> convertInstDeclWithDocM doc docSince lDecl inst
   Syntax.ForD _ foreignDecl ->
     let name = Just $ Names.extractForeignDeclName foreignDecl
         sig = Just $ Names.extractForeignDeclSignature foreignDecl
-     in Maybe.maybeToList <$> convertDeclWithDocM Nothing doc name sig lDecl
+     in Maybe.maybeToList <$> convertDeclWithDocM Nothing doc docSince name sig lDecl
   Syntax.SpliceD _ spliceDecl ->
     let sig = Just . Text.pack . Outputable.showSDocUnsafe . Outputable.ppr $ spliceDecl
-     in Maybe.maybeToList <$> convertDeclWithDocM Nothing doc Nothing sig lDecl
-  _ -> Maybe.maybeToList <$> convertDeclWithDocM Nothing doc (Names.extractDeclName lDecl) Nothing lDecl
+     in Maybe.maybeToList <$> convertDeclWithDocM Nothing doc docSince Nothing sig lDecl
+  _ -> Maybe.maybeToList <$> convertDeclWithDocM Nothing doc docSince (Names.extractDeclName lDecl) Nothing lDecl
 
 -- | Convert a type/class declaration with documentation.
 convertTyClDeclWithDocM ::
   Doc.Doc ->
+  Maybe Since.Since ->
   Syntax.LHsDecl Ghc.GhcPs ->
   Syntax.TyClDecl Ghc.GhcPs ->
   Internal.ConvertM [Located.Located Item.Item]
-convertTyClDeclWithDocM doc lDecl tyClDecl = case tyClDecl of
+convertTyClDeclWithDocM doc docSince lDecl tyClDecl = case tyClDecl of
   Syntax.FamDecl _ famDecl -> case Syntax.fdInfo famDecl of
     Syntax.ClosedTypeFamily (Just eqns) -> do
-      parentItem <- convertDeclWithDocM Nothing doc (Names.extractTyClDeclName tyClDecl) Nothing lDecl
+      parentItem <- convertDeclWithDocM Nothing doc docSince (Names.extractTyClDeclName tyClDecl) Nothing lDecl
       let parentKey = fmap (Item.key . Located.value) parentItem
       eqnItems <- convertTyFamInstEqnsM parentKey eqns
       pure $ Maybe.maybeToList parentItem <> eqnItems
-    _ -> Maybe.maybeToList <$> convertDeclWithDocM Nothing doc (Names.extractTyClDeclName tyClDecl) Nothing lDecl
+    _ -> Maybe.maybeToList <$> convertDeclWithDocM Nothing doc docSince (Names.extractTyClDeclName tyClDecl) Nothing lDecl
   Syntax.DataDecl _ _ _ _ dataDefn -> do
-    parentItem <- convertDeclWithDocM Nothing doc (Names.extractTyClDeclName tyClDecl) (Names.extractTyClDeclTyVars tyClDecl) lDecl
+    parentItem <- convertDeclWithDocM Nothing doc docSince (Names.extractTyClDeclName tyClDecl) (Names.extractTyClDeclTyVars tyClDecl) lDecl
     let parentKey = fmap (Item.key . Located.value) parentItem
         parentType = Names.extractParentTypeText tyClDecl
     childItems <- convertDataDefnM parentKey parentType dataDefn
     pure $ Maybe.maybeToList parentItem <> childItems
   Syntax.ClassDecl {Syntax.tcdSigs = sigs, Syntax.tcdATs = ats, Syntax.tcdDocs = docs} -> do
-    parentItem <- convertDeclWithDocM Nothing doc (Names.extractTyClDeclName tyClDecl) (Names.extractTyClDeclTyVars tyClDecl) lDecl
+    parentItem <- convertDeclWithDocM Nothing doc docSince (Names.extractTyClDeclName tyClDecl) (Names.extractTyClDeclTyVars tyClDecl) lDecl
     let parentKey = fmap (Item.key . Located.value) parentItem
     methodItems <- convertClassSigsWithDocsM parentKey sigs docs
     familyItems <- convertFamilyDeclsM parentKey ats
     pure $ Maybe.maybeToList parentItem <> methodItems <> familyItems
-  Syntax.SynDecl {} -> Maybe.maybeToList <$> convertDeclWithDocM Nothing doc (Names.extractTyClDeclName tyClDecl) (Names.extractSynDeclSignature tyClDecl) lDecl
+  Syntax.SynDecl {} -> Maybe.maybeToList <$> convertDeclWithDocM Nothing doc docSince (Names.extractTyClDeclName tyClDecl) (Names.extractSynDeclSignature tyClDecl) lDecl
 
 -- | Convert an instance declaration with documentation.
 convertInstDeclWithDocM ::
   Doc.Doc ->
+  Maybe Since.Since ->
   Syntax.LHsDecl Ghc.GhcPs ->
   Syntax.InstDecl Ghc.GhcPs ->
   Internal.ConvertM [Located.Located Item.Item]
-convertInstDeclWithDocM doc lDecl inst = case inst of
+convertInstDeclWithDocM doc docSince lDecl inst = case inst of
   Syntax.DataFamInstD _ dataFamInst -> do
-    parentItem <- convertDeclWithDocM Nothing doc (Names.extractInstDeclName inst) Nothing lDecl
+    parentItem <- convertDeclWithDocM Nothing doc docSince (Names.extractInstDeclName inst) Nothing lDecl
     let parentKey = fmap (Item.key . Located.value) parentItem
     childItems <- convertDataDefnM parentKey Nothing (Syntax.feqn_rhs $ Syntax.dfid_eqn dataFamInst)
     pure $ Maybe.maybeToList parentItem <> childItems
-  _ -> Maybe.maybeToList <$> convertDeclWithDocM Nothing doc (Names.extractInstDeclName inst) Nothing lDecl
+  _ -> Maybe.maybeToList <$> convertDeclWithDocM Nothing doc docSince (Names.extractInstDeclName inst) Nothing lDecl
 
 -- | Convert a signature declaration.
 convertSigDeclM ::
   Doc.Doc ->
+  Maybe Since.Since ->
   Syntax.LHsDecl Ghc.GhcPs ->
   Syntax.Sig Ghc.GhcPs ->
   Internal.ConvertM [Located.Located Item.Item]
-convertSigDeclM doc lDecl sig = case sig of
+convertSigDeclM doc docSince lDecl sig = case sig of
   Syntax.TypeSig _ names _ ->
     let sigText = Names.extractSigSignature sig
-     in Maybe.catMaybes <$> traverse (convertSigNameM doc sigText) names
+     in Maybe.catMaybes <$> traverse (convertSigNameM doc docSince sigText) names
   Syntax.PatSynSig _ names _ ->
     let sigText = Names.extractSigSignature sig
-     in Maybe.catMaybes <$> traverse (convertSigNameM doc sigText) names
-  _ -> Maybe.maybeToList <$> convertDeclWithDocM Nothing doc (Names.extractSigName sig) Nothing lDecl
+     in Maybe.catMaybes <$> traverse (convertSigNameM doc docSince sigText) names
+  _ -> Maybe.maybeToList <$> convertDeclWithDocM Nothing doc docSince (Names.extractSigName sig) Nothing lDecl
 
 -- | Convert a single name from a signature.
 convertSigNameM ::
   Doc.Doc ->
+  Maybe Since.Since ->
   Maybe Text.Text ->
   Syntax.LIdP Ghc.GhcPs ->
   Internal.ConvertM (Maybe (Located.Located Item.Item))
-convertSigNameM doc sig lName =
-  Internal.mkItemM (Annotation.getLocA lName) Nothing (Just $ Internal.extractIdPName lName) doc sig ItemKind.Function
+convertSigNameM doc docSince sig lName =
+  Internal.mkItemM (Annotation.getLocA lName) Nothing (Just $ Internal.extractIdPName lName) doc docSince sig ItemKind.Function
 
 -- | Convert a simple declaration without special handling.
 convertDeclSimpleM ::
   Syntax.LHsDecl Ghc.GhcPs ->
   Internal.ConvertM (Maybe (Located.Located Item.Item))
-convertDeclSimpleM = convertDeclWithDocM Nothing Doc.Empty Nothing Nothing
+convertDeclSimpleM = convertDeclWithDocM Nothing Doc.Empty Nothing Nothing Nothing
 
 -- | Convert a declaration with documentation.
 convertDeclWithDocM ::
   Maybe ItemKey.ItemKey ->
   Doc.Doc ->
+  Maybe Since.Since ->
   Maybe ItemName.ItemName ->
   Maybe Text.Text ->
   Syntax.LHsDecl Ghc.GhcPs ->
   Internal.ConvertM (Maybe (Located.Located Item.Item))
-convertDeclWithDocM parentKey doc itemName sig lDecl =
+convertDeclWithDocM parentKey doc docSince itemName sig lDecl =
   let itemKind = ItemKindFrom.itemKindFromDecl $ SrcLoc.unLoc lDecl
-   in Internal.mkItemM (Annotation.getLocA lDecl) parentKey itemName doc sig itemKind
+   in Internal.mkItemM (Annotation.getLocA lDecl) parentKey itemName doc docSince sig itemKind
 
 -- | Convert rule declarations.
 convertRuleDeclsM ::
@@ -340,7 +321,7 @@ convertRuleDeclM ::
   Syntax.LRuleDecl Ghc.GhcPs ->
   Internal.ConvertM (Maybe (Located.Located Item.Item))
 convertRuleDeclM lRuleDecl =
-  Internal.mkItemM (Annotation.getLocA lRuleDecl) Nothing Nothing Doc.Empty Nothing ItemKind.Rule
+  Internal.mkItemM (Annotation.getLocA lRuleDecl) Nothing Nothing Doc.Empty Nothing Nothing ItemKind.Rule
 
 -- | Convert class signatures with associated documentation.
 convertClassSigsWithDocsM ::
@@ -354,7 +335,7 @@ convertClassSigsWithDocsM parentKey sigs docs =
       docDecls = fmap (fmap (Syntax.DocD Hs.noExtField)) docs
       allDecls = List.sortBy (\a b -> SrcLoc.leftmost_smallest (Annotation.getLocA a) (Annotation.getLocA b)) (sigDecls <> docDecls)
       sigsWithDocs = GhcDoc.associateDocs allDecls
-   in concat <$> traverse (uncurry (convertClassDeclWithDocM parentKey)) sigsWithDocs
+   in concat <$> traverse (\(doc, docSince, lDecl) -> convertClassDeclWithDocM parentKey doc docSince lDecl) sigsWithDocs
   where
     isClassOpSig :: Syntax.LSig Ghc.GhcPs -> Bool
     isClassOpSig lSig = case SrcLoc.unLoc lSig of
@@ -365,13 +346,14 @@ convertClassSigsWithDocsM parentKey sigs docs =
 convertClassDeclWithDocM ::
   Maybe ItemKey.ItemKey ->
   Doc.Doc ->
+  Maybe Since.Since ->
   Syntax.LHsDecl Ghc.GhcPs ->
   Internal.ConvertM [Located.Located Item.Item]
-convertClassDeclWithDocM parentKey doc lDecl = case SrcLoc.unLoc lDecl of
+convertClassDeclWithDocM parentKey doc docSince lDecl = case SrcLoc.unLoc lDecl of
   Syntax.SigD _ sig -> case sig of
     Syntax.ClassOpSig _ _ names _ ->
       let sigText = Names.extractSigSignature sig
-       in Maybe.catMaybes <$> traverse (convertIdPM parentKey doc sigText) names
+       in Maybe.catMaybes <$> traverse (convertIdPM parentKey doc docSince sigText) names
     _ -> pure []
   _ -> pure []
 
@@ -379,11 +361,12 @@ convertClassDeclWithDocM parentKey doc lDecl = case SrcLoc.unLoc lDecl of
 convertIdPM ::
   Maybe ItemKey.ItemKey ->
   Doc.Doc ->
+  Maybe Since.Since ->
   Maybe Text.Text ->
   Syntax.LIdP Ghc.GhcPs ->
   Internal.ConvertM (Maybe (Located.Located Item.Item))
-convertIdPM parentKey doc sig lIdP =
-  Internal.mkItemM (Annotation.getLocA lIdP) parentKey (Just $ Internal.extractIdPName lIdP) doc sig ItemKind.ClassMethod
+convertIdPM parentKey doc docSince sig lIdP =
+  Internal.mkItemM (Annotation.getLocA lIdP) parentKey (Just $ Internal.extractIdPName lIdP) doc docSince sig ItemKind.ClassMethod
 
 -- | Convert family declarations.
 convertFamilyDeclsM ::
@@ -406,6 +389,7 @@ convertFamilyDeclM parentKey lFamilyDecl =
         (Just $ Names.extractFamilyDeclName famDecl)
         Doc.Empty
         Nothing
+        Nothing
         itemKind
 
 -- | Convert type family instance equations.
@@ -423,7 +407,7 @@ convertTyFamInstEqnM ::
 convertTyFamInstEqnM parentKey lEqn =
   let eqn = SrcLoc.unLoc lEqn
       sig = Just . Text.pack . Outputable.showSDocUnsafe $ extractTyFamInstEqnSig eqn
-   in Internal.mkItemM (Annotation.getLocA lEqn) parentKey Nothing Doc.Empty sig ItemKind.TypeFamilyInstance
+   in Internal.mkItemM (Annotation.getLocA lEqn) parentKey Nothing Doc.Empty Nothing sig ItemKind.TypeFamilyInstance
 
 -- | Pretty-print a type family instance equation.
 extractTyFamInstEqnSig :: Syntax.TyFamInstEqn Ghc.GhcPs -> Outputable.SDoc
@@ -482,7 +466,8 @@ convertDerivedTypeM ::
   Syntax.LHsSigType Ghc.GhcPs ->
   Internal.ConvertM (Maybe (Located.Located Item.Item))
 convertDerivedTypeM parentKey lSigTy =
-  Internal.mkItemM (Annotation.getLocA lSigTy) parentKey (extractDerivedTypeName lSigTy) (extractDerivedTypeDoc lSigTy) Nothing ItemKind.DerivedInstance
+  let (doc, docSince) = extractDerivedTypeDocAndSince lSigTy
+   in Internal.mkItemM (Annotation.getLocA lSigTy) parentKey (extractDerivedTypeName lSigTy) doc docSince Nothing ItemKind.DerivedInstance
 
 -- | Extract name from a derived type.
 extractDerivedTypeName :: Syntax.LHsSigType Ghc.GhcPs -> Maybe ItemName.ItemName
@@ -494,11 +479,11 @@ extractDerivedTypeName lSigTy =
         _ -> bodyTy
    in Just . ItemName.MkItemName . Text.pack . Outputable.showSDocUnsafe . Outputable.ppr $ ty
 
--- | Extract documentation from a derived type.
-extractDerivedTypeDoc :: Syntax.LHsSigType Ghc.GhcPs -> Doc.Doc
-extractDerivedTypeDoc lSigTy =
+-- | Extract documentation and @since from a derived type.
+extractDerivedTypeDocAndSince :: Syntax.LHsSigType Ghc.GhcPs -> (Doc.Doc, Maybe Since.Since)
+extractDerivedTypeDocAndSince lSigTy =
   let sigTy = SrcLoc.unLoc lSigTy
       bodyTy = SrcLoc.unLoc $ Syntax.sig_body sigTy
    in case bodyTy of
         Syntax.HsDocTy _ _ lDoc -> GhcDoc.convertLHsDoc lDoc
-        _ -> Doc.Empty
+        _ -> (Doc.Empty, Nothing)

--- a/source/library/Scrod/Convert/FromGhc/Exports.hs
+++ b/source/library/Scrod/Convert/FromGhc/Exports.hs
@@ -99,11 +99,11 @@ convertIE lIe = case SrcLoc.unLoc lIe of
         { Section.header =
             Header.MkHeader
               { Header.level = levelFromInt level,
-                Header.title = GhcDoc.convertLHsDoc lDoc
+                Header.title = GhcDoc.convertExportDoc lDoc
               }
         }
   Syntax.IEDoc _ lDoc ->
-    Export.Doc $ GhcDoc.convertLHsDoc lDoc
+    Export.Doc $ GhcDoc.convertExportDoc lDoc
   Syntax.IEDocNamed _ name ->
     Export.DocNamed $ Text.pack name
 

--- a/source/library/Scrod/Convert/FromGhc/Merge.hs
+++ b/source/library/Scrod/Convert/FromGhc/Merge.hs
@@ -49,11 +49,14 @@ mergeItemGroup group =
   let sorted = NonEmpty.sortWith Located.location group
       firstItem = NonEmpty.head sorted
       combinedDoc = foldr (Internal.appendDoc . Item.documentation . Located.value) Doc.Empty sorted
+      combinedSince =
+        Maybe.listToMaybe . Maybe.mapMaybe (Item.since . Located.value) $ NonEmpty.toList sorted
       combinedSig =
         Maybe.listToMaybe . Maybe.mapMaybe (Item.signature . Located.value) $ NonEmpty.toList sorted
       mergedItem =
         (Located.value firstItem)
           { Item.documentation = combinedDoc,
+            Item.since = combinedSince,
             Item.signature = combinedSig
           }
    in firstItem {Located.value = mergedItem}

--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -666,7 +666,7 @@ itemsContents items =
                 ]
 
 itemToHtml :: Located.Located Item.Item -> Element.Element
-itemToHtml (Located.MkLocated loc (Item.MkItem key itemKind _parentKey maybeName doc maybeSig)) =
+itemToHtml (Located.MkLocated loc (Item.MkItem key itemKind _parentKey maybeName doc maybeSince maybeSig)) =
   Xml.element
     "div"
     [ Xml.attribute "class" "card mb-3 border-start border-4",
@@ -682,6 +682,7 @@ itemToHtml (Located.MkLocated loc (Item.MkItem key itemKind _parentKey maybeName
                 <> sigBeforeKind
                 <> [Content.Element kindElement]
                 <> sigAfterKind
+                <> sinceContents
                 <> [Content.Element (locationElement loc)]
             )
       ]
@@ -729,6 +730,17 @@ itemToHtml (Located.MkLocated loc (Item.MkItem key itemKind _parentKey maybeName
                   [Xml.attribute "class" "font-monospace text-body-secondary"]
                   [Xml.text (prefix <> sig)]
             ]
+
+    sinceContents :: [Content.Content Element.Element]
+    sinceContents = case maybeSince of
+      Nothing -> []
+      Just s ->
+        [ Content.Element $
+            Xml.element
+              "span"
+              [Xml.attribute "class" "text-body-secondary small ms-2"]
+              [Xml.text (Text.pack "since " <> sinceToText s)]
+        ]
 
     docContents' :: [Content.Content Element.Element]
     docContents' = case doc of

--- a/source/library/Scrod/Core/Item.hs
+++ b/source/library/Scrod/Core/Item.hs
@@ -9,6 +9,7 @@ import qualified Scrod.Core.Doc as Doc
 import qualified Scrod.Core.ItemKey as ItemKey
 import qualified Scrod.Core.ItemKind as ItemKind
 import qualified Scrod.Core.ItemName as ItemName
+import qualified Scrod.Core.Since as Since
 import qualified Scrod.Json.ToJson as ToJson
 import qualified Scrod.Schema as Schema
 
@@ -18,6 +19,7 @@ data Item = MkItem
     parentKey :: Maybe ItemKey.ItemKey,
     name :: Maybe ItemName.ItemName,
     documentation :: Doc.Doc,
+    since :: Maybe Since.Since,
     signature :: Maybe Text.Text
   }
   deriving (Eq, Generics.Generic, Ord, Show)

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -938,6 +938,42 @@ spec s = Spec.describe s "integration" $ do
             ("/items/0/value/signature", "\"Int\"")
           ]
 
+      Spec.it s "works with @since annotation" $ do
+        check
+          s
+          """
+          -- | Docs
+          --
+          -- @since 1.2.3
+          x :: Int
+          x = 0
+          """
+          [ ("/items/0/value/name", "\"x\""),
+            ("/items/0/value/since/version", "[1,2,3]")
+          ]
+
+      Spec.it s "works with @since annotation with package" $ do
+        check
+          s
+          """
+          -- | Docs
+          --
+          -- @since base-4.16.0
+          x :: Int
+          x = 0
+          """
+          [ ("/items/0/value/name", "\"x\""),
+            ("/items/0/value/since/package", "\"base\""),
+            ("/items/0/value/since/version", "[4,16,0]")
+          ]
+
+      Spec.it s "defaults to no @since" $ do
+        check
+          s
+          "x = 0"
+          [ ("/items/0/value/since", "")
+          ]
+
     Spec.it s "open type family" $ do
       check s "{-# language TypeFamilies #-} type family A" [("/items/0/value/kind/type", "\"OpenTypeFamily\"")]
 


### PR DESCRIPTION
## Summary
- Add `since` field to `Item` type to store `@since` annotations from doc comments
- Update `parseDoc` and the doc association pipeline to extract and propagate `Maybe Since` through all conversion functions
- Display `@since` version in item card headers in HTML output (and include in JSON via generic deriving)

Fixes #157

## Test plan
- Three new integration tests verify item-level `@since`: with version only, with package+version, and default absent
- All 691 existing tests pass
- Verified with `cabal build --flags=pedantic`, `hlint`, and `ormolu`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>