### PR TITLE
Include MINIMAL pragmas in class output

### DIFF
--- a/source/library/Scrod/Convert/FromGhc/ItemKind.hs
+++ b/source/library/Scrod/Convert/FromGhc/ItemKind.hs
@@ -69,6 +69,7 @@ itemKindFromSig sig = case sig of
   Syntax.FixSig {} -> ItemKind.FixitySignature
   Syntax.InlineSig {} -> ItemKind.InlineSignature
   Syntax.SpecSig {} -> ItemKind.SpecialiseSignature
+  Syntax.MinimalSig {} -> ItemKind.MinimalPragma
   _ -> ItemKind.Function
 
 -- | Determine ItemKind from an instance declaration.

--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -806,6 +806,7 @@ kindToText k = case k of
   ItemKind.Annotation -> Text.pack "annotation"
   ItemKind.Splice -> Text.pack "splice"
   ItemKind.Warning -> Text.pack "warning"
+  ItemKind.MinimalPragma -> Text.pack "minimal"
 
 data KindColor
   = KindSuccess
@@ -847,6 +848,7 @@ kindColor k = case k of
   ItemKind.Annotation -> KindSecondary
   ItemKind.Splice -> KindSecondary
   ItemKind.Warning -> KindWarning
+  ItemKind.MinimalPragma -> KindSecondary
 
 kindBadgeClass :: ItemKind.ItemKind -> String
 kindBadgeClass k = case kindColor k of

--- a/source/library/Scrod/Core/ItemKind.hs
+++ b/source/library/Scrod/Core/ItemKind.hs
@@ -71,5 +71,7 @@ data ItemKind
     Splice
   | -- | Warning pragma: @{-# WARNING x "msg" #-}@
     Warning
+  | -- | Minimal pragma: @{-# MINIMAL size #-}@
+    MinimalPragma
   deriving (Eq, Generics.Generic, Ord, Show)
   deriving (ToJson.ToJson, Schema.ToSchema) via Generics.Generically ItemKind

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -1899,7 +1899,14 @@ spec s = Spec.describe s "integration" $ do
           l2m :: a
           {-# minimal l2m #-}
         """
-        []
+        [ ("/items/0/value/kind/type", "\"Class\""),
+          ("/items/0/value/name", "\"L2\""),
+          ("/items/1/value/kind/type", "\"ClassMethod\""),
+          ("/items/1/value/parentKey", "0"),
+          ("/items/2/value/kind/type", "\"MinimalPragma\""),
+          ("/items/2/value/parentKey", "0"),
+          ("/items/2/value/signature", "\"l2m\"")
+        ]
 
     Spec.it s "set cost center pragma" $ do
       check


### PR DESCRIPTION
## Summary
- Add `MinimalPragma` item kind to represent `{-# MINIMAL ... #-}` pragmas
- Handle `MinimalSig` in class body conversion, emitting the pragma as an item with the class as parent
- Pretty-print the boolean formula (e.g. `f, (g | h)`) as the item's signature
- Add HTML rendering with "minimal" label and secondary badge color

Closes #193

## Test plan
- [x] `cabal build --flags=pedantic` succeeds
- [x] All 706 tests pass
- [x] Updated "minimal pragma" test verifies kind, parent, and signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)