### PR TITLE
Parent family instances to their family declarations

### DIFF
--- a/scrod.cabal
+++ b/scrod.cabal
@@ -93,6 +93,7 @@ library
     Scrod.Convert.FromGhc.Constructors
     Scrod.Convert.FromGhc.Doc
     Scrod.Convert.FromGhc.Exports
+    Scrod.Convert.FromGhc.FamilyInstanceParents
     Scrod.Convert.FromGhc.FixityParents
     Scrod.Convert.FromGhc.InlineParents
     Scrod.Convert.FromGhc.InstanceParents

--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -32,6 +32,7 @@ import qualified PackageInfo_scrod as PackageInfo
 import qualified Scrod.Convert.FromGhc.Constructors as Constructors
 import qualified Scrod.Convert.FromGhc.Doc as GhcDoc
 import qualified Scrod.Convert.FromGhc.Exports as Exports
+import qualified Scrod.Convert.FromGhc.FamilyInstanceParents as FamilyInstanceParents
 import qualified Scrod.Convert.FromGhc.FixityParents as FixityParents
 import qualified Scrod.Convert.FromGhc.InlineParents as InlineParents
 import qualified Scrod.Convert.FromGhc.InstanceParents as InstanceParents
@@ -198,7 +199,9 @@ extractItems lHsModule =
       fixityParentedItems = FixityParents.associateFixityParents fixityLocations warningParentedItems
       inlineLocations = InlineParents.extractInlineLocations lHsModule
       inlineParentedItems = InlineParents.associateInlineParents inlineLocations fixityParentedItems
-   in Merge.mergeItemsByName inlineParentedItems
+      familyInstanceNames = FamilyInstanceParents.extractFamilyInstanceNames lHsModule
+      familyParentedItems = FamilyInstanceParents.associateFamilyInstanceParents familyInstanceNames inlineParentedItems
+   in Merge.mergeItemsByName familyParentedItems
 
 -- | Extract items in the conversion monad.
 extractItemsM ::

--- a/source/library/Scrod/Convert/FromGhc/FamilyInstanceParents.hs
+++ b/source/library/Scrod/Convert/FromGhc/FamilyInstanceParents.hs
@@ -1,0 +1,97 @@
+-- | Resolve family instance parent relationships.
+--
+-- Associates type family instance and data family instance items with
+-- their corresponding family declarations when both are defined in the
+-- same module.
+module Scrod.Convert.FromGhc.FamilyInstanceParents where
+
+import qualified Data.Map as Map
+import GHC.Hs ()
+import qualified GHC.Hs.Extension as Ghc
+import qualified GHC.Parser.Annotation as Annotation
+import qualified GHC.Types.SrcLoc as SrcLoc
+import qualified Language.Haskell.Syntax as Syntax
+import qualified Scrod.Convert.FromGhc.Internal as Internal
+import qualified Scrod.Core.Item as Item
+import qualified Scrod.Core.ItemKey as ItemKey
+import qualified Scrod.Core.ItemKind as ItemKind
+import qualified Scrod.Core.ItemName as ItemName
+import qualified Scrod.Core.Located as Located
+import qualified Scrod.Core.Location as Location
+
+-- | Extract a map from source locations of family instance declarations
+-- to the family name they reference.
+extractFamilyInstanceNames ::
+  SrcLoc.Located (Syntax.HsModule Ghc.GhcPs) ->
+  Map.Map Location.Location ItemName.ItemName
+extractFamilyInstanceNames lHsModule =
+  let hsModule = SrcLoc.unLoc lHsModule
+      decls = Syntax.hsmodDecls hsModule
+   in Map.fromList $ concatMap extractDeclFamilyInstanceName decls
+
+-- | Extract family instance name from a single declaration.
+extractDeclFamilyInstanceName ::
+  Syntax.LHsDecl Ghc.GhcPs ->
+  [(Location.Location, ItemName.ItemName)]
+extractDeclFamilyInstanceName lDecl = case SrcLoc.unLoc lDecl of
+  Syntax.InstD _ (Syntax.TyFamInstD _ tyFamInst) ->
+    let eqn = Syntax.tfid_eqn tyFamInst
+        familyName = Internal.extractIdPName $ Syntax.feqn_tycon eqn
+     in foldMap (\loc -> [(loc, familyName)]) $
+          Internal.locationFromSrcSpan (Annotation.getLocA lDecl)
+  Syntax.InstD _ (Syntax.DataFamInstD _ dataFamInst) ->
+    let eqn = Syntax.dfid_eqn dataFamInst
+        familyName = Internal.extractIdPName $ Syntax.feqn_tycon eqn
+     in foldMap (\loc -> [(loc, familyName)]) $
+          Internal.locationFromSrcSpan (Annotation.getLocA lDecl)
+  _ -> []
+
+-- | Associate family instance items with their family declarations.
+associateFamilyInstanceParents ::
+  Map.Map Location.Location ItemName.ItemName ->
+  [Located.Located Item.Item] ->
+  [Located.Located Item.Item]
+associateFamilyInstanceParents familyInstanceNames items =
+  let familyNameToKey = buildFamilyNameToKeyMap items
+   in fmap (resolveFamilyInstanceParent familyInstanceNames familyNameToKey) items
+
+-- | Build a map from family names to their keys.
+buildFamilyNameToKeyMap ::
+  [Located.Located Item.Item] ->
+  Map.Map ItemName.ItemName ItemKey.ItemKey
+buildFamilyNameToKeyMap =
+  Map.fromList . concatMap getFamilyNameAndKey
+  where
+    getFamilyNameAndKey locItem =
+      let val = Located.value locItem
+       in case Item.name val of
+            Nothing -> []
+            Just name ->
+              if isFamilyKind (Item.kind val)
+                then [(name, Item.key val)]
+                else []
+
+-- | Check if an item kind represents a family declaration.
+isFamilyKind :: ItemKind.ItemKind -> Bool
+isFamilyKind k = case k of
+  ItemKind.OpenTypeFamily -> True
+  ItemKind.DataFamily -> True
+  _ -> False
+
+-- | Set the parentKey on a family instance item by looking up the family name.
+resolveFamilyInstanceParent ::
+  Map.Map Location.Location ItemName.ItemName ->
+  Map.Map ItemName.ItemName ItemKey.ItemKey ->
+  Located.Located Item.Item ->
+  Located.Located Item.Item
+resolveFamilyInstanceParent familyInstanceNames familyNameToKey locItem =
+  case Map.lookup (Located.location locItem) familyInstanceNames of
+    Nothing -> locItem
+    Just familyName ->
+      case Map.lookup familyName familyNameToKey of
+        Nothing -> locItem
+        Just parentKey ->
+          locItem
+            { Located.value =
+                (Located.value locItem) {Item.parentKey = Just parentKey}
+            }

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -1325,7 +1325,9 @@ spec s = Spec.describe s "integration" $ do
         data family A a
         data instance A ()
         """
-        [("/items/1/value/kind/type", "\"DataFamilyInstance\"")]
+        [ ("/items/1/value/kind/type", "\"DataFamilyInstance\""),
+          ("/items/1/value/parentKey", "0")
+        ]
 
     Spec.it s "data instance constructor" $ do
       check
@@ -1336,6 +1338,7 @@ spec s = Spec.describe s "integration" $ do
         data instance B () = C
         """
         [ ("/items/1/value/kind/type", "\"DataFamilyInstance\""),
+          ("/items/1/value/parentKey", "0"),
           ("/items/2/value/kind/type", "\"DataConstructor\""),
           ("/items/2/value/parentKey", "1")
         ]
