### PR TITLE
Include strictness in record field signatures

### DIFF
--- a/source/library/Scrod/Convert/FromGhc/Internal.hs
+++ b/source/library/Scrod/Convert/FromGhc/Internal.hs
@@ -134,9 +134,9 @@ extractIdPName = ItemName.MkItemName . extractRdrName
 
 -- | Extract name from a field occurrence.
 extractFieldOccName :: Syntax.LFieldOcc Ghc.GhcPs -> ItemName.ItemName
-extractFieldOccName lFieldOcc =
-  let fieldOcc = SrcLoc.unLoc lFieldOcc
-   in ItemName.MkItemName . extractRdrName $ Syntax.foLabel fieldOcc
+extractFieldOccName lFieldOcc = case SrcLoc.unLoc lFieldOcc of
+  Syntax.FieldOcc _ lbl -> ItemName.MkItemName $ extractRdrName lbl
+  Syntax.XFieldOcc _ -> ItemName.MkItemName . Text.pack $ ""
 
 -- | Append two 'Doc' values.
 appendDoc :: Doc.Doc -> Doc.Doc -> Doc.Doc

--- a/source/library/Scrod/Convert/FromGhc/Internal.hs
+++ b/source/library/Scrod/Convert/FromGhc/Internal.hs
@@ -13,6 +13,7 @@ import qualified Documentation.Haddock.Types as Haddock
 import qualified GHC.Data.FastString as FastString
 import qualified GHC.Hs.Doc as HsDoc
 import qualified GHC.Hs.Extension as Ghc
+import GHC.Hs.Type ()
 import qualified GHC.Types.Name.Reader as Reader
 import qualified GHC.Types.SourceText as SourceText
 import qualified GHC.Types.SrcLoc as SrcLoc
@@ -136,7 +137,6 @@ extractIdPName = ItemName.MkItemName . extractRdrName
 extractFieldOccName :: Syntax.LFieldOcc Ghc.GhcPs -> ItemName.ItemName
 extractFieldOccName lFieldOcc = case SrcLoc.unLoc lFieldOcc of
   Syntax.FieldOcc _ lbl -> ItemName.MkItemName $ extractRdrName lbl
-  Syntax.XFieldOcc _ -> ItemName.MkItemName . Text.pack $ ""
 
 -- | Append two 'Doc' values.
 appendDoc :: Doc.Doc -> Doc.Doc -> Doc.Doc

--- a/source/library/Scrod/Convert/FromGhc/WarningParents.hs
+++ b/source/library/Scrod/Convert/FromGhc/WarningParents.hs
@@ -1,6 +1,3 @@
--- TODO: Figure out why this is necessary and remove it.
-{-# OPTIONS_GHC -Wno-overlapping-patterns #-}
-
 -- | Resolve warning parent relationships.
 --
 -- Associates warning pragma items with their target declarations when
@@ -16,6 +13,7 @@ import qualified GHC.Hs.Extension as Ghc
 import qualified GHC.Parser.Annotation as Annotation
 import qualified GHC.Types.SrcLoc as SrcLoc
 import qualified Language.Haskell.Syntax as Syntax
+import GHC.Hs.Decls ()
 import qualified Scrod.Convert.FromGhc.Internal as Internal
 import qualified Scrod.Core.Item as Item
 import qualified Scrod.Core.ItemKey as ItemKey
@@ -49,7 +47,6 @@ extractWarnDeclLocations ::
 extractWarnDeclLocations lWarnDecl = case SrcLoc.unLoc lWarnDecl of
   Syntax.Warning _ names _ ->
     concatMap (foldMap pure . Internal.locationFromSrcSpan . Annotation.getLocA) names
-  Syntax.XWarnDecl {} -> []
 
 -- | Associate warning items with their target declarations.
 associateWarningParents ::

--- a/source/library/Scrod/Convert/FromGhc/WarningParents.hs
+++ b/source/library/Scrod/Convert/FromGhc/WarningParents.hs
@@ -9,11 +9,11 @@ module Scrod.Convert.FromGhc.WarningParents where
 import qualified Data.Map as Map
 import qualified Data.Maybe as Maybe
 import qualified Data.Set as Set
+import GHC.Hs.Decls ()
 import qualified GHC.Hs.Extension as Ghc
 import qualified GHC.Parser.Annotation as Annotation
 import qualified GHC.Types.SrcLoc as SrcLoc
 import qualified Language.Haskell.Syntax as Syntax
-import GHC.Hs.Decls ()
 import qualified Scrod.Convert.FromGhc.Internal as Internal
 import qualified Scrod.Core.Item as Item
 import qualified Scrod.Core.ItemKey as ItemKey

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -1246,7 +1246,35 @@ spec s = Spec.describe s "integration" $ do
         "data S = T { u :: () }"
         [ ("/items/0/value/kind/type", "\"DataType\""),
           ("/items/1/value/kind/type", "\"DataConstructor\""),
-          ("/items/2/value/kind/type", "\"RecordField\"")
+          ("/items/2/value/kind/type", "\"RecordField\""),
+          ("/items/2/value/signature", "\"()\"")
+        ]
+
+    Spec.it s "record field with strict annotation" $ do
+      check
+        s
+        "data A = B { c :: !Int }"
+        [ ("/items/0/value/kind/type", "\"DataType\""),
+          ("/items/1/value/kind/type", "\"DataConstructor\""),
+          ("/items/2/value/kind/type", "\"RecordField\""),
+          ("/items/2/value/name", "\"c\""),
+          ("/items/2/value/signature", "\"!Int\"")
+        ]
+
+    Spec.it s "record field with lazy annotation" $ do
+      check
+        s
+        "data A = B { c :: ~Int }"
+        [ ("/items/2/value/kind/type", "\"RecordField\""),
+          ("/items/2/value/signature", "\"~Int\"")
+        ]
+
+    Spec.it s "record field with UNPACK pragma" $ do
+      check
+        s
+        "data A = B { c :: {-# UNPACK #-} !Int }"
+        [ ("/items/2/value/kind/type", "\"RecordField\""),
+          ("/items/2/value/signature", "\"{-# UNPACK #-} !Int\"")
         ]
 
     Spec.it s "record field GADT" $ do


### PR DESCRIPTION
Fixes #184.

## Summary
- Include source strictness (`!`), laziness (`~`), and `{-# UNPACK #-}`/`{-# NOUNPACK #-}` pragmas in record field signatures
- Previously `convertConDeclFieldM` only printed `cdf_type`, dropping `cdf_bang` (strictness) and `cdf_unpack` (unpackedness) from the `HsConDeclField`
- Add `strictnessDoc` and `unpackednessDoc` helpers in `Constructors.hs` to render these annotations
- Fix pre-existing `-Wincomplete-record-selectors` warning in `extractFieldOccName` by using an explicit case expression instead of the `foLabel` record selector

Closes #184

## Test plan
- [x] `cabal build --flags=pedantic` succeeds
- [x] All 708 tests pass (705 existing + 3 new)
- [x] New test: `data A = B { c :: !Int }` outputs signature `"!Int"`
- [x] New test: `data A = B { c :: ~Int }` outputs signature `"~Int"`
- [x] New test: `data A = B { c :: {-# UNPACK #-} !Int }` outputs signature `"{-# UNPACK #-} !Int"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)