### PR TITLE
Fix data family instance constructor signatures

### DIFF
--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -309,7 +309,12 @@ convertInstDeclWithDocM doc docSince lDecl inst = case inst of
   Syntax.DataFamInstD _ dataFamInst -> do
     parentItem <- convertDeclWithDocM Nothing doc docSince (Names.extractInstDeclName inst) Nothing lDecl
     let parentKey = fmap (Item.key . Located.value) parentItem
-    childItems <- convertDataDefnM parentKey Nothing (Syntax.feqn_rhs $ Syntax.dfid_eqn dataFamInst)
+        eqn = Syntax.dfid_eqn dataFamInst
+        parentType =
+          Just . Text.pack . Outputable.showSDocUnsafe $
+            Outputable.ppr (Syntax.feqn_tycon eqn)
+              Outputable.<+> Outputable.hsep (pprHsTypeArg <$> Syntax.feqn_pats eqn)
+    childItems <- convertDataDefnM parentKey parentType (Syntax.feqn_rhs eqn)
     pure $ Maybe.maybeToList parentItem <> childItems
   _ -> Maybe.maybeToList <$> convertDeclWithDocM Nothing doc docSince (Names.extractInstDeclName inst) Nothing lDecl
 
@@ -666,9 +671,15 @@ convertTyFamInstEqnM parentKey lEqn =
 extractTyFamInstEqnSig :: Syntax.TyFamInstEqn Ghc.GhcPs -> Outputable.SDoc
 extractTyFamInstEqnSig eqn =
   Outputable.ppr (Syntax.feqn_tycon eqn)
-    Outputable.<+> Outputable.hsep (Outputable.ppr <$> Syntax.feqn_pats eqn)
+    Outputable.<+> Outputable.hsep (pprHsTypeArg <$> Syntax.feqn_pats eqn)
     Outputable.<+> Outputable.text "="
     Outputable.<+> Outputable.ppr (Syntax.feqn_rhs eqn)
+
+-- | Pretty-print a type argument, stripping the 'HsArg' wrapper.
+pprHsTypeArg :: Syntax.LHsTypeArg Ghc.GhcPs -> Outputable.SDoc
+pprHsTypeArg (Syntax.HsValArg _ ty) = Outputable.ppr ty
+pprHsTypeArg (Syntax.HsTypeArg _ ki) = Outputable.text "@" Outputable.<> Outputable.ppr ki
+pprHsTypeArg (Syntax.HsArgPar _) = Outputable.empty
 
 -- | Convert data definition constructors and deriving clauses.
 convertDataDefnM ::

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -1368,7 +1368,8 @@ spec s = Spec.describe s "integration" $ do
         [ ("/items/1/value/kind/type", "\"DataFamilyInstance\""),
           ("/items/1/value/parentKey", "0"),
           ("/items/2/value/kind/type", "\"DataConstructor\""),
-          ("/items/2/value/parentKey", "1")
+          ("/items/2/value/parentKey", "1"),
+          ("/items/2/value/signature", "\"B ()\"")
         ]
 
     Spec.it s "data instance constructor GADT" $ do
@@ -1396,7 +1397,20 @@ spec s = Spec.describe s "integration" $ do
         [ ("/items/1/value/kind/type", "\"DataFamilyInstance\""),
           ("/items/1/value/parentKey", "0"),
           ("/items/2/value/kind/type", "\"DataConstructor\""),
-          ("/items/2/value/parentKey", "1")
+          ("/items/2/value/parentKey", "1"),
+          ("/items/2/value/signature", "\"() -> F\"")
+        ]
+
+    Spec.it s "newtype instance with type argument" $ do
+      check
+        s
+        """
+        {-# language TypeFamilies #-}
+        data family Collection a
+        newtype instance Collection Int = CollectionInt [Int]
+        """
+        [ ("/items/2/value/kind/type", "\"DataConstructor\""),
+          ("/items/2/value/signature", "\"[Int] -> Collection Int\"")
         ]
 
     Spec.it s "newtype instance GADT" $ do


### PR DESCRIPTION
Fixes #219.

## Summary

- Extract the parent type from data family instance equations (`feqn_tycon` + `feqn_pats`) and pass it to `convertDataDefnM`, so constructor signatures use arrow style (e.g. `[Int] -> Collection Int`) instead of printing the raw declaration (`CollectionInt [Int]`).
- Add a `pprHsTypeArg` helper to strip `HsArg` wrappers when pretty-printing type arguments (also fixes the same issue in `extractTyFamInstEqnSig`).
- Add integration tests asserting constructor signatures for data instance, newtype instance, and newtype instance with a type argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)