### PR TITLE
Parent inline pragmas to their target identifier

### DIFF
--- a/scrod.cabal
+++ b/scrod.cabal
@@ -94,6 +94,7 @@ library
     Scrod.Convert.FromGhc.Doc
     Scrod.Convert.FromGhc.Exports
     Scrod.Convert.FromGhc.FixityParents
+    Scrod.Convert.FromGhc.InlineParents
     Scrod.Convert.FromGhc.InstanceParents
     Scrod.Convert.FromGhc.Internal
     Scrod.Convert.FromGhc.ItemKind

--- a/source/library/Scrod/Convert/FromGhc/InlineParents.hs
+++ b/source/library/Scrod/Convert/FromGhc/InlineParents.hs
@@ -1,0 +1,85 @@
+-- | Resolve inline pragma parent relationships.
+--
+-- Associates inline signature items with their target declarations when
+-- those declarations are defined in the same module. Works like
+-- 'Scrod.Convert.FromGhc.FixityParents' but for @INLINE@, @NOINLINE@,
+-- @INLINABLE@, and @OPAQUE@ pragmas.
+module Scrod.Convert.FromGhc.InlineParents where
+
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+import qualified GHC.Hs.Extension as Ghc
+import qualified GHC.Parser.Annotation as Annotation
+import qualified GHC.Types.SrcLoc as SrcLoc
+import qualified Language.Haskell.Syntax as Syntax
+import qualified Scrod.Convert.FromGhc.Internal as Internal
+import qualified Scrod.Core.Item as Item
+import qualified Scrod.Core.ItemKey as ItemKey
+import qualified Scrod.Core.ItemName as ItemName
+import qualified Scrod.Core.Located as Located
+import qualified Scrod.Core.Location as Location
+
+-- | Extract the set of source locations that correspond to names inside
+-- inline signature declarations.
+extractInlineLocations ::
+  SrcLoc.Located (Syntax.HsModule Ghc.GhcPs) ->
+  Set.Set Location.Location
+extractInlineLocations lHsModule =
+  let hsModule = SrcLoc.unLoc lHsModule
+      decls = Syntax.hsmodDecls hsModule
+   in Set.fromList $ concatMap extractDeclInlineLocations decls
+
+-- | Extract inline name locations from a single declaration.
+extractDeclInlineLocations ::
+  Syntax.LHsDecl Ghc.GhcPs ->
+  [Location.Location]
+extractDeclInlineLocations lDecl = case SrcLoc.unLoc lDecl of
+  Syntax.SigD _ (Syntax.InlineSig _ lName _) ->
+    foldMap pure $ Internal.locationFromSrcSpan (Annotation.getLocA lName)
+  _ -> []
+
+-- | Associate inline items with their target declarations.
+associateInlineParents ::
+  Set.Set Location.Location ->
+  [Located.Located Item.Item] ->
+  [Located.Located Item.Item]
+associateInlineParents inlineLocations items =
+  let nameToKey = buildNameToKeyMap inlineLocations items
+   in fmap (resolveInlineParent inlineLocations nameToKey) items
+
+-- | Build a map from item names to their keys, excluding inline items.
+buildNameToKeyMap ::
+  Set.Set Location.Location ->
+  [Located.Located Item.Item] ->
+  Map.Map ItemName.ItemName ItemKey.ItemKey
+buildNameToKeyMap inlineLocations =
+  Map.fromList . concatMap getNameAndKey
+  where
+    getNameAndKey locItem =
+      let val = Located.value locItem
+       in case Item.name val of
+            Nothing -> []
+            Just name ->
+              if Set.member (Located.location locItem) inlineLocations
+                then []
+                else [(name, Item.key val)]
+
+-- | Set the parentKey on an inline item by looking up the target name.
+resolveInlineParent ::
+  Set.Set Location.Location ->
+  Map.Map ItemName.ItemName ItemKey.ItemKey ->
+  Located.Located Item.Item ->
+  Located.Located Item.Item
+resolveInlineParent inlineLocations nameToKey locItem =
+  if Set.member (Located.location locItem) inlineLocations
+    then case Item.name (Located.value locItem) of
+      Nothing -> locItem
+      Just name ->
+        case Map.lookup name nameToKey of
+          Nothing -> locItem
+          Just parentKey ->
+            locItem
+              { Located.value =
+                  (Located.value locItem) {Item.parentKey = Just parentKey}
+              }
+    else locItem

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -1808,14 +1808,19 @@ spec s = Spec.describe s "integration" $ do
           ("/items/2/value/parentKey", "1")
         ]
 
-    Spec.it s "inline pragma" $ do
+    Spec.it s "inline pragma has parent set" $ do
       check
         s
         """
         i = ()
         {-# inline i #-}
         """
-        []
+        [ ("/items/0/value/name", "\"i\""),
+          ("/items/0/value/kind/type", "\"Function\""),
+          ("/items/1/value/name", "\"i\""),
+          ("/items/1/value/kind/type", "\"InlineSignature\""),
+          ("/items/1/value/parentKey", "0")
+        ]
 
     Spec.it s "inline pragma with phase control" $ do
       check
@@ -1824,7 +1829,9 @@ spec s = Spec.describe s "integration" $ do
         j = ()
         {-# inline [1] j #-}
         """
-        []
+        [ ("/items/1/value/kind/type", "\"InlineSignature\""),
+          ("/items/1/value/parentKey", "0")
+        ]
 
     Spec.it s "inline pragma with inverted phase control" $ do
       check
@@ -1833,16 +1840,34 @@ spec s = Spec.describe s "integration" $ do
         k = ()
         {-# inline [~2] k #-}
         """
-        []
+        [ ("/items/1/value/kind/type", "\"InlineSignature\""),
+          ("/items/1/value/parentKey", "0")
+        ]
 
-    Spec.it s "noinline pragma" $ do
+    Spec.it s "noinline pragma has parent set" $ do
       check
         s
         """
         l = ()
         {-# noinline l #-}
         """
-        []
+        [ ("/items/0/value/name", "\"l\""),
+          ("/items/0/value/kind/type", "\"Function\""),
+          ("/items/1/value/name", "\"l\""),
+          ("/items/1/value/kind/type", "\"InlineSignature\""),
+          ("/items/1/value/parentKey", "0")
+        ]
+
+    Spec.it s "orphaned inline pragma has no parent" $ do
+      check
+        s
+        """
+        {-# inline x #-}
+        """
+        [ ("/items/0/value/name", "\"x\""),
+          ("/items/0/value/kind/type", "\"InlineSignature\""),
+          ("/items/0/value/parentKey", "")
+        ]
 
     Spec.it s "specialize pragma" $ do
       check


### PR DESCRIPTION
## Summary
- Handle `InlineSig` explicitly in `convertSigDeclM` to extract the identifier name and use the name location (matching the fixity signature approach)
- Add `InlineParents` module following the `FixityParents` pattern to resolve parent relationships by name lookup
- Wire `InlineParents` into the `extractItems` pipeline after fixity parent resolution
- INLINE, NOINLINE, INLINABLE, and OPAQUE pragmas are now parented to their target declaration when it exists in the same module

Closes #187

## Test plan
- [x] Existing "inline pragma" test updated to verify name, kind, and parentKey
- [x] Existing "noinline pragma" test updated to verify parenting
- [x] Phase control variants verified to have parent set
- [x] New "orphaned inline pragma has no parent" test for inline without matching declaration
- [x] All 706 tests pass
- [x] Builds clean with `--flags=pedantic`

🤖 Generated with [Claude Code](https://claude.com/claude-code)