### PR TITLE
Use Warning item kind for warning pragmas

### DIFF
--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -385,7 +385,7 @@ convertWarnNameM ::
   Syntax.LIdP Ghc.GhcPs ->
   Internal.ConvertM (Maybe (Located.Located Item.Item))
 convertWarnNameM doc lName =
-  Internal.mkItemM (Annotation.getLocA lName) Nothing (Just $ Internal.extractIdPName lName) doc Nothing Nothing ItemKind.Function
+  Internal.mkItemM (Annotation.getLocA lName) Nothing (Just $ Internal.extractIdPName lName) doc Nothing Nothing ItemKind.Warning
 
 -- | Convert class signatures with associated documentation.
 convertClassSigsWithDocsM ::

--- a/source/library/Scrod/Convert/FromGhc/ItemKind.hs
+++ b/source/library/Scrod/Convert/FromGhc/ItemKind.hs
@@ -20,7 +20,7 @@ itemKindFromDecl decl = case decl of
   Syntax.KindSigD {} -> ItemKind.StandaloneKindSig
   Syntax.DefD {} -> ItemKind.Default
   Syntax.ForD _ foreignDecl -> itemKindFromForeignDecl foreignDecl
-  Syntax.WarningD {} -> ItemKind.Function -- Treat as function for now
+  Syntax.WarningD {} -> ItemKind.Warning
   Syntax.AnnD {} -> ItemKind.Annotation
   Syntax.RuleD {} -> ItemKind.Rule
   Syntax.SpliceD {} -> ItemKind.Splice

--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -805,6 +805,7 @@ kindToText k = case k of
   ItemKind.Default -> Text.pack "default"
   ItemKind.Annotation -> Text.pack "annotation"
   ItemKind.Splice -> Text.pack "splice"
+  ItemKind.Warning -> Text.pack "warning"
 
 data KindColor
   = KindSuccess
@@ -845,6 +846,7 @@ kindColor k = case k of
   ItemKind.Default -> KindSecondary
   ItemKind.Annotation -> KindSecondary
   ItemKind.Splice -> KindSecondary
+  ItemKind.Warning -> KindWarning
 
 kindBadgeClass :: ItemKind.ItemKind -> String
 kindBadgeClass k = case kindColor k of

--- a/source/library/Scrod/Core/ItemKind.hs
+++ b/source/library/Scrod/Core/ItemKind.hs
@@ -69,5 +69,7 @@ data ItemKind
     Annotation
   | -- | Template Haskell splice or quasi-quote: @$(expr)@ or @[quoter|...|]@
     Splice
+  | -- | Warning pragma: @{-# WARNING x "msg" #-}@
+    Warning
   deriving (Eq, Generics.Generic, Ord, Show)
   deriving (ToJson.ToJson, Schema.ToSchema) via Generics.Generically ItemKind

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -1936,7 +1936,7 @@ spec s = Spec.describe s "integration" $ do
         [ ("/items/0/value/name", "\"x\""),
           ("/items/0/value/kind/type", "\"Function\""),
           ("/items/1/value/name", "\"x\""),
-          ("/items/1/value/kind/type", "\"Function\""),
+          ("/items/1/value/kind/type", "\"Warning\""),
           ("/items/1/value/parentKey", "0"),
           ("/items/1/value/documentation/value/value", "\"w\"")
         ]
@@ -1954,11 +1954,11 @@ spec s = Spec.describe s "integration" $ do
           ("/items/1/value/name", "\"y\""),
           ("/items/1/value/kind/type", "\"Function\""),
           ("/items/2/value/name", "\"x\""),
-          ("/items/2/value/kind/type", "\"Function\""),
+          ("/items/2/value/kind/type", "\"Warning\""),
           ("/items/2/value/parentKey", "0"),
           ("/items/2/value/documentation/value/value", "\"z\""),
           ("/items/3/value/name", "\"y\""),
-          ("/items/3/value/kind/type", "\"Function\""),
+          ("/items/3/value/kind/type", "\"Warning\""),
           ("/items/3/value/parentKey", "1"),
           ("/items/3/value/documentation/value/value", "\"z\"")
         ]
@@ -1970,7 +1970,7 @@ spec s = Spec.describe s "integration" $ do
         {-# warning x "w" #-}
         """
         [ ("/items/0/value/name", "\"x\""),
-          ("/items/0/value/kind/type", "\"Function\""),
+          ("/items/0/value/kind/type", "\"Warning\""),
           ("/items/0/value/parentKey", ""),
           ("/items/0/value/documentation/value/value", "\"w\"")
         ]


### PR DESCRIPTION
Fixes #182.

## Summary
- Add a `Warning` constructor to `ItemKind` for `{-# WARNING #-}` pragmas
- Map `WarningD` GHC declarations and warning name items to the new `Warning` kind instead of `Function`
- Render warning items with an orange/yellow badge (`KindWarning`) instead of green (`KindSuccess`)

Closes #182

## Test plan
- [x] `cabal build --flags=pedantic` succeeds
- [x] All 705 tests pass with `cabal test --test-options='--hide-successes'`
- [x] Integration tests updated to expect `"Warning"` kind for warning pragma items

🤖 Generated with [Claude Code](https://claude.com/claude-code)