### PR TITLE
Mention JSON schema asset in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Download the latest release from [GitHub Releases](https://github.com/tfausak/sc
 | `scrod-*.vsix` | VSCode extension for live documentation preview |
 | `scrod-*-wasm.tar.gz` | WASM build (for use in browsers) |
 | `scrod-*-wasi.tar.gz` | WASI build (for use with runtimes like Wasmtime) |
+| `scrod-*-schema.json` | JSON schema for the JSON output format |
 | `scrod-*.tar.gz` | Source tarball |
 
 Or build from source with [GHC](https://www.haskell.org/ghc/) 9.14 and [Cabal](https://www.haskell.org/cabal/):


### PR DESCRIPTION
## Summary
- Add `scrod-*-schema.json` (JSON schema for the JSON output format) to the release assets table in the README

Closes #179

## Test plan
- [x] Verify the new row appears correctly in the asset table
- [ ] Confirm rendered Markdown table looks correct on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)