### PR TITLE
Extract only the kind type from standalone kind signatures

### DIFF
--- a/source/library/Scrod/Convert/FromGhc/Names.hs
+++ b/source/library/Scrod/Convert/FromGhc/Names.hs
@@ -31,7 +31,9 @@ extractDeclName lDecl = case SrcLoc.unLoc lDecl of
 extractStandaloneKindSigName :: Syntax.StandaloneKindSig Ghc.GhcPs -> ItemName.ItemName
 extractStandaloneKindSigName (Syntax.StandaloneKindSig _ lName _) = Internal.extractIdPName lName
 
--- | Extract signature from a kind signature.
+-- | Extract signature from a standalone kind signature.
+-- Only returns the kind type, not the name.
+-- For example, @type X :: a -> a@ produces @"a -> a"@.
 extractKindSigSignature :: Syntax.StandaloneKindSig Ghc.GhcPs -> Text.Text
 extractKindSigSignature (Syntax.StandaloneKindSig _ _ lSigType) =
   Text.pack . Outputable.showSDocUnsafe . Outputable.ppr $ lSigType

--- a/source/library/Scrod/Convert/FromGhc/Names.hs
+++ b/source/library/Scrod/Convert/FromGhc/Names.hs
@@ -33,7 +33,8 @@ extractStandaloneKindSigName (Syntax.StandaloneKindSig _ lName _) = Internal.ext
 
 -- | Extract signature from a kind signature.
 extractKindSigSignature :: Syntax.StandaloneKindSig Ghc.GhcPs -> Text.Text
-extractKindSigSignature = Text.pack . Outputable.showSDocUnsafe . Outputable.ppr
+extractKindSigSignature (Syntax.StandaloneKindSig _ _ lSigType) =
+  Text.pack . Outputable.showSDocUnsafe . Outputable.ppr $ lSigType
 
 -- | Extract name from a type/class declaration.
 extractTyClDeclName :: Syntax.TyClDecl Ghc.GhcPs -> Maybe ItemName.ItemName

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -1935,7 +1935,16 @@ spec s = Spec.describe s "integration" $ do
         type O :: *
         data O
         """
-        []
+        [("/items/0/value/signature", "\"*\"")]
+
+    Spec.it s "standalone kind signature with data" $ do
+      check
+        s
+        """
+        type X :: a -> a
+        data X a = X
+        """
+        [("/items/0/value/signature", "\"a -> a\"")]
 
     Spec.it s "default declaration" $ do
       check s "default ()" [("/items", "[]")]


### PR DESCRIPTION
## Summary
- `extractKindSigSignature` was pretty-printing the entire `StandaloneKindSig` node, producing `type X :: a -> a` instead of just `a -> a`
- Fixed to extract only the `LHsSigType` (the kind type) from the `StandaloneKindSig` constructor
- Added signature assertions to existing standalone kind signature test
- Added new test case matching the exact scenario from the issue (`type X :: a -> a` with `data X a = X`)

Closes #197

## Test plan
- [x] All 707 tests pass
- [x] `type O :: *` produces signature `*` (not `type O :: *`)
- [x] `type X :: a -> a` with `data X a = X` produces signature `a -> a`

🤖 Generated with [Claude Code](https://claude.com/claude-code)