@@ -1349,6 +1352,7 @@ spec s = Spec.describe s "integration" $ do
         data instance D where E :: D
         """
         [ ("/items/1/value/kind/type", "\"DataFamilyInstance\""),
+          ("/items/1/value/parentKey", "0"),
           ("/items/2/value/kind/type", "\"GADTConstructor\""),
           ("/items/2/value/parentKey", "1")
         ]
@@ -1362,6 +1366,7 @@ spec s = Spec.describe s "integration" $ do
         newtype instance F = G ()
         """
         [ ("/items/1/value/kind/type", "\"DataFamilyInstance\""),
+          ("/items/1/value/parentKey", "0"),
           ("/items/2/value/kind/type", "\"DataConstructor\""),
           ("/items/2/value/parentKey", "1")
         ]
@@ -1375,6 +1380,7 @@ spec s = Spec.describe s "integration" $ do
         newtype instance H where I :: () -> H
         """
         [ ("/items/1/value/kind/type", "\"DataFamilyInstance\""),
+          ("/items/1/value/parentKey", "0"),
           ("/items/2/value/kind/type", "\"GADTConstructor\""),
           ("/items/2/value/parentKey", "1")
         ]
@@ -1387,7 +1393,9 @@ spec s = Spec.describe s "integration" $ do
         type family J
         type instance J = ()
         """
-        [("/items/1/value/kind/type", "\"TypeFamilyInstance\"")]
+        [ ("/items/1/value/kind/type", "\"TypeFamilyInstance\""),
+          ("/items/1/value/parentKey", "0")
+        ]
 
     Spec.it s "standalone deriving" $ do
       check


### PR DESCRIPTION
## Summary
- Add `FamilyInstanceParents` module that associates type family instance and data family instance items with their corresponding family declarations
- Extract family name from `feqn_tycon` in the GHC AST and match instances to families by name
- Wire family instance parenting into the `extractItems` pipeline after inline parenting
- Add integration test assertions verifying `parentKey` is set on all family instance types

Closes #194

## Test plan
- [x] All 706 tests pass
- [x] Data family instances have correct `parentKey`
- [x] Type family instances have correct `parentKey`
- [x] Newtype family instances have correct `parentKey`
- [x] GADT-style family instance constructors have correct `parentKey`

🤖 Generated with [Claude Code](https://claude.com/claude-code)