### PR TITLE
Exclude default declarations from output

### DIFF
--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -243,6 +243,7 @@ convertDeclWithDocMaybeM doc lDecl = case SrcLoc.unLoc lDecl of
   Syntax.SpliceD _ spliceDecl ->
     let sig = Just . Text.pack . Outputable.showSDocUnsafe . Outputable.ppr $ spliceDecl
      in Maybe.maybeToList <$> convertDeclWithDocM Nothing doc Nothing sig lDecl
+  Syntax.DefD {} -> pure []
   _ -> Maybe.maybeToList <$> convertDeclWithDocM Nothing doc (Names.extractDeclName lDecl) Nothing lDecl
 
 -- | Convert a type/class declaration with documentation.

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -1686,7 +1686,7 @@ spec s = Spec.describe s "integration" $ do
         []
 
     Spec.it s "default declaration" $ do
-      check s "default ()" []
+      check s "default ()" [("/items", "[]")]
 
     Spec.it s "foreign import" $ do
       check


### PR DESCRIPTION
## Summary
- Skip `default` declarations (e.g., `default ()`) during GHC AST conversion so they don't appear as empty items in the output
- Update the integration test to assert that `default ()` produces no items

Fixes #160

## Test plan
- [x] All 688 tests pass
- [x] `ormolu --mode check` passes
- [x] `hlint source/` passes
- Verify `default ()` produces `"items":[]` in JSON output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>