### PR TITLE
Fix #153: Resolve named documentation chunks

### DIFF
--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -563,7 +563,5 @@ resolveNamedDocExport ::
   Export.Export
 resolveNamedDocExport namedChunks export = case export of
   Export.DocNamed name ->
-    case Map.lookup name namedChunks of
-      Just doc -> Export.Doc doc
-      Nothing -> export
+    maybe export Export.Doc (Map.lookup name namedChunks)
   _ -> export

--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -38,6 +38,7 @@ import qualified Scrod.Convert.FromGhc.Merge as Merge
 import qualified Scrod.Convert.FromGhc.Names as Names
 import qualified Scrod.Convert.FromGhc.WarningParents as WarningParents
 import qualified Scrod.Core.Doc as Doc
+import qualified Scrod.Core.Export as Export
 import qualified Scrod.Core.Extension as Extension
 import qualified Scrod.Core.Import as Import
 import qualified Scrod.Core.Item as Item
@@ -64,6 +65,7 @@ fromGhc ::
 fromGhc isSignature ((language, extensions), lHsModule) = do
   version <- maybe (Left "invalid version") Right $ versionFromBase PackageInfo.version
   let (moduleDocumentation, moduleSince) = extractModuleDocAndSince lHsModule
+      namedDocChunks = extractNamedDocChunks lHsModule
   Right
     Module.MkModule
       { Module.version = version,
@@ -74,7 +76,7 @@ fromGhc isSignature ((language, extensions), lHsModule) = do
         Module.signature = isSignature,
         Module.name = extractModuleName lHsModule,
         Module.warning = extractModuleWarning lHsModule,
-        Module.exports = Exports.extractModuleExports lHsModule,
+        Module.exports = resolveNamedDocExports namedDocChunks <$> Exports.extractModuleExports lHsModule,
         Module.imports = extractModuleImports lHsModule,
         Module.items = extractItems lHsModule
       }
@@ -528,3 +530,40 @@ extractDerivStrategy ::
   Maybe (Syntax.LDerivStrategy Ghc.GhcPs) ->
   Maybe Text.Text
 extractDerivStrategy = fmap (Text.pack . Outputable.showSDocUnsafe . Outputable.ppr . SrcLoc.unLoc)
+
+-- | Extract named documentation chunks from module declarations.
+extractNamedDocChunks ::
+  SrcLoc.Located (Syntax.HsModule Ghc.GhcPs) ->
+  Map.Map Text.Text Doc.Doc
+extractNamedDocChunks lHsModule =
+  let hsModule = SrcLoc.unLoc lHsModule
+      decls = Syntax.hsmodDecls hsModule
+   in Map.fromList $ Maybe.mapMaybe extractNamedDocChunk decls
+
+-- | Extract a named doc chunk from a declaration, if applicable.
+extractNamedDocChunk ::
+  Syntax.LHsDecl Ghc.GhcPs ->
+  Maybe (Text.Text, Doc.Doc)
+extractNamedDocChunk lDecl = case SrcLoc.unLoc lDecl of
+  Syntax.DocD _ (Hs.DocCommentNamed name lDoc) ->
+    Just (Text.pack name, GhcDoc.convertExportDoc lDoc)
+  _ -> Nothing
+
+-- | Resolve named documentation chunk references in an export list.
+resolveNamedDocExports ::
+  Map.Map Text.Text Doc.Doc ->
+  [Export.Export] ->
+  [Export.Export]
+resolveNamedDocExports namedChunks = fmap (resolveNamedDocExport namedChunks)
+
+-- | Resolve a single named documentation chunk reference.
+resolveNamedDocExport ::
+  Map.Map Text.Text Doc.Doc ->
+  Export.Export ->
+  Export.Export
+resolveNamedDocExport namedChunks export = case export of
+  Export.DocNamed name ->
+    case Map.lookup name namedChunks of
+      Just doc -> Export.Doc doc
+      Nothing -> export
+  _ -> export

--- a/source/library/Scrod/Convert/FromGhc/Doc.hs
+++ b/source/library/Scrod/Convert/FromGhc/Doc.hs
@@ -71,6 +71,8 @@ associateNextDocsLoop pendingDoc pendingSince (lDecl : rest) = case SrcLoc.unLoc
      in associateNextDocsLoop (Internal.appendDoc pendingDoc newDoc) (Internal.appendSince pendingSince newSince) rest
   Syntax.DocD _ (Hs.DocCommentPrev _) ->
     (Doc.Empty, Nothing, lDecl) : associateNextDocsLoop Doc.Empty Nothing rest
+  Syntax.DocD _ (Hs.DocCommentNamed {}) ->
+    associateNextDocsLoop pendingDoc pendingSince rest
   _ ->
     (pendingDoc, pendingSince, lDecl) : associateNextDocsLoop Doc.Empty Nothing rest
 

--- a/source/library/Scrod/Convert/FromGhc/InstanceParents.hs
+++ b/source/library/Scrod/Convert/FromGhc/InstanceParents.hs
@@ -8,6 +8,7 @@ module Scrod.Convert.FromGhc.InstanceParents where
 
 import qualified Data.Map as Map
 import qualified Data.Maybe as Maybe
+import GHC.Hs ()
 import qualified GHC.Hs.Extension as Ghc
 import qualified GHC.Parser.Annotation as Annotation
 import qualified GHC.Types.SrcLoc as SrcLoc

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -799,7 +799,7 @@ spec s = Spec.describe s "integration" $ do
           ]
 
     Spec.describe s "doc named" $ do
-      Spec.it s "works" $ do
+      Spec.it s "unresolved" $ do
         check
           s
           """
@@ -809,6 +809,49 @@ spec s = Spec.describe s "integration" $ do
           """
           [ ("/exports/0/type", "\"DocNamed\""),
             ("/exports/0/value", "\"foo\"")
+          ]
+
+      Spec.it s "resolved" $ do
+        check
+          s
+          """
+          module M
+            ( -- $foo
+              unit,
+            ) where
+
+          -- $foo
+          -- bar
+
+          unit :: ()
+          unit = ()
+          """
+          [ ("/exports/0/type", "\"Doc\""),
+            ("/exports/0/value/type", "\"Paragraph\""),
+            ("/exports/0/value/value/type", "\"String\""),
+            ("/exports/0/value/value/value", "\"bar\""),
+            ("/exports/1/type", "\"Identifier\""),
+            ("/exports/1/value/name/name", "\"unit\"")
+          ]
+
+      Spec.it s "does not create items for named chunks" $ do
+        check
+          s
+          """
+          module M
+            ( -- $foo
+              unit,
+            ) where
+
+          -- $foo
+          -- bar
+
+          unit :: ()
+          unit = ()
+          """
+          [ ("/items/0/value/name", "\"unit\""),
+            ("/items/0/value/kind/type", "\"Function\""),
+            ("/items/0/value/signature", "\"()\"")
           ]
 
   Spec.describe s "imports" $ do


### PR DESCRIPTION
## Summary
- Named doc chunks (`-- $foo`) referenced in the export list are now expanded to their documentation content instead of appearing as raw `DocNamed` entries
- Named chunk definitions (`-- $foo` / `-- bar` in the module body) are excluded from the items list so they no longer appear as spurious items
- Fix pre-existing build error in `InstanceParents.hs` (missing `GHC.Hs ()` import for `Anno` type instance)

Closes #153

## Test plan
- [x] New integration test: named chunk reference is resolved to `Doc` with expanded content
- [x] New integration test: named chunks don't create items
- [x] Existing test: unresolved named chunk reference stays as `DocNamed`
- [x] All 698 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)