### PR TITLE
Handle specialize pragmas correctly

### DIFF
--- a/scrod.cabal
+++ b/scrod.cabal
@@ -99,6 +99,7 @@ library
     Scrod.Convert.FromGhc.ItemKind
     Scrod.Convert.FromGhc.Merge
     Scrod.Convert.FromGhc.Names
+    Scrod.Convert.FromGhc.SpecialiseParents
     Scrod.Convert.FromGhc.WarningParents
     Scrod.Convert.FromHaddock
     Scrod.Convert.ToHtml

--- a/source/library/Scrod/Convert/FromGhc/ItemKind.hs
+++ b/source/library/Scrod/Convert/FromGhc/ItemKind.hs
@@ -69,6 +69,7 @@ itemKindFromSig sig = case sig of
   Syntax.FixSig {} -> ItemKind.FixitySignature
   Syntax.InlineSig {} -> ItemKind.InlineSignature
   Syntax.SpecSig {} -> ItemKind.SpecialiseSignature
+  Syntax.SpecSigE {} -> ItemKind.SpecialiseSignature
   _ -> ItemKind.Function
 
 -- | Determine ItemKind from an instance declaration.

--- a/source/library/Scrod/Convert/FromGhc/SpecialiseParents.hs
+++ b/source/library/Scrod/Convert/FromGhc/SpecialiseParents.hs
@@ -1,0 +1,97 @@
+-- | Resolve specialise parent relationships.
+--
+-- Associates specialise signature items with their target declarations when
+-- those declarations are defined in the same module. Works like
+-- 'Scrod.Convert.FromGhc.FixityParents' but for @SPECIALIZE@ pragmas.
+module Scrod.Convert.FromGhc.SpecialiseParents where
+
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+import qualified GHC.Hs.Extension as Ghc
+import qualified GHC.Parser.Annotation as Annotation
+import qualified GHC.Types.SrcLoc as SrcLoc
+import qualified Language.Haskell.Syntax as Syntax
+import qualified Scrod.Convert.FromGhc.Internal as Internal
+import qualified Scrod.Core.Item as Item
+import qualified Scrod.Core.ItemKey as ItemKey
+import qualified Scrod.Core.ItemName as ItemName
+import qualified Scrod.Core.Located as Located
+import qualified Scrod.Core.Location as Location
+
+-- | Extract the set of source locations that correspond to names inside
+-- specialise signature declarations.
+extractSpecialiseLocations ::
+  SrcLoc.Located (Syntax.HsModule Ghc.GhcPs) ->
+  Set.Set Location.Location
+extractSpecialiseLocations lHsModule =
+  let hsModule = SrcLoc.unLoc lHsModule
+      decls = Syntax.hsmodDecls hsModule
+   in Set.fromList $ concatMap extractDeclSpecialiseLocations decls
+
+-- | Extract specialise name locations from a single declaration.
+extractDeclSpecialiseLocations ::
+  Syntax.LHsDecl Ghc.GhcPs ->
+  [Location.Location]
+extractDeclSpecialiseLocations lDecl = case SrcLoc.unLoc lDecl of
+  Syntax.SigD _ (Syntax.SpecSig _ lName _ _) ->
+    foldMap pure $ Internal.locationFromSrcSpan (Annotation.getLocA lName)
+  Syntax.SigD _ (Syntax.SpecSigE _ _ lExpr _) ->
+    extractExprNameLocations lExpr
+  _ -> []
+
+-- | Extract name locations from a SpecSigE expression.
+extractExprNameLocations ::
+  Syntax.LHsExpr Ghc.GhcPs ->
+  [Location.Location]
+extractExprNameLocations lExpr = case SrcLoc.unLoc lExpr of
+  Syntax.ExprWithTySig _ body _ -> case SrcLoc.unLoc body of
+    Syntax.HsVar _ lName ->
+      foldMap pure . Internal.locationFromSrcSpan $ Annotation.getLocA lName
+    _ -> []
+  _ -> []
+
+-- | Associate specialise items with their target declarations.
+associateSpecialiseParents ::
+  Set.Set Location.Location ->
+  [Located.Located Item.Item] ->
+  [Located.Located Item.Item]
+associateSpecialiseParents specialiseLocations items =
+  let nameToKey = buildNameToKeyMap specialiseLocations items
+   in fmap (resolveSpecialiseParent specialiseLocations nameToKey) items
+
+-- | Build a map from item names to their keys, excluding specialise items.
+buildNameToKeyMap ::
+  Set.Set Location.Location ->
+  [Located.Located Item.Item] ->
+  Map.Map ItemName.ItemName ItemKey.ItemKey
+buildNameToKeyMap specialiseLocations =
+  Map.fromList . concatMap getNameAndKey
+  where
+    getNameAndKey locItem =
+      let val = Located.value locItem
+       in case Item.name val of
+            Nothing -> []
+            Just name ->
+              if Set.member (Located.location locItem) specialiseLocations
+                then []
+                else [(name, Item.key val)]
+
+-- | Set the parentKey on a specialise item by looking up the target name.
+resolveSpecialiseParent ::
+  Set.Set Location.Location ->
+  Map.Map ItemName.ItemName ItemKey.ItemKey ->
+  Located.Located Item.Item ->
+  Located.Located Item.Item
+resolveSpecialiseParent specialiseLocations nameToKey locItem =
+  if Set.member (Located.location locItem) specialiseLocations
+    then case Item.name (Located.value locItem) of
+      Nothing -> locItem
+      Just name ->
+        case Map.lookup name nameToKey of
+          Nothing -> locItem
+          Just parentKey ->
+            locItem
+              { Located.value =
+                  (Located.value locItem) {Item.parentKey = Just parentKey}
+              }
+    else locItem

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -1852,7 +1852,24 @@ spec s = Spec.describe s "integration" $ do
         j2 = id
         {-# specialize j2 :: () -> () #-}
         """
-        []
+        [ ("/items/0/value/kind/type", "\"Function\""),
+          ("/items/0/value/name", "\"j2\""),
+          ("/items/1/value/kind/type", "\"SpecialiseSignature\""),
+          ("/items/1/value/name", "\"j2\""),
+          ("/items/1/value/parentKey", "0"),
+          ("/items/1/value/signature", "\"() -> ()\"")
+        ]
+
+    Spec.it s "orphaned specialize pragma" $ do
+      check
+        s
+        """
+        {-# specialize j3 :: () -> () #-}
+        """
+        [ ("/items/0/value/kind/type", "\"SpecialiseSignature\""),
+          ("/items/0/value/name", "\"j3\""),
+          ("/items/0/value/signature", "\"() -> ()\"")
+        ]
 
     Spec.it s "specialize instance pragma" $ do
       check


### PR DESCRIPTION
## Summary
- Handle `SpecSig` and `SpecSigE` explicitly in `convertSigDeclM` to extract the function name and specialization type signature
- Add `SpecSigE` to `itemKindFromSig` so it maps to `SpecialiseSignature` instead of falling through to `Function`
- Create `SpecialiseParents` module to associate specialize pragmas with their target declarations using the same pattern as `FixityParents`

Closes #189

## Test plan
- [x] `cabal build --flags=pedantic` succeeds
- [x] All 706 tests pass
- [x] New "specialize pragma" test verifies correct kind, parent, name, and signature
- [x] New "orphaned specialize pragma" test verifies no parent when target is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)