### PR TITLE
Use correct item kind for pattern synonym signatures

### DIFF
--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -293,10 +293,10 @@ convertSigDeclM ::
 convertSigDeclM doc docSince lDecl sig = case sig of
   Syntax.TypeSig _ names _ ->
     let sigText = Names.extractSigSignature sig
-     in Maybe.catMaybes <$> traverse (convertSigNameM doc docSince sigText) names
+     in Maybe.catMaybes <$> traverse (convertSigNameM doc docSince sigText ItemKind.Function) names
   Syntax.PatSynSig _ names _ ->
     let sigText = Names.extractSigSignature sig
-     in Maybe.catMaybes <$> traverse (convertSigNameM doc docSince sigText) names
+     in Maybe.catMaybes <$> traverse (convertSigNameM doc docSince sigText ItemKind.PatternSynonym) names
   Syntax.FixSig _ (Syntax.FixitySig _ names (SyntaxBasic.Fixity prec dir)) ->
     let fixityDoc = Doc.Paragraph . Doc.String $ fixityDirectionToText dir <> Text.pack (" " <> show prec)
         combinedDoc = combineDoc doc fixityDoc
@@ -310,10 +310,11 @@ convertSigNameM ::
   Doc.Doc ->
   Maybe Since.Since ->
   Maybe Text.Text ->
+  ItemKind.ItemKind ->
   Syntax.LIdP Ghc.GhcPs ->
   Internal.ConvertM (Maybe (Located.Located Item.Item))
-convertSigNameM doc docSince sig lName =
-  Internal.mkItemM (Annotation.getLocA lName) Nothing (Just $ Internal.extractIdPName lName) doc docSince sig ItemKind.Function
+convertSigNameM doc docSince sig itemKind lName =
+  Internal.mkItemM (Annotation.getLocA lName) Nothing (Just $ Internal.extractIdPName lName) doc docSince sig itemKind
 
 -- | Convert a single name from a fixity signature.
 convertFixityNameM ::

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -1625,13 +1625,22 @@ spec s = Spec.describe s "integration" $ do
       check s "(j :: ()) = ()" []
 
     Spec.it s "bidirectional pattern synonym" $ do
-      check s "{-# language PatternSynonyms #-} pattern L = ()" []
+      check
+        s
+        "{-# language PatternSynonyms #-} pattern L = ()"
+        [("/items/0/value/kind/type", "\"PatternSynonym\"")]
 
     Spec.it s "unidirectional pattern synonym" $ do
-      check s "{-# language PatternSynonyms #-} pattern M <- ()" []
+      check
+        s
+        "{-# language PatternSynonyms #-} pattern M <- ()"
+        [("/items/0/value/kind/type", "\"PatternSynonym\"")]
 
     Spec.it s "explicitly bidirectional pattern synonym" $ do
-      check s "{-# language PatternSynonyms #-} pattern N <- () where N = ()" []
+      check
+        s
+        "{-# language PatternSynonyms #-} pattern N <- () where N = ()"
+        [("/items/0/value/kind/type", "\"PatternSynonym\"")]
 
     Spec.it s "type signature" $ do
       check
@@ -1650,7 +1659,16 @@ spec s = Spec.describe s "integration" $ do
         pattern P :: ()
         pattern P = ()
         """
-        []
+        [("/items/0/value/kind/type", "\"PatternSynonym\"")]
+
+    Spec.it s "pattern synonym signature without binding" $ do
+      check
+        s
+        """
+        {-# language PatternSynonyms #-}
+        pattern Q :: a
+        """
+        [("/items/0/value/kind/type", "\"PatternSynonym\"")]
 
     Spec.describe s "method signature" $ do
       Spec.it s "works" $ do


### PR DESCRIPTION
## Summary
- `convertSigNameM` was hardcoding `ItemKind.Function` for all signature types, including `PatSynSig`
- Added an `ItemKind` parameter to `convertSigNameM` so callers pass the correct kind
- `TypeSig` passes `Function`, `PatSynSig` passes `PatternSynonym`
- Added kind assertions to existing pattern synonym tests and a new test for a standalone pattern synonym signature (without binding)

Closes #195

## Test plan
- [x] All 707 tests pass
- [x] `pattern X :: a` (signature only) shows kind `PatternSynonym`
- [x] `pattern X = ()` (binding) still shows kind `PatternSynonym`
- [x] `pattern P :: (); pattern P = ()` (sig + binding) shows kind `PatternSynonym`

🤖 Generated with [Claude Code](https://claude.com/claude-code)