### PR TITLE
Parent default method signatures to their method

### DIFF
--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -805,6 +805,7 @@ kindToText k = case k of
   ItemKind.Default -> Text.pack "default"
   ItemKind.Annotation -> Text.pack "annotation"
   ItemKind.Splice -> Text.pack "splice"
+  ItemKind.DefaultMethodSignature -> Text.pack "default"
 
 data KindColor
   = KindSuccess
@@ -845,6 +846,7 @@ kindColor k = case k of
   ItemKind.Default -> KindSecondary
   ItemKind.Annotation -> KindSecondary
   ItemKind.Splice -> KindSecondary
+  ItemKind.DefaultMethodSignature -> KindPrimary
 
 kindBadgeClass :: ItemKind.ItemKind -> String
 kindBadgeClass k = case kindColor k of

--- a/source/library/Scrod/Core/ItemKind.hs
+++ b/source/library/Scrod/Core/ItemKind.hs
@@ -69,5 +69,7 @@ data ItemKind
     Annotation
   | -- | Template Haskell splice or quasi-quote: @$(expr)@ or @[quoter|...|]@
     Splice
+  | -- | Default method signature: @default m :: Show a => a -> String@
+    DefaultMethodSignature
   deriving (Eq, Generics.Generic, Ord, Show)
   deriving (ToJson.ToJson, Schema.ToSchema) via Generics.Generically ItemKind

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -1704,7 +1704,18 @@ spec s = Spec.describe s "integration" $ do
           default t :: a
           t = undefined
         """
-        []
+        [ ("/items/0/value/kind/type", "\"Class\""),
+          ("/items/0/value/name", "\"S\""),
+          ("/items/0/value/key", "0"),
+          ("/items/1/value/kind/type", "\"ClassMethod\""),
+          ("/items/1/value/name", "\"t\""),
+          ("/items/1/value/parentKey", "0"),
+          ("/items/1/value/key", "1"),
+          ("/items/2/value/kind/type", "\"DefaultMethodSignature\""),
+          ("/items/2/value/name", "\"t\""),
+          ("/items/2/value/parentKey", "1"),
+          ("/items/2/value/signature", "\"a\"")
+        ]
 
     Spec.it s "fixity has parent set" $ do
       check

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -1743,6 +1743,24 @@ spec s = Spec.describe s "integration" $ do
           ("/items/2/value/signature", "\"a\"")
         ]
 
+    Spec.it s "default method signature with doc" $ do
+      check
+        s
+        """
+        {-# language DefaultSignatures #-}
+        class S a where
+          t :: a
+          -- | the default
+          default t :: a
+          t = undefined
+        """
+        [ ("/items/2/value/kind/type", "\"DefaultMethodSignature\""),
+          ("/items/2/value/name", "\"t\""),
+          ("/items/2/value/documentation/type", "\"Paragraph\""),
+          ("/items/2/value/documentation/value/type", "\"String\""),
+          ("/items/2/value/documentation/value/value", "\"the default\"")
+        ]
+
     Spec.it s "fixity has parent set" $ do
       check
         s


### PR DESCRIPTION
## Summary
- Add `DefaultMethodSignature` constructor to `ItemKind` for `default m :: ...` signatures inside class declarations
- Distinguish default method signatures (`ClassOpSig _ True`) from regular class methods (`ClassOpSig _ False`) during class body conversion
- Parent default method signature items to the corresponding class method (not the class itself)
- Display with "default" badge text and primary (blue) color in HTML output

Closes #186

## Test plan
- [x] Integration test verifies the default method signature has kind `DefaultMethodSignature`, correct name, parent key pointing to the method, and signature text
- [x] All 705 tests pass
- [x] Builds clean with `--flags=pedantic`

🤖 Generated with [Claude Code](https://claude.com/claude-code)