### PR TITLE
Properly handle type role annotations

### DIFF
--- a/scrod.cabal
+++ b/scrod.cabal
@@ -99,6 +99,7 @@ library
     Scrod.Convert.FromGhc.ItemKind
     Scrod.Convert.FromGhc.Merge
     Scrod.Convert.FromGhc.Names
+    Scrod.Convert.FromGhc.RoleParents
     Scrod.Convert.FromGhc.WarningParents
     Scrod.Convert.FromHaddock
     Scrod.Convert.ToHtml

--- a/source/library/Scrod/Convert/FromGhc/ItemKind.hs
+++ b/source/library/Scrod/Convert/FromGhc/ItemKind.hs
@@ -25,7 +25,7 @@ itemKindFromDecl decl = case decl of
   Syntax.RuleD {} -> ItemKind.Rule
   Syntax.SpliceD {} -> ItemKind.Splice
   Syntax.DocD {} -> ItemKind.Function -- Doc comment
-  Syntax.RoleAnnotD {} -> ItemKind.Function -- Role annotation
+  Syntax.RoleAnnotD {} -> ItemKind.RoleAnnotation
   Syntax.DerivD {} -> ItemKind.StandaloneDeriving
 
 -- | Determine ItemKind from a type/class declaration.

--- a/source/library/Scrod/Convert/FromGhc/RoleParents.hs
+++ b/source/library/Scrod/Convert/FromGhc/RoleParents.hs
@@ -46,7 +46,10 @@ associateRoleParents roleLocations items =
   let nameToKey = buildNameToKeyMap roleLocations items
    in fmap (resolveRoleParent roleLocations nameToKey) items
 
--- | Build a map from item names to their keys, excluding role annotation items.
+-- | Build a map from item names to their keys, excluding role annotation
+-- items and child items. Only top-level declarations (those with no
+-- parentKey) are eligible parents, so that @data T = T@ maps to the
+-- type declaration rather than the constructor.
 buildNameToKeyMap ::
   Set.Set Location.Location ->
   [Located.Located Item.Item] ->
@@ -60,6 +63,7 @@ buildNameToKeyMap roleLocations =
             Nothing -> []
             Just name ->
               if Set.member (Located.location locItem) roleLocations
+                || Item.parentKey val /= Nothing
                 then []
                 else [(name, Item.key val)]
 

--- a/source/library/Scrod/Convert/FromGhc/RoleParents.hs
+++ b/source/library/Scrod/Convert/FromGhc/RoleParents.hs
@@ -6,6 +6,7 @@
 module Scrod.Convert.FromGhc.RoleParents where
 
 import qualified Data.Map as Map
+import qualified Data.Maybe as Maybe
 import qualified Data.Set as Set
 import qualified GHC.Hs.Extension as Ghc
 import qualified GHC.Parser.Annotation as Annotation
@@ -63,7 +64,7 @@ buildNameToKeyMap roleLocations =
             Nothing -> []
             Just name ->
               if Set.member (Located.location locItem) roleLocations
-                || Item.parentKey val /= Nothing
+                || Maybe.isJust (Item.parentKey val)
                 then []
                 else [(name, Item.key val)]
 

