### PR TITLE
Remove trivial associateParents and toJsonSchema aliases

### DIFF
--- a/source/executables/scrod-wasi/Main.hs
+++ b/source/executables/scrod-wasi/Main.hs
@@ -1,4 +1,5 @@
+import qualified GHC.Stack as Stack
 import qualified Scrod
 
-main :: IO ()
+main :: (Stack.HasCallStack) => IO ()
 main = Scrod.defaultMain

--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -38,13 +38,13 @@ import qualified Scrod.Convert.FromGhc.Exports as Exports
 import qualified Scrod.Convert.FromGhc.FamilyInstanceParents as FamilyInstanceParents
 import qualified Scrod.Convert.FromGhc.FixityParents as FixityParents
 import qualified Scrod.Convert.FromGhc.InlineParents as InlineParents
-import qualified Scrod.Convert.FromGhc.ParentAssociation as ParentAssociation
 import qualified Scrod.Convert.FromGhc.InstanceParents as InstanceParents
 import qualified Scrod.Convert.FromGhc.Internal as Internal
 import qualified Scrod.Convert.FromGhc.ItemKind as ItemKindFrom
 import qualified Scrod.Convert.FromGhc.KindSigParents as KindSigParents
 import qualified Scrod.Convert.FromGhc.Merge as Merge
 import qualified Scrod.Convert.FromGhc.Names as Names
+import qualified Scrod.Convert.FromGhc.ParentAssociation as ParentAssociation
 import qualified Scrod.Convert.FromGhc.RoleParents as RoleParents
 import qualified Scrod.Convert.FromGhc.SpecialiseParents as SpecialiseParents
 import qualified Scrod.Convert.FromGhc.WarningParents as WarningParents

--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -38,6 +38,7 @@ import qualified Scrod.Convert.FromGhc.Exports as Exports
 import qualified Scrod.Convert.FromGhc.FamilyInstanceParents as FamilyInstanceParents
 import qualified Scrod.Convert.FromGhc.FixityParents as FixityParents
 import qualified Scrod.Convert.FromGhc.InlineParents as InlineParents
+import qualified Scrod.Convert.FromGhc.ParentAssociation as ParentAssociation
 import qualified Scrod.Convert.FromGhc.InstanceParents as InstanceParents
 import qualified Scrod.Convert.FromGhc.Internal as Internal
 import qualified Scrod.Convert.FromGhc.ItemKind as ItemKindFrom
@@ -211,11 +212,11 @@ extractItems lHsModule =
       specialiseLocations = SpecialiseParents.extractSpecialiseLocations lHsModule
       roleLocations = RoleParents.extractRoleLocations lHsModule
       allPragmaLocations = Set.unions [warningLocations, fixityLocations, inlineLocations, specialiseLocations, roleLocations]
-      warningParentedItems = WarningParents.associateWarningParents allPragmaLocations warningLocations parentedItems
-      fixityParentedItems = FixityParents.associateFixityParents allPragmaLocations fixityLocations warningParentedItems
-      inlineParentedItems = InlineParents.associateInlineParents allPragmaLocations inlineLocations fixityParentedItems
-      specialiseParentedItems = SpecialiseParents.associateSpecialiseParents allPragmaLocations specialiseLocations inlineParentedItems
-      roleParentedItems = RoleParents.associateRoleParents allPragmaLocations roleLocations specialiseParentedItems
+      warningParentedItems = ParentAssociation.associateParents allPragmaLocations warningLocations parentedItems
+      fixityParentedItems = ParentAssociation.associateParents allPragmaLocations fixityLocations warningParentedItems
+      inlineParentedItems = ParentAssociation.associateParents allPragmaLocations inlineLocations fixityParentedItems
+      specialiseParentedItems = ParentAssociation.associateParents allPragmaLocations specialiseLocations inlineParentedItems
+      roleParentedItems = ParentAssociation.associateParents allPragmaLocations roleLocations specialiseParentedItems
       familyInstanceNames = FamilyInstanceParents.extractFamilyInstanceNames lHsModule
       familyParentedItems = FamilyInstanceParents.associateFamilyInstanceParents familyInstanceNames roleParentedItems
       mergedItems = Merge.mergeItemsByName familyParentedItems

