### PR TITLE
Show deriving strategy on derived instances

### DIFF
--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -219,6 +219,9 @@ convertDeclWithDocMaybeM doc docSince lDecl = case SrcLoc.unLoc lDecl of
   Syntax.SpliceD _ spliceDecl ->
     let sig = Just . Text.pack . Outputable.showSDocUnsafe . Outputable.ppr $ spliceDecl
      in Maybe.maybeToList <$> convertDeclWithDocM Nothing doc docSince Nothing sig lDecl
+  Syntax.DerivD _ derivDecl ->
+    let strategy = extractDerivStrategy $ Syntax.deriv_strategy derivDecl
+     in Maybe.maybeToList <$> convertDeclWithDocM Nothing doc docSince (Names.extractDeclName lDecl) strategy lDecl
   _ -> Maybe.maybeToList <$> convertDeclWithDocM Nothing doc docSince (Names.extractDeclName lDecl) Nothing lDecl
 
 -- | Convert a type/class declaration with documentation.

--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -464,25 +464,28 @@ convertDerivingClauseM ::
   Internal.ConvertM [Located.Located Item.Item]
 convertDerivingClauseM parentKey lClause = do
   let clause = SrcLoc.unLoc lClause
+      strategy = extractDerivStrategy $ Syntax.deriv_clause_strategy clause
       derivClauseTys = SrcLoc.unLoc $ Syntax.deriv_clause_tys clause
-  convertDerivClauseTysM parentKey derivClauseTys
+  convertDerivClauseTysM parentKey strategy derivClauseTys
 
 -- | Convert deriving clause types.
 convertDerivClauseTysM ::
   Maybe ItemKey.ItemKey ->
+  Maybe Text.Text ->
   Syntax.DerivClauseTys Ghc.GhcPs ->
   Internal.ConvertM [Located.Located Item.Item]
-convertDerivClauseTysM parentKey dct = case dct of
-  Syntax.DctSingle _ lSigTy -> Maybe.maybeToList <$> convertDerivedTypeM parentKey lSigTy
-  Syntax.DctMulti _ lSigTys -> Maybe.catMaybes <$> traverse (convertDerivedTypeM parentKey) lSigTys
+convertDerivClauseTysM parentKey strategy dct = case dct of
+  Syntax.DctSingle _ lSigTy -> Maybe.maybeToList <$> convertDerivedTypeM parentKey strategy lSigTy
+  Syntax.DctMulti _ lSigTys -> Maybe.catMaybes <$> traverse (convertDerivedTypeM parentKey strategy) lSigTys
 
 -- | Convert a derived type to an item.
 convertDerivedTypeM ::
   Maybe ItemKey.ItemKey ->
+  Maybe Text.Text ->
   Syntax.LHsSigType Ghc.GhcPs ->
   Internal.ConvertM (Maybe (Located.Located Item.Item))
-convertDerivedTypeM parentKey lSigTy =
-  Internal.mkItemM (Annotation.getLocA lSigTy) parentKey (extractDerivedTypeName lSigTy) (extractDerivedTypeDoc lSigTy) Nothing ItemKind.DerivedInstance
+convertDerivedTypeM parentKey strategy lSigTy =
+  Internal.mkItemM (Annotation.getLocA lSigTy) parentKey (extractDerivedTypeName lSigTy) (extractDerivedTypeDoc lSigTy) strategy ItemKind.DerivedInstance
 
 -- | Extract name from a derived type.
 extractDerivedTypeName :: Syntax.LHsSigType Ghc.GhcPs -> Maybe ItemName.ItemName
@@ -502,3 +505,9 @@ extractDerivedTypeDoc lSigTy =
    in case bodyTy of
         Syntax.HsDocTy _ _ lDoc -> GhcDoc.convertLHsDoc lDoc
         _ -> Doc.Empty
+
+-- | Extract deriving strategy text from a deriving clause.
+extractDerivStrategy ::
+  Maybe (Syntax.LDerivStrategy Ghc.GhcPs) ->
+  Maybe Text.Text
+extractDerivStrategy = fmap (Text.pack . Outputable.showSDocUnsafe . Outputable.ppr . SrcLoc.unLoc)

