### PR TITLE
Fix #220: Preserve data declarations with standalone kind signatures

### DIFF
--- a/scrod.cabal
+++ b/scrod.cabal
@@ -100,6 +100,7 @@ library
     Scrod.Convert.FromGhc.InstanceParents
     Scrod.Convert.FromGhc.Internal
     Scrod.Convert.FromGhc.ItemKind
+    Scrod.Convert.FromGhc.KindSigParents
     Scrod.Convert.FromGhc.Merge
     Scrod.Convert.FromGhc.Names
     Scrod.Convert.FromGhc.RoleParents

--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -41,6 +41,7 @@ import qualified Scrod.Convert.FromGhc.InlineParents as InlineParents
 import qualified Scrod.Convert.FromGhc.InstanceParents as InstanceParents
 import qualified Scrod.Convert.FromGhc.Internal as Internal
 import qualified Scrod.Convert.FromGhc.ItemKind as ItemKindFrom
+import qualified Scrod.Convert.FromGhc.KindSigParents as KindSigParents
 import qualified Scrod.Convert.FromGhc.Merge as Merge
 import qualified Scrod.Convert.FromGhc.Names as Names
 import qualified Scrod.Convert.FromGhc.RoleParents as RoleParents
@@ -218,6 +219,11 @@ extractItems lHsModule =
       familyInstanceNames = FamilyInstanceParents.extractFamilyInstanceNames lHsModule
       familyParentedItems = FamilyInstanceParents.associateFamilyInstanceParents familyInstanceNames roleParentedItems
       mergedItems = Merge.mergeItemsByName familyParentedItems
+      -- Standalone kind signature association runs after merging so
+      -- that type signatures and bindings are merged first. This
+      -- parents data, newtype, type synonym, and class declarations
+      -- to their corresponding standalone kind signature.
+      kindSigParentedItems = KindSigParents.associateKindSigParents mergedItems
       -- COMPLETE pragma association runs after merging and uses inverted
       -- semantics: pattern synonyms are parented to the COMPLETE pragma
       -- (not the pragma to the patterns). This is because COMPLETE
@@ -225,7 +231,7 @@ extractItems lHsModule =
       -- declaration. It must run after merging because pattern synonyms
       -- are merged with their type signatures first.
       completeNames = CompleteParents.extractCompleteNames lHsModule
-   in CompleteParents.associateCompleteParents completeNames mergedItems
+   in CompleteParents.associateCompleteParents completeNames kindSigParentedItems
 
 -- | Extract items in the conversion monad.
 extractItemsM ::

--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -221,8 +221,8 @@ extractItems lHsModule =
       mergedItems = Merge.mergeItemsByName familyParentedItems
       -- Standalone kind signature association runs after merging so
       -- that type signatures and bindings are merged first. This
-      -- parents data, newtype, type synonym, and class declarations
-      -- to their corresponding standalone kind signature.
+      -- parents associated declarations to their corresponding
+      -- standalone kind signature (see 'KindSigParents').
       kindSigParentedItems = KindSigParents.associateKindSigParents mergedItems
       -- COMPLETE pragma association runs after merging and uses inverted
       -- semantics: pattern synonyms are parented to the COMPLETE pragma

--- a/source/library/Scrod/Convert/FromGhc/KindSigParents.hs
+++ b/source/library/Scrod/Convert/FromGhc/KindSigParents.hs
@@ -1,9 +1,9 @@
 -- | Resolve standalone kind signature parent relationships.
 --
--- Associates type, data, newtype, and class declarations with their
--- corresponding standalone kind signature when both are defined in
--- the same module. This runs after merging so that type signatures
--- and bindings are merged first.
+-- Associates type, data, newtype, class, type family, and data family
+-- declarations with their corresponding standalone kind signature when
+-- both are defined in the same module. This runs after merging so that
+-- type signatures and bindings are merged first.
 module Scrod.Convert.FromGhc.KindSigParents where
 
 import qualified Data.Map as Map

