### PR TITLE
Include name and signature for RULES pragmas

### DIFF
--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -375,7 +375,15 @@ convertRuleDeclM ::
   Syntax.LRuleDecl Ghc.GhcPs ->
   Internal.ConvertM (Maybe (Located.Located Item.Item))
 convertRuleDeclM lRuleDecl =
-  Internal.mkItemM (Annotation.getLocA lRuleDecl) Nothing Nothing Doc.Empty Nothing Nothing ItemKind.Rule
+  let ruleDecl = SrcLoc.unLoc lRuleDecl
+      name = Just . ItemName.MkItemName . Text.pack . FastString.unpackFS . SrcLoc.unLoc $ Syntax.rd_name ruleDecl
+      sig =
+        Just . Text.pack . Outputable.showSDocUnsafe $
+          Outputable.ppr (Syntax.rd_bndrs ruleDecl)
+            Outputable.<+> Outputable.ppr (Syntax.rd_lhs ruleDecl)
+            Outputable.<+> Outputable.text "="
+            Outputable.<+> Outputable.ppr (Syntax.rd_rhs ruleDecl)
+   in Internal.mkItemM (Annotation.getLocA lRuleDecl) Nothing name Doc.Empty Nothing sig ItemKind.Rule
 
 -- | Convert warning declarations.
 convertWarnDeclsM ::

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -2029,7 +2029,12 @@ spec s = Spec.describe s "integration" $ do
         x4 = id
         {-# rules "q" x4 = id #-}
         """
-        []
+        [ ("/items/0/value/kind/type", "\"Function\""),
+          ("/items/0/value/name", "\"x4\""),
+          ("/items/1/value/kind/type", "\"Rule\""),
+          ("/items/1/value/name", "\"q\""),
+          ("/items/1/value/signature", "\"x4 = id\"")
+        ]
 
     Spec.it s "splice declaration" $ do
       check


### PR DESCRIPTION
## Summary
- Extract rule name from `rd_name` field of `RuleDecl` and set it as the item name
- Construct rule signature from binders + LHS = RHS (e.g. `forall a. id a = a`)

Closes #191

## Test plan
- [x] `cabal build --flags=pedantic` succeeds
- [x] All 706 tests pass
- [x] Updated "rules pragma" test verifies name and signature extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)