### PR TITLE
Fix #210: Parent patterns to their COMPLETE pragma

### DIFF
--- a/scrod.cabal
+++ b/scrod.cabal
@@ -90,6 +90,7 @@ library
     Scrod
     Scrod.Cabal
     Scrod.Convert.FromGhc
+    Scrod.Convert.FromGhc.CompleteParents
     Scrod.Convert.FromGhc.Constructors
     Scrod.Convert.FromGhc.Doc
     Scrod.Convert.FromGhc.Exports

--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -30,6 +30,7 @@ import qualified GHC.Utils.Outputable as Outputable
 import qualified Language.Haskell.Syntax as Syntax
 import qualified Language.Haskell.Syntax.Basic as SyntaxBasic
 import qualified PackageInfo_scrod as PackageInfo
+import qualified Scrod.Convert.FromGhc.CompleteParents as CompleteParents
 import qualified Scrod.Convert.FromGhc.Constructors as Constructors
 import qualified Scrod.Convert.FromGhc.Doc as GhcDoc
 import qualified Scrod.Convert.FromGhc.Exports as Exports
@@ -209,7 +210,9 @@ extractItems lHsModule =
       roleParentedItems = RoleParents.associateRoleParents roleLocations specialiseParentedItems
       familyInstanceNames = FamilyInstanceParents.extractFamilyInstanceNames lHsModule
       familyParentedItems = FamilyInstanceParents.associateFamilyInstanceParents familyInstanceNames roleParentedItems
-   in Merge.mergeItemsByName familyParentedItems
+      mergedItems = Merge.mergeItemsByName familyParentedItems
+      completeNames = CompleteParents.extractCompleteNames lHsModule
+   in CompleteParents.associateCompleteParents completeNames mergedItems
 
 -- | Extract items in the conversion monad.
 extractItemsM ::