--- a/source/library/Scrod/Convert/FromGhc/FixityParents.hs
+++ b/source/library/Scrod/Convert/FromGhc/FixityParents.hs
@@ -11,9 +11,6 @@ import qualified GHC.Parser.Annotation as Annotation
 import qualified GHC.Types.SrcLoc as SrcLoc
 import qualified Language.Haskell.Syntax as Syntax
 import qualified Scrod.Convert.FromGhc.Internal as Internal
-import qualified Scrod.Convert.FromGhc.ParentAssociation as ParentAssociation
-import qualified Scrod.Core.Item as Item
-import qualified Scrod.Core.Located as Located
 import qualified Scrod.Core.Location as Location
 
 -- | Extract the set of source locations that correspond to names inside
@@ -34,11 +31,3 @@ extractDeclFixityLocations lDecl = case SrcLoc.unLoc lDecl of
   Syntax.SigD _ (Syntax.FixSig _ (Syntax.FixitySig _ names _)) ->
     concatMap (foldMap pure . Internal.locationFromSrcSpan . Annotation.getLocA) names
   _ -> []
-
--- | Associate fixity items with their target declarations.
-associateFixityParents ::
-  Set.Set Location.Location ->
-  Set.Set Location.Location ->
-  [Located.Located Item.Item] ->
-  [Located.Located Item.Item]
-associateFixityParents = ParentAssociation.associateParents

--- a/source/library/Scrod/Convert/FromGhc/InlineParents.hs
+++ b/source/library/Scrod/Convert/FromGhc/InlineParents.hs
@@ -11,9 +11,6 @@ import qualified GHC.Parser.Annotation as Annotation
 import qualified GHC.Types.SrcLoc as SrcLoc
 import qualified Language.Haskell.Syntax as Syntax
 import qualified Scrod.Convert.FromGhc.Internal as Internal
-import qualified Scrod.Convert.FromGhc.ParentAssociation as ParentAssociation
-import qualified Scrod.Core.Item as Item
-import qualified Scrod.Core.Located as Located
 import qualified Scrod.Core.Location as Location
 
 -- | Extract the set of source locations that correspond to names inside
@@ -34,11 +31,3 @@ extractDeclInlineLocations lDecl = case SrcLoc.unLoc lDecl of
   Syntax.SigD _ (Syntax.InlineSig _ lName _) ->
     foldMap pure $ Internal.locationFromSrcSpan (Annotation.getLocA lName)
   _ -> []
-
--- | Associate inline items with their target declarations.
-associateInlineParents ::
-  Set.Set Location.Location ->
-  Set.Set Location.Location ->
-  [Located.Located Item.Item] ->
-  [Located.Located Item.Item]
-associateInlineParents = ParentAssociation.associateParents

--- a/source/library/Scrod/Convert/FromGhc/RoleParents.hs
+++ b/source/library/Scrod/Convert/FromGhc/RoleParents.hs
@@ -11,9 +11,6 @@ import qualified GHC.Parser.Annotation as Annotation
 import qualified GHC.Types.SrcLoc as SrcLoc
 import qualified Language.Haskell.Syntax as Syntax
 import qualified Scrod.Convert.FromGhc.Internal as Internal
-import qualified Scrod.Convert.FromGhc.ParentAssociation as ParentAssociation
-import qualified Scrod.Core.Item as Item
-import qualified Scrod.Core.Located as Located
 import qualified Scrod.Core.Location as Location
 
 -- | Extract the set of source locations that correspond to role annotation
@@ -34,11 +31,3 @@ extractDeclRoleLocations lDecl = case SrcLoc.unLoc lDecl of
   Syntax.RoleAnnotD _ (Syntax.RoleAnnotDecl _ lName _) ->
     foldMap pure $ Internal.locationFromSrcSpan (Annotation.getLocA lName)
   _ -> []
-
--- | Associate role annotation items with their target declarations.
-associateRoleParents ::
-  Set.Set Location.Location ->
-  Set.Set Location.Location ->
-  [Located.Located Item.Item] ->
-  [Located.Located Item.Item]
-associateRoleParents = ParentAssociation.associateParents