--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -701,6 +701,7 @@ itemToHtml (Located.MkLocated loc (Item.MkItem key itemKind _parentKey maybeName
       ItemKind.TypeData -> True
       ItemKind.TypeSynonym -> True
       ItemKind.Class -> True
+      ItemKind.DerivedInstance -> True
       _ -> False
 
     kindElement :: Element.Element

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -1380,7 +1380,8 @@ spec s = Spec.describe s "integration" $ do
         """
         [ ("/items/2/value/kind/type", "\"StandaloneDeriving\""),
           ("/items/2/value/name", "\"O W2\""),
-          ("/items/2/value/parentKey", "1")
+          ("/items/2/value/parentKey", "1"),
+          ("/items/2/value/signature", "\"anyclass\"")
         ]
 
     Spec.it s "standalone deriving via" $ do
@@ -1425,19 +1426,6 @@ spec s = Spec.describe s "integration" $ do
         [ ("/items/1/value/kind/type", "\"DerivedInstance\""),
           ("/items/1/value/name", "\"Show\""),
           ("/items/1/value/signature", "\"stock\"")
-        ]
-
-    Spec.it s "data deriving anyclass" $ do
-      check
-        s
-        """
-        {-# LANGUAGE DerivingStrategies, DeriveAnyClass #-}
-        class C a
-        data R4
-        deriving anyclass instance C R4
-        """
-        [ ("/items/2/value/kind/type", "\"StandaloneDeriving\""),
-          ("/items/2/value/name", "\"C R4\"")
         ]
 
     Spec.it s "data deriving via" $ do

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -1379,6 +1379,52 @@ spec s = Spec.describe s "integration" $ do
           ("/items/2/value/name", "\"Eq\"")
         ]
 
+    Spec.it s "data deriving stock" $ do
+      check
+        s
+        """
+        {-# LANGUAGE DerivingStrategies #-}
+        data R3 deriving stock Show
+        """
+        [ ("/items/1/value/kind/type", "\"DerivedInstance\""),
+          ("/items/1/value/name", "\"Show\""),
+          ("/items/1/value/signature", "\"stock\"")
+        ]
+
+    Spec.it s "data deriving anyclass" $ do
+      check
+        s
+        """
+        {-# LANGUAGE DerivingStrategies, DeriveAnyClass #-}
+        class C a
+        data R4
+        deriving anyclass instance C R4
+        """
+        [ ("/items/2/value/kind/type", "\"StandaloneDeriving\""),
+          ("/items/2/value/name", "\"C R4\"")
+        ]
+
+    Spec.it s "data deriving via" $ do
+      check
+        s
+        """
+        {-# LANGUAGE DerivingStrategies, DerivingVia #-}
+        data R5 deriving Show via ()
+        """
+        [ ("/items/1/value/kind/type", "\"DerivedInstance\""),
+          ("/items/1/value/name", "\"Show\""),
+          ("/items/1/value/signature", "\"via ()\"")
+        ]
+
+    Spec.it s "data deriving no strategy" $ do
+      check
+        s
+        "data R6 deriving Show"
+        [ ("/items/1/value/kind/type", "\"DerivedInstance\""),
+          ("/items/1/value/name", "\"Show\""),
+          ("/items/1/value/signature", "")
+        ]
+
     Spec.it s "data GADT deriving" $ do
       check s "data T where deriving Show" []
 


### PR DESCRIPTION
## Summary
- Extract the deriving strategy (stock, anyclass, newtype, via) from GHC's `HsDerivingClause` and store it in the `signature` field of `DerivedInstance` items
- Display the strategy before the kind badge in HTML output (e.g., **Show** stock [deriving])
- Add integration tests for stock, via, and no-strategy deriving clauses

Fixes #158

## Test plan
- [x] All 692 tests pass
- [x] `ormolu --mode check` passes
- [x] `hlint source/` passes
- Verify with example from issue: `data A deriving B; deriving stock C; deriving anyclass D; deriving newtype E; deriving F via G`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>