### PR TITLE
Fix #225: Use export list to drive HTML declarations ordering

### DIFF
--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -652,7 +652,7 @@ declarationsContents exports items =
                       [Xml.string "Unexported"]
                 ]
                   <> concatMap renderUnexportedItem unexportedTopLevel
-                  <> fmap (\li -> Content.Element (itemToHtml li)) orphanedChildren
+                  <> fmap (Content.Element . itemToHtml) orphanedChildren
        in [ Content.Element $
               Xml.element
                 "section"


### PR DESCRIPTION
Fixes #225.

## Summary

- When a module has an explicit export list, the HTML output now renders items in export-list order instead of source order
- Section headings (`-- * Section`) and documentation (`-- | doc`) from the export list appear inline between item cards
- Items not in the export list are collected under an "Unexported" heading at the bottom of the Declarations section
- Modules without an export list continue to show all items in source order (no change)
- The standalone "Exports" section has been removed — the export list now drives the Declarations section directly

## Test plan

- [x] All 730 existing tests pass
- [x] Pedantic build (`-Werror`) passes
- [x] Ormolu formatting passes
- [x] Manual smoke tests verify:
  - No export list → items in source order
  - Export list `(y, x)` → items rendered as y, x
  - Partial export list → exported items first, unexported items under "Unexported" heading
  - Section headings from export groups render as `<h3>` between items

🤖 Generated with [Claude Code](https://claude.ai/code)