### PR TITLE
Use CompletePragma item kind for COMPLETE pragmas

### DIFF
--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -307,6 +307,12 @@ convertSigDeclM doc docSince lDecl sig = case sig of
      in Maybe.catMaybes <$> traverse (convertFixityNameM combinedDoc) names
   Syntax.InlineSig _ lName _ ->
     Maybe.maybeToList <$> convertInlineNameM doc docSince lName
+  Syntax.CompleteMatchSig _ names mTyCon ->
+    let namesSig = Outputable.hsep (Outputable.punctuate (Outputable.text ",") (fmap Outputable.ppr names))
+        sigText = Just . Text.pack . Outputable.showSDocUnsafe $ case mTyCon of
+          Nothing -> namesSig
+          Just tyCon -> namesSig Outputable.<+> Outputable.text "::" Outputable.<+> Outputable.ppr tyCon
+     in Maybe.maybeToList <$> Internal.mkItemM (Annotation.getLocA lDecl) Nothing Nothing doc docSince sigText ItemKind.CompletePragma
   _ -> Maybe.maybeToList <$> convertDeclWithDocM Nothing doc docSince (Names.extractSigName sig) Nothing lDecl
 
 -- | Convert a single name from a signature.

--- a/source/library/Scrod/Convert/FromGhc/ItemKind.hs
+++ b/source/library/Scrod/Convert/FromGhc/ItemKind.hs
@@ -70,6 +70,7 @@ itemKindFromSig sig = case sig of
   Syntax.InlineSig {} -> ItemKind.InlineSignature
   Syntax.SpecSig {} -> ItemKind.SpecialiseSignature
   Syntax.MinimalSig {} -> ItemKind.MinimalPragma
+  Syntax.CompleteMatchSig {} -> ItemKind.CompletePragma
   _ -> ItemKind.Function
 
 -- | Determine ItemKind from an instance declaration.

--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -807,6 +807,7 @@ kindToText k = case k of
   ItemKind.Splice -> Text.pack "splice"
   ItemKind.Warning -> Text.pack "warning"
   ItemKind.MinimalPragma -> Text.pack "minimal"
+  ItemKind.CompletePragma -> Text.pack "complete"
 
 data KindColor
   = KindSuccess
@@ -849,6 +850,7 @@ kindColor k = case k of
   ItemKind.Splice -> KindSecondary
   ItemKind.Warning -> KindWarning
   ItemKind.MinimalPragma -> KindSecondary
+  ItemKind.CompletePragma -> KindSecondary
 
 kindBadgeClass :: ItemKind.ItemKind -> String
 kindBadgeClass k = case kindColor k of

--- a/source/library/Scrod/Core/ItemKind.hs
+++ b/source/library/Scrod/Core/ItemKind.hs
@@ -73,5 +73,7 @@ data ItemKind
     Warning
   | -- | Minimal pragma: @{-# MINIMAL size #-}@
     MinimalPragma
+  | -- | Complete pragma: @{-# COMPLETE Nil, Cons #-}@
+    CompletePragma
   deriving (Eq, Generics.Generic, Ord, Show)
   deriving (ToJson.ToJson, Schema.ToSchema) via Generics.Generically ItemKind

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -1934,7 +1934,9 @@ spec s = Spec.describe s "integration" $ do
         pattern N2 = ()
         {-# complete N2 #-}
         """
-        []
+        [ ("/items/1/value/kind/type", "\"CompletePragma\""),
+          ("/items/1/value/signature", "\"N2\"")
+        ]
 
     Spec.it s "standalone kind signature" $ do
       check


### PR DESCRIPTION
## Summary
- Added `CompletePragma` constructor to `ItemKind`
- Added `CompleteMatchSig` mapping in `itemKindFromSig` to return `CompletePragma`
- Added explicit handling in `convertSigDeclM` to extract the signature (pattern names and optional type class) from `CompleteMatchSig`
- Added "complete" label and `KindSecondary` color in `ToHtml`
- Added integration test assertions for kind and signature

Closes #199

## Test plan
- [x] All 706 tests pass
- [x] `{-# COMPLETE Nil #-}` shows kind `CompletePragma` and signature `Nil`
- [x] Builds clean with `--flags=pedantic`

🤖 Generated with [Claude Code](https://claude.com/claude-code)