--- a/source/library/Scrod/Convert/FromGhc/KindSigParents.hs
+++ b/source/library/Scrod/Convert/FromGhc/KindSigParents.hs
@@ -1,0 +1,59 @@
+-- | Resolve standalone kind signature parent relationships.
+--
+-- Associates type, data, newtype, and class declarations with their
+-- corresponding standalone kind signature when both are defined in
+-- the same module. This runs after merging so that type signatures
+-- and bindings are merged first.
+module Scrod.Convert.FromGhc.KindSigParents where
+
+import qualified Data.Map as Map
+import qualified Data.Maybe as Maybe
+import qualified Scrod.Core.Item as Item
+import qualified Scrod.Core.ItemKey as ItemKey
+import qualified Scrod.Core.ItemKind as ItemKind
+import qualified Scrod.Core.ItemName as ItemName
+import qualified Scrod.Core.Located as Located
+
+-- | Associate declarations with their standalone kind signatures.
+associateKindSigParents ::
+  [Located.Located Item.Item] ->
+  [Located.Located Item.Item]
+associateKindSigParents items =
+  let kindSigNameToKey = buildKindSigNameToKeyMap items
+   in fmap (resolveKindSigParent kindSigNameToKey) items
+
+-- | Build a map from standalone kind signature names to their keys.
+buildKindSigNameToKeyMap ::
+  [Located.Located Item.Item] ->
+  Map.Map ItemName.ItemName ItemKey.ItemKey
+buildKindSigNameToKeyMap =
+  Map.fromList . Maybe.mapMaybe getKindSigNameAndKey
+  where
+    getKindSigNameAndKey locItem =
+      let val = Located.value locItem
+       in case (Item.kind val, Item.name val) of
+            (ItemKind.StandaloneKindSig, Just name) ->
+              Just (name, Item.key val)
+            _ -> Nothing
+
+-- | Set the parentKey on a declaration item if a standalone kind
+-- signature with the same name exists.
+resolveKindSigParent ::
+  Map.Map ItemName.ItemName ItemKey.ItemKey ->
+  Located.Located Item.Item ->
+  Located.Located Item.Item
+resolveKindSigParent kindSigNameToKey locItem =
+  let val = Located.value locItem
+   in case Item.name val of
+        Nothing -> locItem
+        Just name ->
+          if Maybe.isJust (Item.parentKey val)
+            || Item.kind val == ItemKind.StandaloneKindSig
+            then locItem
+            else case Map.lookup name kindSigNameToKey of
+              Nothing -> locItem
+              Just parentKey ->
+                locItem
+                  { Located.value =
+                      val {Item.parentKey = Just parentKey}
+                  }

--- a/source/library/Scrod/Convert/FromGhc/Merge.hs
+++ b/source/library/Scrod/Convert/FromGhc/Merge.hs
@@ -14,6 +14,7 @@ import qualified Scrod.Convert.FromGhc.Internal as Internal
 import qualified Scrod.Core.Doc as Doc
 import qualified Scrod.Core.Item as Item
 import qualified Scrod.Core.ItemKey as ItemKey
+import qualified Scrod.Core.ItemKind as ItemKind
 import qualified Scrod.Core.ItemName as ItemName
 import qualified Scrod.Core.Located as Located
 
@@ -37,10 +38,16 @@ buildMergeMap items =
    in Map.map mergeItemGroup groups
 
 -- | Check if an item is eligible for merging.
+--
+-- Standalone kind signatures are excluded because they should remain
+-- as separate items with the associated declaration parented to them,
+-- not merged into a single item (see 'KindSigParents').
 isMergeCandidate :: Located.Located Item.Item -> Bool
 isMergeCandidate item =
   let val = Located.value item
-   in Maybe.isNothing (Item.parentKey val) && Maybe.isJust (Item.name val)
+   in Maybe.isNothing (Item.parentKey val)
+        && Maybe.isJust (Item.name val)
+        && Item.kind val /= ItemKind.StandaloneKindSig
 
 -- | Merge a group of items sharing the same name into a single item.
 mergeItemGroup :: NonEmpty.NonEmpty (Located.Located Item.Item) -> Located.Located Item.Item

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -2097,7 +2097,13 @@ spec s = Spec.describe s "integration" $ do
         type O :: *
         data O
         """
-        [("/items/0/value/signature", "\"*\"")]
+        [ ("/items/0/value/kind/type", "\"StandaloneKindSig\""),
+          ("/items/0/value/name", "\"O\""),
+          ("/items/0/value/signature", "\"*\""),
+          ("/items/1/value/kind/type", "\"DataType\""),
+          ("/items/1/value/name", "\"O\""),
+          ("/items/1/value/parentKey", "0")
+        ]
 
     Spec.it s "standalone kind signature with data" $ do
       check
@@ -2106,7 +2112,36 @@ spec s = Spec.describe s "integration" $ do
         type X :: a -> a
         data X a = X
         """