--- a/source/library/Scrod/Convert/FromGhc/SpecialiseParents.hs
+++ b/source/library/Scrod/Convert/FromGhc/SpecialiseParents.hs
@@ -11,9 +11,6 @@ import qualified GHC.Parser.Annotation as Annotation
 import qualified GHC.Types.SrcLoc as SrcLoc
 import qualified Language.Haskell.Syntax as Syntax
 import qualified Scrod.Convert.FromGhc.Internal as Internal
-import qualified Scrod.Convert.FromGhc.ParentAssociation as ParentAssociation
-import qualified Scrod.Core.Item as Item
-import qualified Scrod.Core.Located as Located
 import qualified Scrod.Core.Location as Location
 
 -- | Extract the set of source locations that correspond to names inside
@@ -47,11 +44,3 @@ extractExprNameLocations lExpr = case SrcLoc.unLoc lExpr of
       foldMap pure . Internal.locationFromSrcSpan $ Annotation.getLocA lName
     _ -> []
   _ -> []
-
--- | Associate specialise items with their target declarations.
-associateSpecialiseParents ::
-  Set.Set Location.Location ->
-  Set.Set Location.Location ->
-  [Located.Located Item.Item] ->
-  [Located.Located Item.Item]
-associateSpecialiseParents = ParentAssociation.associateParents

--- a/source/library/Scrod/Convert/FromGhc/WarningParents.hs
+++ b/source/library/Scrod/Convert/FromGhc/WarningParents.hs
@@ -12,9 +12,6 @@ import qualified GHC.Parser.Annotation as Annotation
 import qualified GHC.Types.SrcLoc as SrcLoc
 import qualified Language.Haskell.Syntax as Syntax
 import qualified Scrod.Convert.FromGhc.Internal as Internal
-import qualified Scrod.Convert.FromGhc.ParentAssociation as ParentAssociation
-import qualified Scrod.Core.Item as Item
-import qualified Scrod.Core.Located as Located
 import qualified Scrod.Core.Location as Location
 
 -- | Extract the set of source locations that correspond to names inside
@@ -43,11 +40,3 @@ extractWarnDeclLocations ::
 extractWarnDeclLocations lWarnDecl = case SrcLoc.unLoc lWarnDecl of
   Syntax.Warning _ names _ ->
     concatMap (foldMap pure . Internal.locationFromSrcSpan . Annotation.getLocA) names
-
--- | Associate warning items with their target declarations.
-associateWarningParents ::
-  Set.Set Location.Location ->
-  Set.Set Location.Location ->
-  [Located.Located Item.Item] ->
-  [Located.Located Item.Item]
-associateWarningParents = ParentAssociation.associateParents

--- a/source/library/Scrod/Convert/ToJsonSchema.hs
+++ b/source/library/Scrod/Convert/ToJsonSchema.hs
@@ -19,18 +19,14 @@ import qualified Scrod.JsonPointer.Pointer as Pointer
 import qualified Scrod.Schema as ToSchema
 import qualified Scrod.Spec as Spec
 
--- | See 'moduleSchema'.
-toJsonSchema :: Json.Value
-toJsonSchema = moduleSchema
-
 -- | Schema for the top-level module object.
 --
 -- Runs the 'ToSchema.ToSchema' instance for 'Module.Module' in
 -- 'ToSchema.SchemaM', extracts the resulting object schema, and wraps
 -- it with JSON Schema metadata (@$schema@, @$id@, @title@,
 -- @description@) and any accumulated @$defs@.
-moduleSchema :: Json.Value
-moduleSchema =
+toJsonSchema :: Json.Value
+toJsonSchema =
   let (schema, defs) =
         ToSchema.runSchemaM $
           ToSchema.toSchema


### PR DESCRIPTION
## Summary
- Remove 5 `associate*Parents` wrappers that just forwarded to `ParentAssociation.associateParents`; call it directly from `FromGhc`
- Remove `toJsonSchema`/`moduleSchema` indirection in `ToJsonSchema` by renaming `moduleSchema` to `toJsonSchema`
- Clean up now-unused imports (`ParentAssociation`, `Item`, `Located`) from the 5 `*Parents` modules

## Test plan
- [x] `cabal build` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)