--- a/source/library/Scrod/Convert/FromGhc/RoleParents.hs
+++ b/source/library/Scrod/Convert/FromGhc/RoleParents.hs
@@ -1,0 +1,84 @@
+-- | Resolve role annotation parent relationships.
+--
+-- Associates role annotation items with their target type declarations
+-- when those declarations are defined in the same module. Works like
+-- 'Scrod.Convert.FromGhc.FixityParents' but for @type role@ declarations.
+module Scrod.Convert.FromGhc.RoleParents where
+
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+import qualified GHC.Hs.Extension as Ghc
+import qualified GHC.Parser.Annotation as Annotation
+import qualified GHC.Types.SrcLoc as SrcLoc
+import qualified Language.Haskell.Syntax as Syntax
+import qualified Scrod.Convert.FromGhc.Internal as Internal
+import qualified Scrod.Core.Item as Item
+import qualified Scrod.Core.ItemKey as ItemKey
+import qualified Scrod.Core.ItemName as ItemName
+import qualified Scrod.Core.Located as Located
+import qualified Scrod.Core.Location as Location
+
+-- | Extract the set of source locations that correspond to role annotation
+-- declaration names.
+extractRoleLocations ::
+  SrcLoc.Located (Syntax.HsModule Ghc.GhcPs) ->
+  Set.Set Location.Location
+extractRoleLocations lHsModule =
+  let hsModule = SrcLoc.unLoc lHsModule
+      decls = Syntax.hsmodDecls hsModule
+   in Set.fromList $ concatMap extractDeclRoleLocations decls
+
+-- | Extract role annotation name locations from a single declaration.
+extractDeclRoleLocations ::
+  Syntax.LHsDecl Ghc.GhcPs ->
+  [Location.Location]
+extractDeclRoleLocations lDecl = case SrcLoc.unLoc lDecl of
+  Syntax.RoleAnnotD _ (Syntax.RoleAnnotDecl _ lName _) ->
+    foldMap pure $ Internal.locationFromSrcSpan (Annotation.getLocA lName)
+  _ -> []
+
+-- | Associate role annotation items with their target declarations.
+associateRoleParents ::
+  Set.Set Location.Location ->
+  [Located.Located Item.Item] ->
+  [Located.Located Item.Item]
+associateRoleParents roleLocations items =
+  let nameToKey = buildNameToKeyMap roleLocations items
+   in fmap (resolveRoleParent roleLocations nameToKey) items
+
+-- | Build a map from item names to their keys, excluding role annotation items.
+buildNameToKeyMap ::
+  Set.Set Location.Location ->
+  [Located.Located Item.Item] ->
+  Map.Map ItemName.ItemName ItemKey.ItemKey
+buildNameToKeyMap roleLocations =
+  Map.fromList . concatMap getNameAndKey
+  where
+    getNameAndKey locItem =
+      let val = Located.value locItem
+       in case Item.name val of
+            Nothing -> []
+            Just name ->
+              if Set.member (Located.location locItem) roleLocations
+                then []
+                else [(name, Item.key val)]
+
+-- | Set the parentKey on a role annotation item by looking up the target name.
+resolveRoleParent ::
+  Set.Set Location.Location ->
+  Map.Map ItemName.ItemName ItemKey.ItemKey ->
+  Located.Located Item.Item ->
+  Located.Located Item.Item
+resolveRoleParent roleLocations nameToKey locItem =
+  if Set.member (Located.location locItem) roleLocations
+    then case Item.name (Located.value locItem) of
+      Nothing -> locItem
+      Just name ->
+        case Map.lookup name nameToKey of
+          Nothing -> locItem
+          Just parentKey ->
+            locItem
+              { Located.value =
+                  (Located.value locItem) {Item.parentKey = Just parentKey}
+              }
+    else locItem

--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -805,6 +805,7 @@ kindToText k = case k of
   ItemKind.Default -> Text.pack "default"
   ItemKind.Annotation -> Text.pack "annotation"
   ItemKind.Splice -> Text.pack "splice"
+  ItemKind.RoleAnnotation -> Text.pack "role"
 
 data KindColor
   = KindSuccess
@@ -845,6 +846,7 @@ kindColor k = case k of
   ItemKind.Default -> KindSecondary
   ItemKind.Annotation -> KindSecondary
   ItemKind.Splice -> KindSecondary
+  ItemKind.RoleAnnotation -> KindSecondary
 
 kindBadgeClass :: ItemKind.ItemKind -> String
 kindBadgeClass k = case kindColor k of

--- a/source/library/Scrod/Core/ItemKind.hs
+++ b/source/library/Scrod/Core/ItemKind.hs
@@ -69,5 +69,7 @@ data ItemKind
     Annotation
   | -- | Template Haskell splice or quasi-quote: @$(expr)@ or @[quoter|...|]@
     Splice