--- a/source/library/Scrod/Convert/FromGhc/CompleteParents.hs
+++ b/source/library/Scrod/Convert/FromGhc/CompleteParents.hs
@@ -1,0 +1,91 @@
+-- | Resolve COMPLETE pragma parent relationships.
+--
+-- Associates pattern synonym items with their COMPLETE pragma when
+-- those patterns are listed in a @COMPLETE@ pragma in the same module.
+-- Unlike other parent associations (where a pragma is parented to its
+-- target), here the targets (pattern synonyms) are parented to the
+-- pragma, so they are grouped under it in the output.
+module Scrod.Convert.FromGhc.CompleteParents where
+
+import qualified Data.Map as Map
+import qualified Data.Maybe as Maybe
+import qualified GHC.Hs.Extension as Ghc
+import qualified GHC.Parser.Annotation as Annotation
+import qualified GHC.Types.SrcLoc as SrcLoc
+import qualified Language.Haskell.Syntax as Syntax
+import qualified Scrod.Convert.FromGhc.Internal as Internal
+import qualified Scrod.Core.Item as Item
+import qualified Scrod.Core.ItemKey as ItemKey
+import qualified Scrod.Core.ItemKind as ItemKind
+import qualified Scrod.Core.ItemName as ItemName
+import qualified Scrod.Core.Located as Located
+import qualified Scrod.Core.Location as Location
+
+-- | Extract a mapping from pattern names referenced in COMPLETE pragmas
+-- to the source location of the COMPLETE pragma that references them.
+extractCompleteNames ::
+  SrcLoc.Located (Syntax.HsModule Ghc.GhcPs) ->
+  Map.Map ItemName.ItemName Location.Location
+extractCompleteNames lHsModule =
+  let hsModule = SrcLoc.unLoc lHsModule
+      decls = Syntax.hsmodDecls hsModule
+   in Map.fromList $ concatMap extractDeclCompleteNames decls
+
+-- | Extract pattern name to COMPLETE pragma location pairs from a
+-- single declaration.
+extractDeclCompleteNames ::
+  Syntax.LHsDecl Ghc.GhcPs ->
+  [(ItemName.ItemName, Location.Location)]
+extractDeclCompleteNames lDecl = case SrcLoc.unLoc lDecl of
+  Syntax.SigD _ (Syntax.CompleteMatchSig _ names _) ->
+    case Internal.locationFromSrcSpan (Annotation.getLocA lDecl) of
+      Nothing -> []
+      Just loc -> fmap (\lName -> (Internal.extractIdPName lName, loc)) names
+  _ -> []
+
+-- | Associate pattern synonym items with their COMPLETE pragma parent.
+associateCompleteParents ::
+  Map.Map ItemName.ItemName Location.Location ->
+  [Located.Located Item.Item] ->
+  [Located.Located Item.Item]
+associateCompleteParents completeNames items =
+  let locationToKey = buildLocationToKeyMap items
+   in fmap (resolveCompleteParent completeNames locationToKey) items
+
+-- | Build a map from COMPLETE pragma item locations to their keys.
+buildLocationToKeyMap ::
+  [Located.Located Item.Item] ->
+  Map.Map Location.Location ItemKey.ItemKey
+buildLocationToKeyMap =
+  Map.fromList . Maybe.mapMaybe getLocationAndKey
+  where
+    getLocationAndKey locItem =
+      let val = Located.value locItem
+       in case Item.kind val of
+            ItemKind.CompletePragma ->
+              Just (Located.location locItem, Item.key val)
+            _ -> Nothing
+
+-- | Set the parentKey on a pattern synonym item if its name appears
+-- in a COMPLETE pragma.
+resolveCompleteParent ::
+  Map.Map ItemName.ItemName Location.Location ->
+  Map.Map Location.Location ItemKey.ItemKey ->
+  Located.Located Item.Item ->
+  Located.Located Item.Item
+resolveCompleteParent completeNames locationToKey locItem =
+  let val = Located.value locItem
+   in case Item.name val of
+        Nothing -> locItem
+        Just name ->
+          if Maybe.isJust (Item.parentKey val)
+            then locItem
+            else case Map.lookup name completeNames of
+              Nothing -> locItem
+              Just loc -> case Map.lookup loc locationToKey of
+                Nothing -> locItem
+                Just parentKey ->
+                  locItem
+                    { Located.value =
+                        val {Item.parentKey = Just parentKey}
+                    }

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -2055,8 +2055,31 @@ spec s = Spec.describe s "integration" $ do
         pattern N2 = ()
         {-# complete N2 #-}
         """
-        [ ("/items/1/value/kind/type", "\"CompletePragma\""),
+        [ ("/items/0/value/kind/type", "\"PatternSynonym\""),
+          ("/items/0/value/parentKey", "2"),
+          ("/items/1/value/kind/type", "\"CompletePragma\""),
           ("/items/1/value/signature", "\"N2\"")
+        ]
+
+    Spec.it s "complete pragma with multiple patterns" $ do
+      check
+        s
+        """
+        {-# language PatternSynonyms #-}
+        pattern Nil :: [a]
+        pattern Nil = []
+        pattern Cons :: a -> [a] -> [a]
+        pattern Cons x xs = x : xs
+        {-# complete Nil, Cons #-}
+        """
+        [ ("/items/0/value/kind/type", "\"PatternSynonym\""),
+          ("/items/0/value/name", "\"Nil\""),
+          ("/items/0/value/parentKey", "4"),
+          ("/items/1/value/kind/type", "\"PatternSynonym\""),
+          ("/items/1/value/name", "\"Cons\""),
+          ("/items/1/value/parentKey", "4"),
+          ("/items/2/value/kind/type", "\"CompletePragma\""),
+          ("/items/2/value/signature", "\"Nil, Cons\"")
         ]
 
     Spec.it s "standalone kind signature" $ do


### PR DESCRIPTION
Fixes #210.

## Summary
- Added `Scrod.Convert.FromGhc.CompleteParents` module that associates pattern synonym items with their COMPLETE pragma as parent
- The step runs after merging (so pattern signature/binding pairs are already combined) but uses the same location-based approach as other parent modules
- Pattern synonyms listed in a `{-# COMPLETE ... #-}` pragma now have the pragma's item key as their `parentKey`, grouping them together in output

## Test plan
- [x] Updated existing "complete pragma" test to verify `parentKey` is set
- [x] Added new "complete pragma with multiple patterns" test matching the issue's example (Nil, Cons)
- [x] Full test suite passes (720 tests)
- [x] Pedantic build passes (`--flags=pedantic`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)