### PR TITLE
Fix #209: Display deriving strategy after kind badge

### DIFF
--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -702,7 +702,6 @@ itemToHtml (Located.MkLocated loc (Item.MkItem key itemKind _parentKey maybeName
       ItemKind.TypeData -> True
       ItemKind.TypeSynonym -> True
       ItemKind.Class -> True
-      ItemKind.DerivedInstance -> True
       _ -> False
 
     kindElement :: Element.Element


### PR DESCRIPTION
## Summary

Fixes #209.

- Removes `DerivedInstance` from the `isTypeVarSignature` list in `ToHtml.hs`
- This changes how attached deriving clauses render the strategy text (stock, newtype, anyclass, via) in HTML: instead of showing it before the kind badge with a non-breaking space prefix (`B stock [deriving]`), it now shows after the badge with `:: ` prefix (`B [deriving] :: stock`), matching standalone deriving display

🤖 Generated with [Claude Code](https://claude.com/claude-code)