-        [("/items/0/value/signature", "\"a -> a\"")]
+        [ ("/items/0/value/kind/type", "\"StandaloneKindSig\""),
+          ("/items/0/value/name", "\"X\""),
+          ("/items/0/value/signature", "\"a -> a\""),
+          ("/items/1/value/kind/type", "\"DataType\""),
+          ("/items/1/value/name", "\"X\""),
+          ("/items/1/value/parentKey", "0"),
+          ("/items/1/value/signature", "\"a\""),
+          ("/items/2/value/kind/type", "\"DataConstructor\""),
+          ("/items/2/value/name", "\"X\""),
+          ("/items/2/value/parentKey", "1")
+        ]
+
+    Spec.it s "standalone kind signature with newtype" $ do
+      check
+        s
+        """
+        type Phantom :: * -> *
+        newtype Phantom a = MkPhantom ()
+        """
+        [ ("/items/0/value/kind/type", "\"StandaloneKindSig\""),
+          ("/items/0/value/name", "\"Phantom\""),
+          ("/items/0/value/signature", "\"* -> *\""),
+          ("/items/1/value/kind/type", "\"Newtype\""),
+          ("/items/1/value/name", "\"Phantom\""),
+          ("/items/1/value/parentKey", "0"),
+          ("/items/1/value/signature", "\"a\""),
+          ("/items/2/value/kind/type", "\"DataConstructor\""),
+          ("/items/2/value/name", "\"MkPhantom\""),
+          ("/items/2/value/parentKey", "1")
+        ]
 
     Spec.it s "default declaration" $ do
       check s "default ()" [("/items", "[]")]

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -2143,6 +2143,53 @@ spec s = Spec.describe s "integration" $ do
           ("/items/2/value/parentKey", "1")
         ]
 
+    Spec.it s "standalone kind signature with type synonym" $ do
+      check
+        s
+        """
+        type T :: * -> *
+        type T a = Maybe a
+        """
+        [ ("/items/0/value/kind/type", "\"StandaloneKindSig\""),
+          ("/items/0/value/name", "\"T\""),
+          ("/items/0/value/signature", "\"* -> *\""),
+          ("/items/1/value/kind/type", "\"TypeSynonym\""),
+          ("/items/1/value/name", "\"T\""),
+          ("/items/1/value/parentKey", "0")
+        ]
+
+    Spec.it s "standalone kind signature with class" $ do
+      check
+        s
+        """
+        {-# LANGUAGE ConstraintKinds #-}
+        type C :: * -> Constraint
+        class C a
+        """
+        [ ("/items/0/value/kind/type", "\"StandaloneKindSig\""),
+          ("/items/0/value/name", "\"C\""),
+          ("/items/0/value/signature", "\"* -> Constraint\""),
+          ("/items/1/value/kind/type", "\"Class\""),
+          ("/items/1/value/name", "\"C\""),
+          ("/items/1/value/parentKey", "0")
+        ]
+
+    Spec.it s "standalone kind signature with type family" $ do
+      check
+        s
+        """
+        {-# LANGUAGE TypeFamilies #-}
+        type F :: * -> *
+        type family F a
+        """
+        [ ("/items/0/value/kind/type", "\"StandaloneKindSig\""),
+          ("/items/0/value/name", "\"F\""),
+          ("/items/0/value/signature", "\"* -> *\""),
+          ("/items/1/value/kind/type", "\"OpenTypeFamily\""),
+          ("/items/1/value/name", "\"F\""),
+          ("/items/1/value/parentKey", "0")
+        ]
+
     Spec.it s "default declaration" $ do
       check s "default ()" [("/items", "[]")]
 


### PR DESCRIPTION
## Summary

Fixes #220.

- Excluded `StandaloneKindSig` items from merge candidates in `Merge.hs`, preventing them from absorbing the associated data/newtype/type/class declaration
- Added a new `KindSigParents` post-merge pass that parents declarations to their corresponding standalone kind signature by matching names
- Updated existing integration tests to verify the full item structure (kind, name, parentKey) and added a new test for standalone kind signatures with newtypes

## Test plan

- [x] `cabal build` succeeds
- [x] `cabal test --test-options='--hide-successes'` — all 726 tests pass
- [x] Manual verification: `type Phantom :: Type -> Type` / `data Phantom a = MkPhantom` now produces three items (StandaloneKindSig → DataType → DataConstructor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)