+  | -- | Role annotation: @type role T nominal@
+    RoleAnnotation
   deriving (Eq, Generics.Generic, Ord, Show)
   deriving (ToJson.ToJson, Schema.ToSchema) via Generics.Generically ItemKind

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -2164,6 +2164,25 @@ spec s = Spec.describe s "integration" $ do
           ("/items/2/value/signature", "\"nominal phantom\"")
         ]
 
+    Spec.it s "role annotation with name collision data T = T" $ do
+      check
+        s
+        """
+        {-# language RoleAnnotations #-}
+        data T = T
+        type role T nominal
+        """
+        [ ("/items/0/value/name", "\"T\""),
+          ("/items/0/value/kind/type", "\"DataType\""),
+          ("/items/0/value/key", "0"),
+          ("/items/1/value/kind/type", "\"DataConstructor\""),
+          ("/items/1/value/name", "\"T\""),
+          ("/items/2/value/name", "\"T\""),
+          ("/items/2/value/kind/type", "\"RoleAnnotation\""),
+          ("/items/2/value/parentKey", "0"),
+          ("/items/2/value/signature", "\"nominal\"")
+        ]
+
     Spec.it s "orphaned role annotation has no parent" $ do
       check
         s

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -2047,7 +2047,44 @@ spec s = Spec.describe s "integration" $ do
         data R a = MkR
         type role R nominal
         """
-        []
+        [ ("/items/0/value/name", "\"R\""),
+          ("/items/0/value/kind/type", "\"DataType\""),
+          ("/items/1/value/kind/type", "\"DataConstructor\""),
+          ("/items/2/value/name", "\"R\""),
+          ("/items/2/value/kind/type", "\"RoleAnnotation\""),
+          ("/items/2/value/parentKey", "0"),
+          ("/items/2/value/signature", "\"nominal\"")
+        ]
+
+    Spec.it s "role annotation with multiple roles" $ do
+      check
+        s
+        """
+        {-# language RoleAnnotations #-}
+        data T a b = MkT
+        type role T nominal phantom
+        """
+        [ ("/items/0/value/name", "\"T\""),
+          ("/items/0/value/kind/type", "\"DataType\""),
+          ("/items/1/value/kind/type", "\"DataConstructor\""),
+          ("/items/2/value/name", "\"T\""),
+          ("/items/2/value/kind/type", "\"RoleAnnotation\""),
+          ("/items/2/value/parentKey", "0"),
+          ("/items/2/value/signature", "\"nominal phantom\"")
+        ]
+
+    Spec.it s "orphaned role annotation has no parent" $ do
+      check
+        s
+        """
+        {-# language RoleAnnotations #-}
+        type role R nominal
+        """
+        [ ("/items/0/value/name", "\"R\""),
+          ("/items/0/value/kind/type", "\"RoleAnnotation\""),
+          ("/items/0/value/parentKey", ""),
+          ("/items/0/value/signature", "\"nominal\"")
+        ]
 
   Spec.describe s "html" $ do
     Spec.it s "generates html without error" $ do


### PR DESCRIPTION
Fixes #185.

## Summary
- Add `RoleAnnotation` constructor to `ItemKind` so type role declarations display with the correct "role" badge (gray, secondary) instead of "function" (green)
- Add explicit `RoleAnnotD` handling in `FromGhc.hs` that extracts the type name and renders the roles (nominal/representational/phantom) as the item signature
- Create new `RoleParents` module (following the `FixityParents`/`WarningParents` pattern) to associate role annotation items with their parent type declarations
- Wire `RoleParents` into the `extractItems` pipeline between fixity parents and merge

## Test plan
- [x] `cabal build --flags=pedantic` succeeds
- [x] All 707 tests pass (705 existing - 1 replaced + 3 new)
- [x] `type role R nominal` → name "R", kind "RoleAnnotation", parent = data type, signature "nominal"
- [x] `type role T nominal phantom` → signature "nominal phantom"
- [x] Orphaned role annotation (no matching type) → no parent key

🤖 Generated with [Claude Code](https://claude.com/claude-code)