### PR TITLE
Fix #218: Strip HsArg wrapper from type family equation signatures

### DIFF
--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -666,9 +666,15 @@ convertTyFamInstEqnM parentKey lEqn =
 extractTyFamInstEqnSig :: Syntax.TyFamInstEqn Ghc.GhcPs -> Outputable.SDoc
 extractTyFamInstEqnSig eqn =
   Outputable.ppr (Syntax.feqn_tycon eqn)
-    Outputable.<+> Outputable.hsep (Outputable.ppr <$> Syntax.feqn_pats eqn)
+    Outputable.<+> Outputable.hsep (pprHsTypeArg <$> Syntax.feqn_pats eqn)
     Outputable.<+> Outputable.text "="
     Outputable.<+> Outputable.ppr (Syntax.feqn_rhs eqn)
+
+-- | Pretty-print a type argument, stripping the 'HsArg' wrapper.
+pprHsTypeArg :: Syntax.LHsTypeArg Ghc.GhcPs -> Outputable.SDoc
+pprHsTypeArg (Syntax.HsValArg _ ty) = Outputable.ppr ty
+pprHsTypeArg (Syntax.HsTypeArg _ ki) = Outputable.text "@" Outputable.<> Outputable.ppr ki
+pprHsTypeArg (Syntax.HsArgPar _) = Outputable.empty
 
 -- | Convert data definition constructors and deriving clauses.
 convertDataDefnM ::

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -1029,7 +1029,16 @@ spec s = Spec.describe s "integration" $ do
         "{-# language TypeFamilies #-} type family C a where C () = ()"
         [ ("/items/0/value/kind/type", "\"ClosedTypeFamily\""),
           ("/items/1/value/kind/type", "\"TypeFamilyInstance\""),
-          ("/items/1/value/parentKey", "0")
+          ("/items/1/value/parentKey", "0"),
+          ("/items/1/value/signature", "\"C () = ()\"")
+        ]
+
+    Spec.it s "closed type family with multiple equations" $ do
+      check
+        s
+        "{-# language TypeFamilies, DataKinds #-} type family IsUnit a where IsUnit () = 'True; IsUnit _ = 'False"
+        [ ("/items/1/value/signature", "\"IsUnit () = 'True\""),
+          ("/items/2/value/signature", "\"IsUnit _ = 'False\"")
         ]
 
     Spec.it s "data family" $ do


### PR DESCRIPTION
Fixes #218.

## Summary

- `extractTyFamInstEqnSig` was calling `Outputable.ppr` directly on `HsArg` values from `feqn_pats`, which included the GHC-internal constructor name (e.g. `HsValArg`) in rendered signatures.
- Added a `pprHsTypeArg` helper that pattern-matches on each `HsArg` variant (`HsValArg`, `HsTypeArg`, `HsArgPar`) and pretty-prints only the inner type or kind.
- Added signature assertions to the existing closed type family test and a new test with the exact example from the issue (`IsUnit`).

## Test plan

- [x] `cabal build` succeeds
- [x] All 725 tests pass (`cabal test --test-options='--hide-successes'`)
- [x] Manual verification: `IsUnit () = 'True` and `IsUnit _ = 'False` (no `HsValArg`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)