### PR TITLE
Parent instances under their class

### DIFF
--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -185,7 +185,8 @@ extractItems ::
 extractItems lHsModule =
   let rawItems = Internal.runConvert $ extractItemsM lHsModule
       instanceHeadTypes = InstanceParents.extractInstanceHeadTypeNames lHsModule
-      parentedItems = InstanceParents.associateInstanceParents instanceHeadTypes rawItems
+      instanceClassNames = InstanceParents.extractInstanceClassNames lHsModule
+      parentedItems = InstanceParents.associateInstanceParents instanceHeadTypes instanceClassNames rawItems
       warningLocations = WarningParents.extractWarningLocations lHsModule
       warningParentedItems = WarningParents.associateWarningParents warningLocations parentedItems
    in Merge.mergeItemsByName warningParentedItems

--- a/source/library/Scrod/Convert/FromGhc/InstanceParents.hs
+++ b/source/library/Scrod/Convert/FromGhc/InstanceParents.hs
@@ -89,10 +89,13 @@ extractHeadTypeName lTy = case SrcLoc.unLoc lTy of
   _ -> Nothing
 
 -- | Extract the class name from an instance head. For @C T@ this
--- returns @C@; for @Functor F@ this returns @Functor@.
+-- returns @C@; for @Functor F@ this returns @Functor@. For nullary
+-- classes (e.g., @instance C@) this returns @C@.
 extractClassName :: Syntax.LHsType Ghc.GhcPs -> Maybe ItemName.ItemName
 extractClassName lTy = case SrcLoc.unLoc lTy of
   Syntax.HsAppTy _ fun _ -> extractOutermostTyCon fun
+  Syntax.HsAppKindTy _ fun _ -> extractOutermostTyCon fun
+  Syntax.HsTyVar {} -> extractOutermostTyCon lTy
   Syntax.HsQualTy _ _ body -> extractClassName body
   Syntax.HsForAllTy _ _ body -> extractClassName body
   Syntax.HsParTy _ inner -> extractClassName inner

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -1234,7 +1234,9 @@ spec s = Spec.describe s "integration" $ do
         class Z a
         instance Z ()
         """
-        [("/items/1/value/kind/type", "\"ClassInstance\"")]
+        [ ("/items/1/value/kind/type", "\"ClassInstance\""),
+          ("/items/1/value/parentKey", "0")
+        ]
 
     Spec.it s "class instance parent is local type" $ do
       check
@@ -1256,7 +1258,8 @@ spec s = Spec.describe s "integration" $ do
         class C a
         instance C Int
         """
-        [ ("/items/1/value/kind/type", "\"ClassInstance\"")
+        [ ("/items/1/value/kind/type", "\"ClassInstance\""),
+          ("/items/1/value/parentKey", "0")
         ]
 
     Spec.it s "data instance" $ do

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -1262,6 +1262,18 @@ spec s = Spec.describe s "integration" $ do
           ("/items/1/value/parentKey", "0")
         ]
 
+    Spec.it s "standalone deriving parent is local class when type is external" $ do
+      check
+        s
+        """
+        {-# language StandaloneDeriving #-}
+        class C a where
+        deriving instance C Int
+        """
+        [ ("/items/1/value/kind/type", "\"StandaloneDeriving\""),
+          ("/items/1/value/parentKey", "0")
+        ]
+
     Spec.it s "data instance" $ do
       check
         s


### PR DESCRIPTION
## Summary
- When an instance (e.g., `instance C Int`) is defined in a module that also defines the class `C`, the instance is now parented under `C`
- The existing behavior of parenting under the local type takes priority — only falls back to the class when the type isn't defined locally
- Extracts class names from instance heads alongside the existing head type name extraction, using the class name as a fallback parent

Closes #163

## Test plan
- [x] Updated "class instance" test to assert `parentKey` points to the class
- [x] Updated "class instance parent is local class when type is external" test to assert `parentKey`
- [x] Existing "class instance parent is local type" test still passes (type takes priority over class)
- [x] All 696 tests pass
- [x] Builds clean with `--flags=pedantic`

🤖 Generated with [Claude Code](https://claude.com/claude-code)