### PR TITLE
Fix #230: Preserve unreferenced named doc chunks as items

### DIFF
--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -260,7 +260,7 @@ convertDeclWithDocMaybeM doc docSince lDecl = case SrcLoc.unLoc lDecl of
   Syntax.DocD _ (Hs.DocCommentNamed name lNamedDoc) ->
     let chunkName = Just . ItemName.MkItemName . Text.pack $ '$' : name
         chunkDoc = GhcDoc.convertExportDoc lNamedDoc
-     in Maybe.maybeToList <$> Internal.mkItemM (Annotation.getLocA lDecl) Nothing chunkName (Internal.appendDoc doc chunkDoc) docSince Nothing ItemKind.Function
+     in Maybe.maybeToList <$> Internal.mkItemM (Annotation.getLocA lDecl) Nothing chunkName (Internal.appendDoc doc chunkDoc) docSince Nothing ItemKind.DocumentationChunk
   Syntax.DocD {} -> Maybe.maybeToList <$> convertDeclSimpleM lDecl
   Syntax.SigD _ sig -> convertSigDeclM doc docSince lDecl sig
   Syntax.KindSigD _ kindSig ->

--- a/source/library/Scrod/Convert/FromGhc/Doc.hs
+++ b/source/library/Scrod/Convert/FromGhc/Doc.hs
@@ -83,7 +83,9 @@ associateNextDocsLoop referencedChunkNames pendingDoc pendingSince (lDecl : rest
     (Doc.Empty, Nothing, lDecl) : associateNextDocsLoop referencedChunkNames Doc.Empty Nothing rest
   Syntax.DocD _ (Hs.DocCommentNamed name _)
     | Set.member (Text.pack name) referencedChunkNames ->
-        associateNextDocsLoop referencedChunkNames pendingDoc pendingSince rest
+        associateNextDocsLoop referencedChunkNames Doc.Empty Nothing rest
+    | otherwise ->
+        (Doc.Empty, Nothing, lDecl) : associateNextDocsLoop referencedChunkNames Doc.Empty Nothing rest
   _ ->
     (pendingDoc, pendingSince, lDecl) : associateNextDocsLoop referencedChunkNames Doc.Empty Nothing rest
 

--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -809,6 +809,7 @@ kindToText k = case k of
   ItemKind.CompletePragma -> Text.pack "complete"
   ItemKind.DefaultMethodSignature -> Text.pack "default"
   ItemKind.RoleAnnotation -> Text.pack "role"
+  ItemKind.DocumentationChunk -> Text.pack "doc chunk"
 
 data KindColor
   = KindSuccess
@@ -854,6 +855,7 @@ kindColor k = case k of
   ItemKind.CompletePragma -> KindSecondary
   ItemKind.DefaultMethodSignature -> KindPrimary
   ItemKind.RoleAnnotation -> KindSecondary
+  ItemKind.DocumentationChunk -> KindSecondary
 
 kindBadgeClass :: ItemKind.ItemKind -> String
 kindBadgeClass k = case kindColor k of

--- a/source/library/Scrod/Core/ItemKind.hs
+++ b/source/library/Scrod/Core/ItemKind.hs
@@ -79,5 +79,7 @@ data ItemKind
     DefaultMethodSignature
   | -- | Role annotation: @type role T nominal@
     RoleAnnotation
+  | -- | Named documentation chunk: @-- $name@
+    DocumentationChunk
   deriving (Eq, Generics.Generic, Ord, Show)
   deriving (ToJson.ToJson, Schema.ToSchema) via Generics.Generically ItemKind

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -834,7 +834,7 @@ spec s = Spec.describe s "integration" $ do
             ("/exports/1/value/name/name", "\"unit\"")
           ]
 
-      Spec.it s "does not create items for named chunks" $ do
+      Spec.it s "does not create items for referenced named chunks" $ do
         check
           s
           """
@@ -852,6 +852,45 @@ spec s = Spec.describe s "integration" $ do
           [ ("/items/0/value/name", "\"unit\""),
             ("/items/0/value/kind/type", "\"Function\""),
             ("/items/0/value/signature", "\"()\"")
+          ]
+
+      Spec.it s "creates items for unreferenced named chunks" $ do
+        check
+          s
+          """
+          -- $a
+          -- b
+          x=0
+          """
+          [ ("/items/0/value/name", "\"$a\""),
+            ("/items/0/value/documentation/type", "\"Paragraph\""),
+            ("/items/0/value/documentation/value/value", "\"b\""),
+            ("/items/1/value/name", "\"x\"")
+          ]
+
+      Spec.it s "creates items for unreferenced named chunks with explicit exports" $ do
+        check
+          s
+          """
+          module M
+            ( -- $foo
+              unit,
+            ) where
+
+          -- $foo
+          -- bar
+
+          -- $baz
+          -- quux
+
+          unit :: ()
+          unit = ()
+          """
+          [ ("/exports/0/type", "\"Doc\""),
+            ("/exports/0/value/value/value", "\"bar\""),
+            ("/items/0/value/name", "\"$baz\""),
+            ("/items/0/value/documentation/value/value", "\"quux\""),
+            ("/items/1/value/name", "\"unit\"")
           ]
 
   Spec.describe s "imports" $ do

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -868,6 +868,41 @@ spec s = Spec.describe s "integration" $ do
             ("/items/1/value/name", "\"x\"")
           ]
 
+      Spec.it s "preceding doc comment does not leak past named chunk" $ do
+        check
+          s
+          """
+          module M
+            ( -- $bar
+              unit,
+            ) where
+
+          -- | foo
+          -- $bar
+          -- qux
+          unit :: ()
+          unit = ()
+          """
+          [ ("/exports/0/value/value/value", "\"qux\""),
+            ("/items/0/value/name", "\"unit\""),
+            ("/items/0/value/documentation/type", "\"Empty\"")
+          ]
+
+      Spec.it s "preceding doc comment does not leak past unreferenced named chunk" $ do
+        check
+          s
+          """
+          -- | foo
+          -- $a
+          -- chunk
+          x=0
+          """
+          [ ("/items/0/value/name", "\"$a\""),
+            ("/items/0/value/documentation/value/value", "\"chunk\""),
+            ("/items/1/value/name", "\"x\""),
+            ("/items/1/value/documentation/type", "\"Empty\"")
+          ]
+
       Spec.it s "creates items for unreferenced named chunks with explicit exports" $ do
         check
           s


### PR DESCRIPTION
## Summary

- Named documentation groups (`-- $name`) that aren't referenced in the export list were being silently dropped from the output
- Now unreferenced named chunks appear as top-level items with the chunk name (prefixed with `$`) and their documentation content
- Referenced named chunks continue to be resolved in the export list and excluded from items, as before

Fixes #230.

## Implementation

- `associateDocs` now accepts a `Set Text` of referenced chunk names; only chunks in that set are skipped during doc association
- `convertDeclWithDocMaybeM` handles `DocCommentNamed` explicitly, extracting the chunk name and content into a proper item
- `extractReferencedChunkNames` computes which chunk names appear in the export list (before resolution)

## Test plan

- [x] Existing test "does not create items for referenced named chunks" still passes (renamed for clarity)
- [x] New test "creates items for unreferenced named chunks" — verifies the issue example (`-- $a / -- b / x=0`)
- [x] New test "creates items for unreferenced named chunks with explicit exports" — verifies mixed scenario where one chunk is referenced and another is not
- [x] All 732 tests pass
- [x] Pedantic build (`--flags=pedantic`) passes with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)