### PR TITLE
Display function arguments as child items (#235)

### DIFF
--- a/docs/plans/2026-02-17-function-argument-display-design.md
+++ b/docs/plans/2026-02-17-function-argument-display-design.md
@@ -1,0 +1,109 @@
+# Function Argument Display
+
+Issue: #235
+
+## Problem
+
+When a function has per-argument Haddock docs (`-- ^`), the signature is rendered
+via GHC's `ppr` which includes those doc comments inline as text. This looks
+syntactically incorrect in the current `<code>` rendering. For example:
+
+```haskell
+f :: a -- ^ i
+  -> a -- ^ o
+```
+
+The signature displays with embedded comments and awkward newlines rather than a
+clean `:: a -> a`.
+
+## Design
+
+Model each positional function/constructor argument as a child Item with a new
+`Argument` ItemKind. Strip inline doc comments from the parent signature so it
+renders cleanly. Argument items render as nested cards (the same pattern used by
+RecordField items).
+
+### Core types
+
+Add one variant to `ItemKind`:
+
+```haskell
+| Argument  -- ^ Positional argument of a function or constructor
+```
+
+No changes to `Item`. Argument items use existing fields:
+
+- `signature` = the individual argument's type text (e.g. `"Int"`, `"a"`)
+- `documentation` = the per-argument Haddock doc (or `Empty` if undocumented)
+- `parentKey` = the owning function or constructor
+- `name` = `Nothing` (positional args have no names)
+- `kind` = `Argument`
+
+### GHC extraction: functions
+
+In `Scrod.Convert.FromGhc.Names`:
+
+- New function `extractSigArguments` walks the `HsFunTy` / `HsDocTy` chain in a
+  type signature. For each arrow-separated argument: if it's wrapped in
+  `HsDocTy`, extract the doc and the inner type; otherwise `(type, Nothing)`.
+  Returns `[(Text, Maybe LHsDoc)]`.
+- Modify `extractSigSignature` to strip `HsDocTy` nodes before `ppr`-ing, so the
+  parent signature is clean (e.g. `"a -> a"`).
+
+In `Scrod.Convert.FromGhc`:
+
+- After creating the function Item, call `extractSigArguments` and emit a child
+  Argument item for each positional argument (all args, not only documented ones).
+
+### GHC extraction: constructors
+
+In `Scrod.Convert.FromGhc.Constructors`:
+
+- For `PrefixCon fields`: iterate over `HsConDeclField` list, extract `cdf_doc`
+  and `cdf_type`, emit Argument child items.
+- For `InfixCon l r`: same, two Argument items.
+- For `PrefixConGADT`: same pattern.
+- Record constructors are unchanged (they already have named RecordField children).
+- Continue stripping `cdf_doc` from the parent signature.
+
+### HTML rendering
+
+No special-casing in `ToHtml`. Argument child items render as nested cards via
+the existing `renderItemWithChildren` recursion.
+
+Changes:
+
+- Add `ItemKind.Argument -> "argument"` to `kindToString`.
+- Badge color: covered by existing wildcard `_ -> "text-bg-secondary"`.
+
+### JSON output
+
+No changes needed. Argument items appear in the `items` array with
+`"kind": {"type": "Argument"}`, `"parentKey"` pointing to their function or
+constructor, `"signature"` with the type text, and `"documentation"` with the arg
+doc.
+
+### Testing
+
+Integration tests:
+
+- Functions with per-argument docs: verify parent signature is clean, verify child
+  Argument items exist with correct signature and documentation.
+- Functions with no arg docs: verify Argument child items have `Empty` docs.
+- Update existing constructor arg doc tests to verify Argument child items instead
+  of expecting docs to be silently stripped.
+- Edge cases: constraints + forall + args, mixed documented/undocumented args.
+
+## Alternatives considered
+
+### New `arguments` field on Item
+
+Add `arguments :: [(Text, Doc)]` to `Item`. Simpler (no ItemKey allocation) but
+breaks the "everything is an Item" model, requires JSON schema changes, and is
+less extensible.
+
+### Structured Signature type
+
+Replace `signature :: Maybe Text` with a structured `Signature` type containing
+argument breakdown. Larger refactor, couples args to signatures, and doesn't give
+arguments first-class item status.

--- a/docs/plans/2026-02-17-function-argument-display-design.md
+++ b/docs/plans/2026-02-17-function-argument-display-design.md
@@ -1,109 +1,582 @@
-# Function Argument Display
+# Function Argument Display Implementation Plan
 
-Issue: #235
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
-## Problem
+**Goal:** Display per-argument Haddock docs as child items instead of embedding them in the type signature text.
 
-When a function has per-argument Haddock docs (`-- ^`), the signature is rendered
-via GHC's `ppr` which includes those doc comments inline as text. This looks
-syntactically incorrect in the current `<code>` rendering. For example:
+**Architecture:** Add `Argument` to `ItemKind`, walk the GHC type AST to extract per-argument types and docs, emit child Argument items, strip doc comments from parent signatures. Existing child-item rendering handles display.
 
-```haskell
-f :: a -- ^ i
-  -> a -- ^ o
-```
+**Tech Stack:** Haskell, GHC 9.14 API (`Language.Haskell.Syntax`, `GHC.Hs.Doc`), Tasty/HUnit tests.
 
-The signature displays with embedded comments and awkward newlines rather than a
-clean `:: a -> a`.
+---
 
-## Design
+### Task 1: Add `Argument` to `ItemKind`
 
-Model each positional function/constructor argument as a child Item with a new
-`Argument` ItemKind. Strip inline doc comments from the parent signature so it
-renders cleanly. Argument items render as nested cards (the same pattern used by
-RecordField items).
+**Files:**
+- Modify: `source/library/Scrod/Core/ItemKind.hs:82` (before `deriving`)
 
-### Core types
+**Step 1: Add the variant**
 
-Add one variant to `ItemKind`:
+In `source/library/Scrod/Core/ItemKind.hs`, add before the `deriving` line (line 84):
 
 ```haskell
-| Argument  -- ^ Positional argument of a function or constructor
+  | -- | Positional argument of a function or constructor
+    Argument
 ```
 
-No changes to `Item`. Argument items use existing fields:
+This goes after `DocumentationChunk` (line 83) and before `deriving` (line 84).
 
-- `signature` = the individual argument's type text (e.g. `"Int"`, `"a"`)
-- `documentation` = the per-argument Haddock doc (or `Empty` if undocumented)
-- `parentKey` = the owning function or constructor
-- `name` = `Nothing` (positional args have no names)
-- `kind` = `Argument`
+**Step 2: Add to `kindToString` in ToHtml**
 
-### GHC extraction: functions
+In `source/library/Scrod/Convert/ToHtml.hs`, add a new case in `kindToString` (after line 714, the `RecordField` case):
 
-In `Scrod.Convert.FromGhc.Names`:
+```haskell
+  ItemKind.Argument -> "argument"
+```
 
-- New function `extractSigArguments` walks the `HsFunTy` / `HsDocTy` chain in a
-  type signature. For each arrow-separated argument: if it's wrapped in
-  `HsDocTy`, extract the doc and the inner type; otherwise `(type, Nothing)`.
-  Returns `[(Text, Maybe LHsDoc)]`.
-- Modify `extractSigSignature` to strip `HsDocTy` nodes before `ppr`-ing, so the
-  parent signature is clean (e.g. `"a -> a"`).
+**Step 3: Build to verify**
 
-In `Scrod.Convert.FromGhc`:
+Run: `cabal build --flags=pedantic 2>&1 | tail -5`
 
-- After creating the function Item, call `extractSigArguments` and emit a child
-  Argument item for each positional argument (all args, not only documented ones).
+The build must succeed with no warnings. The `-Weverything` flag ensures the new `ItemKind` variant is covered in all pattern matches. If any `-Wincomplete-patterns` warnings appear, fix them.
 
-### GHC extraction: constructors
+**Step 4: Commit**
 
-In `Scrod.Convert.FromGhc.Constructors`:
+```bash
+git add source/library/Scrod/Core/ItemKind.hs source/library/Scrod/Convert/ToHtml.hs
+git commit -m "Add Argument variant to ItemKind (#235)"
+```
 
-- For `PrefixCon fields`: iterate over `HsConDeclField` list, extract `cdf_doc`
-  and `cdf_type`, emit Argument child items.
-- For `InfixCon l r`: same, two Argument items.
-- For `PrefixConGADT`: same pattern.
-- Record constructors are unchanged (they already have named RecordField children).
-- Continue stripping `cdf_doc` from the parent signature.
+---
 
-### HTML rendering
+### Task 2: Add argument extraction for function type signatures
 
-No special-casing in `ToHtml`. Argument child items render as nested cards via
-the existing `renderItemWithChildren` recursion.
+**Files:**
+- Modify: `source/library/Scrod/Convert/FromGhc/Names.hs`
 
-Changes:
+This task adds two new functions and modifies one existing function in `Names.hs`.
 
-- Add `ItemKind.Argument -> "argument"` to `kindToString`.
-- Badge color: covered by existing wildcard `_ -> "text-bg-secondary"`.
+**Step 1: Add new imports**
 
-### JSON output
+At the top of `source/library/Scrod/Convert/FromGhc/Names.hs`, add:
 
-No changes needed. Argument items appear in the `items` array with
-`"kind": {"type": "Argument"}`, `"parentKey"` pointing to their function or
-constructor, `"signature"` with the type text, and `"documentation"` with the arg
-doc.
+```haskell
+import qualified GHC.Hs.Doc as HsDoc
+import qualified GHC.Parser.Annotation as Annotation
+```
 
-### Testing
+(Keep existing imports; `Annotation` might already be needed indirectly via `Internal`.)
 
-Integration tests:
+**Step 2: Write `stripHsDocTy` helper**
 
-- Functions with per-argument docs: verify parent signature is clean, verify child
-  Argument items exist with correct signature and documentation.
-- Functions with no arg docs: verify Argument child items have `Empty` docs.
-- Update existing constructor arg doc tests to verify Argument child items instead
-  of expecting docs to be silently stripped.
-- Edge cases: constraints + forall + args, mixed documented/undocumented args.
+Add a recursive function that strips `HsDocTy` wrappers from an `LHsType`:
 
-## Alternatives considered
+```haskell
+-- | Recursively strip HsDocTy wrappers from a type.
+-- This removes inline Haddock comments so the type pretty-prints cleanly.
+stripHsDocTy :: Syntax.LHsType Ghc.GhcPs -> Syntax.LHsType Ghc.GhcPs
+stripHsDocTy lTy = case SrcLoc.unLoc lTy of
+  Syntax.HsDocTy _ innerTy _ -> stripHsDocTy innerTy
+  Syntax.HsFunTy x mult lhs rhs ->
+    let lTy' = SrcLoc.L (Annotation.getLocA lTy) (Syntax.HsFunTy x mult (stripHsDocTy lhs) (stripHsDocTy rhs))
+     in lTy'
+  Syntax.HsForAllTy x tele body ->
+    SrcLoc.L (Annotation.getLocA lTy) (Syntax.HsForAllTy x tele (stripHsDocTy body))
+  Syntax.HsQualTy x ctxt body ->
+    SrcLoc.L (Annotation.getLocA lTy) (Syntax.HsQualTy x ctxt (stripHsDocTy body))
+  Syntax.HsParTy x inner ->
+    SrcLoc.L (Annotation.getLocA lTy) (Syntax.HsParTy x (stripHsDocTy inner))
+  _ -> lTy
+```
 
-### New `arguments` field on Item
+**Step 3: Write `extractSigArguments`**
 
-Add `arguments :: [(Text, Doc)]` to `Item`. Simpler (no ItemKey allocation) but
-breaks the "everything is an Item" model, requires JSON schema changes, and is
-less extensible.
+Add a function that walks the `HsFunTy` chain and extracts `(type_text, doc, since)` triples:
 
-### Structured Signature type
+```haskell
+-- | Extract positional arguments from a type signature.
+-- Walks the HsFunTy chain, extracting each argument's type text
+-- and optional documentation from HsDocTy wrappers.
+-- The return type of the function (the final non-arrow part) is NOT included.
+extractSigArguments ::
+  Syntax.Sig Ghc.GhcPs ->
+  [(Text.Text, Maybe (HsDoc.LHsDoc Ghc.GhcPs))]
+extractSigArguments sig = case sig of
+  Syntax.TypeSig _ _ wcType ->
+    extractTypeArguments . Syntax.sig_body . SrcLoc.unLoc . Syntax.hswc_body $ wcType
+  Syntax.PatSynSig _ _ sigType ->
+    extractTypeArguments . Syntax.sig_body . SrcLoc.unLoc $ sigType
+  Syntax.ClassOpSig _ _ _ sigType ->
+    extractTypeArguments . Syntax.sig_body . SrcLoc.unLoc $ sigType
+  _ -> []
 
-Replace `signature :: Maybe Text` with a structured `Signature` type containing
-argument breakdown. Larger refactor, couples args to signatures, and doesn't give
-arguments first-class item status.
+-- | Walk an LHsType, skipping forall/context, collecting arrow-separated arguments.
+extractTypeArguments ::
+  Syntax.LHsType Ghc.GhcPs ->
+  [(Text.Text, Maybe (HsDoc.LHsDoc Ghc.GhcPs))]
+extractTypeArguments lTy = case SrcLoc.unLoc lTy of
+  Syntax.HsForAllTy _ _ body -> extractTypeArguments body
+  Syntax.HsQualTy _ _ body -> extractTypeArguments body
+  Syntax.HsFunTy _ _ lhs rhs ->
+    extractOneArgument lhs : extractTypeArguments rhs
+  Syntax.HsDocTy _ innerTy doc ->
+    -- A doc on the outermost type (the return type) — no arguments
+    -- Actually this shouldn't happen at the top for a function with args,
+    -- but handle gracefully by returning empty.
+    []
+  _ -> []
+
+-- | Extract type text and optional doc from a single argument type.
+extractOneArgument ::
+  Syntax.LHsType Ghc.GhcPs ->
+  (Text.Text, Maybe (HsDoc.LHsDoc Ghc.GhcPs))
+extractOneArgument lTy = case SrcLoc.unLoc lTy of
+  Syntax.HsDocTy _ innerTy doc ->
+    (Text.pack . Outputable.showSDocUnsafe . Outputable.ppr $ innerTy, Just doc)
+  _ ->
+    (Text.pack . Outputable.showSDocUnsafe . Outputable.ppr $ lTy, Nothing)
+```
+
+**Step 4: Modify `extractSigSignature` to strip docs**
+
+Change `extractSigSignature` to strip `HsDocTy` before pretty-printing. Replace the current implementation:
+
+```haskell
+extractSigSignature :: Syntax.Sig Ghc.GhcPs -> Maybe Text.Text
+extractSigSignature sig = case sig of
+  Syntax.TypeSig _ _ ty ->
+    Just . Text.pack . Outputable.showSDocUnsafe . Outputable.ppr $
+      stripHsSigWcType ty
+  Syntax.PatSynSig _ _ ty ->
+    Just . Text.pack . Outputable.showSDocUnsafe . Outputable.ppr $
+      stripHsSigType ty
+  Syntax.ClassOpSig _ _ _ ty ->
+    Just . Text.pack . Outputable.showSDocUnsafe . Outputable.ppr $
+      stripHsSigType ty
+  _ -> Nothing
+
+-- | Strip HsDocTy from a wildcard-wrapped sig type.
+stripHsSigWcType ::
+  Syntax.LHsSigWcType Ghc.GhcPs -> Syntax.LHsSigWcType Ghc.GhcPs
+stripHsSigWcType wc@(Syntax.HsWC {Syntax.hswc_body = lSigTy}) =
+  wc {Syntax.hswc_body = stripHsSigType lSigTy}
+stripHsSigWcType wc = wc
+
+-- | Strip HsDocTy from a sig type.
+stripHsSigType ::
+  Syntax.LHsSigType Ghc.GhcPs -> Syntax.LHsSigType Ghc.GhcPs
+stripHsSigType lSigTy = case SrcLoc.unLoc lSigTy of
+  Syntax.HsSig x bndrs body ->
+    SrcLoc.L (Annotation.getLocA lSigTy) (Syntax.HsSig x bndrs (stripHsDocTy body))
+  _ -> lSigTy
+```
+
+**Step 5: Build to verify**
+
+Run: `cabal build --flags=pedantic 2>&1 | tail -10`
+
+Expected: SUCCESS. The modified `extractSigSignature` should compile and the new functions should have no warnings.
+
+**Step 6: Commit**
+
+```bash
+git add source/library/Scrod/Convert/FromGhc/Names.hs
+git commit -m "Add argument extraction and doc stripping for type signatures (#235)"
+```
+
+---
+
+### Task 3: Emit Argument child items for function signatures
+
+**Files:**
+- Modify: `source/library/Scrod/Convert/FromGhc.hs:336-378`
+
+**Step 1: Modify `convertSigDeclM` for `TypeSig`**
+
+Change the `TypeSig` case (lines 343-346) to also extract arguments and emit child items:
+
+```haskell
+  Syntax.TypeSig _ names _ ->
+    let sigText = Names.extractSigSignature sig
+        args = Names.extractSigArguments sig
+     in fmap concat . flip traverse names $ \lName -> do
+          parentResult <- Internal.mkItemWithKeyM
+            (Annotation.getLocA lName)
+            Nothing
+            (Just $ Internal.extractIdPName lName)
+            doc
+            docSince
+            sigText
+            ItemKind.Function
+          case parentResult of
+            Nothing -> pure []
+            Just (parentItem, parentKey) -> do
+              argItems <- convertArguments (Just parentKey) (Annotation.getLocA lName) args
+              pure $ [parentItem] <> argItems
+```
+
+Do the same for `PatSynSig` (lines 347-349):
+
+```haskell
+  Syntax.PatSynSig _ names _ ->
+    let sigText = Names.extractSigSignature sig
+        args = Names.extractSigArguments sig
+     in fmap concat . flip traverse names $ \lName -> do
+          parentResult <- Internal.mkItemWithKeyM
+            (Annotation.getLocA lName)
+            Nothing
+            (Just $ Internal.extractIdPName lName)
+            doc
+            docSince
+            sigText
+            ItemKind.PatternSynonym
+          case parentResult of
+            Nothing -> pure []
+            Just (parentItem, parentKey) -> do
+              argItems <- convertArguments (Just parentKey) (Annotation.getLocA lName) args
+              pure $ [parentItem] <> argItems
+```
+
+**Step 2: Add `convertArguments` helper**
+
+Add this function to `FromGhc.hs`:
+
+```haskell
+-- | Convert extracted argument data into child Argument items.
+convertArguments ::
+  Maybe ItemKey.ItemKey ->
+  SrcLoc.SrcSpan ->
+  [(Text.Text, Maybe (HsDoc.LHsDoc Ghc.GhcPs))] ->
+  Internal.ConvertM [Located.Located Item.Item]
+convertArguments parentKey srcSpan args =
+  Maybe.catMaybes <$> traverse (convertOneArgument parentKey srcSpan) args
+
+-- | Convert a single argument to an Argument item.
+convertOneArgument ::
+  Maybe ItemKey.ItemKey ->
+  SrcLoc.SrcSpan ->
+  (Text.Text, Maybe (HsDoc.LHsDoc Ghc.GhcPs)) ->
+  Internal.ConvertM (Maybe (Located.Located Item.Item))
+convertOneArgument parentKey srcSpan (sigText, mDoc) =
+  let (argDoc, argSince) = maybe (Doc.Empty, Nothing) GhcDoc.convertLHsDoc mDoc
+   in Internal.mkItemM srcSpan parentKey Nothing argDoc argSince (Just sigText) ItemKind.Argument
+```
+
+Also add the new import at the top of `FromGhc.hs`:
+
+```haskell
+import qualified GHC.Hs.Doc as HsDoc
+```
+
+(Note: `HsDoc` may already be imported — check and add only if missing.)
+
+**Step 3: Remove now-unused `convertSigNameM`**
+
+The old `convertSigNameM` function (lines 369-378) is no longer called by the `TypeSig`/`PatSynSig` cases. Check if any other code calls it. If not, remove it to avoid dead-code warnings.
+
+Actually, the `ClassOpSig` case at line 367 uses it indirectly via the catch-all. Check: the `ClassOpSig` case in `convertSigDeclM` may also need updating if class methods can have argument docs. For now, keep `convertSigNameM` if `ClassOpSig` still uses it (it's handled via the catch-all `_ ->` at line 367).
+
+Wait — looking at lines 343-349 again, `ClassOpSig` is NOT handled by those cases; it falls through to the catch-all at line 367 which calls `convertDeclWithDocM`. So `convertSigNameM` is only used by the `TypeSig` and `PatSynSig` cases. If we change both, `convertSigNameM` becomes unused — remove it.
+
+**Step 4: Build to verify**
+
+Run: `cabal build --flags=pedantic 2>&1 | tail -10`
+
+Expected: SUCCESS.
+
+**Step 5: Commit**
+
+```bash
+git add source/library/Scrod/Convert/FromGhc.hs
+git commit -m "Emit Argument child items for function type signatures (#235)"
+```
+
+---
+
+### Task 4: Handle class method signatures
+
+**Files:**
+- Modify: `source/library/Scrod/Convert/FromGhc.hs`
+
+**Step 1: Look at how ClassOpSig is handled**
+
+`ClassOpSig` is handled in `convertClassSigsWithDocsM`. Find this function and apply the same pattern: extract arguments, create parent item with key, emit argument children.
+
+The approach is the same as Task 3 but for `ClassOpSig` inside class bodies. Find all call sites that create items for `ClassOpSig` or `ClassMethod` items and ensure they also emit argument children.
+
+**Step 2: Build and test**
+
+Run: `cabal build --flags=pedantic 2>&1 | tail -10`
+
+**Step 3: Commit**
+
+```bash
+git add source/library/Scrod/Convert/FromGhc.hs
+git commit -m "Emit Argument child items for class method signatures (#235)"
+```
+
+---
+
+### Task 5: Emit Argument child items for prefix constructors
+
+**Files:**
+- Modify: `source/library/Scrod/Convert/FromGhc/Constructors.hs:201-218`
+
+**Step 1: Modify `extractFieldsFromH98DetailsM`**
+
+Change the `PrefixCon` and `InfixCon` cases to emit Argument items:
+
+```haskell
+extractFieldsFromH98DetailsM parentKey details = case details of
+  Syntax.PrefixCon fields -> convertPrefixArgsM parentKey fields
+  Syntax.InfixCon l r -> convertPrefixArgsM parentKey [l, r]
+  Syntax.RecCon lFields -> convertConDeclFieldsM parentKey (SrcLoc.unLoc lFields)
+```
+
+**Step 2: Modify `extractFieldsFromGADTDetailsM`**
+
+```haskell
+extractFieldsFromGADTDetailsM parentKey details = case details of
+  Syntax.PrefixConGADT _ fields -> convertPrefixArgsM parentKey fields
+  Syntax.RecConGADT _ lFields -> convertConDeclFieldsM parentKey (SrcLoc.unLoc lFields)
+```
+
+**Step 3: Add `convertPrefixArgsM`**
+
+```haskell
+-- | Convert prefix constructor arguments to Argument items.
+convertPrefixArgsM ::
+  Maybe ItemKey.ItemKey ->
+  [Syntax.HsConDeclField Ghc.GhcPs] ->
+  Internal.ConvertM [Located.Located Item.Item]
+convertPrefixArgsM parentKey = Maybe.catMaybes <$> traverse (convertPrefixArgM parentKey)
+
+-- | Convert a single prefix constructor argument to an Argument item.
+convertPrefixArgM ::
+  Maybe ItemKey.ItemKey ->
+  Syntax.HsConDeclField Ghc.GhcPs ->
+  Internal.ConvertM (Maybe (Located.Located Item.Item))
+convertPrefixArgM parentKey field =
+  let (argDoc, argSince) = maybe (Doc.Empty, Nothing) GhcDoc.convertLHsDoc $ Syntax.cdf_doc field
+      sig =
+        Just . Text.pack . Outputable.showSDocUnsafe $
+          unpackednessDoc (Syntax.cdf_unpack field)
+            Outputable.<> strictnessDoc (Syntax.cdf_bang field)
+            Outputable.<> Outputable.ppr (Syntax.cdf_type field)
+   in Internal.mkItemM
+        (Annotation.getLocA (Syntax.cdf_type field))
+        parentKey
+        Nothing
+        argDoc
+        argSince
+        sig
+        ItemKind.Argument
+```
+
+Note: The `Annotation.getLocA` call on `cdf_type` gives us the source location of the argument type. We might need to use a different span — check what `Annotation.getLocA` returns for `LHsType`. If it's `SrcSpanAnn`, this should work. If not, use `SrcLoc.getLoc` instead.
+
+**Step 4: Build to verify**
+
+Run: `cabal build --flags=pedantic 2>&1 | tail -10`
+
+Expected: SUCCESS.
+
+**Step 5: Commit**
+
+```bash
+git add source/library/Scrod/Convert/FromGhc/Constructors.hs
+git commit -m "Emit Argument child items for prefix constructors (#235)"
+```
+
+---
+
+### Task 6: Write integration tests for function arguments
+
+**Files:**
+- Modify: `source/library/Scrod/TestSuite/Integration.hs`
+
+**Step 1: Add test for function with arg docs**
+
+Add after the existing function tests section:
+
+```haskell
+    Spec.it s "function with arg docs" $ do
+      check
+        s
+        """
+        f :: a -- ^ i
+          -> a -- ^ o
+        """
+        [ ("/items/0/value/kind/type", "\"Function\""),
+          ("/items/0/value/name", "\"f\""),
+          ("/items/0/value/signature", "\"a -> a\""),
+          ("/items/1/value/kind/type", "\"Argument\""),
+          ("/items/1/value/parentKey", show (items0Key)),
+          ("/items/1/value/signature", "\"a\""),
+          ("/items/1/value/documentation/type", "\"Paragraph\""),
+          ("/items/2/value/kind/type", "\"Argument\""),
+          ("/items/2/value/signature", "\"a\""),
+          ("/items/2/value/documentation/type", "\"Paragraph\"")
+        ]
+```
+
+Note: The exact item indices and key values depend on how `ConvertM` assigns keys. Run the test first to discover the actual values, then update assertions to match.
+
+**Step 2: Add test for function without arg docs**
+
+```haskell
+    Spec.it s "function without arg docs" $ do
+      check
+        s
+        "f :: Int -> Bool -> String"
+        [ ("/items/0/value/kind/type", "\"Function\""),
+          ("/items/0/value/signature", "\"Int -> Bool -> String\""),
+          ("/items/1/value/kind/type", "\"Argument\""),
+          ("/items/1/value/signature", "\"Int\""),
+          ("/items/1/value/documentation/type", "\"Empty\""),
+          ("/items/2/value/kind/type", "\"Argument\""),
+          ("/items/2/value/signature", "\"Bool\""),
+          ("/items/2/value/documentation/type", "\"Empty\"")
+        ]
+```
+
+**Step 3: Add test for function with forall + constraints + arg docs**
+
+```haskell
+    Spec.it s "function with forall and constraints and arg docs" $ do
+      check
+        s
+        """
+        {-# language ExplicitForAll #-}
+        f :: forall a. Show a => a -- ^ input
+          -> String -- ^ output
+        """
+        [ ("/items/0/value/signature", "\"forall a. Show a => a -> String\""),
+          ("/items/1/value/kind/type", "\"Argument\""),
+          ("/items/1/value/signature", "\"a\""),
+          ("/items/2/value/kind/type", "\"Argument\""),
+          ("/items/2/value/signature", "\"String\"")
+        ]
+```
+
+**Step 4: Run tests**
+
+Run: `cabal test --test-options='--hide-successes -p "/function with arg/"'`
+
+Expected: All new tests PASS. If indices or key values are wrong, adjust assertions.
+
+**Step 5: Commit**
+
+```bash
+git add source/library/Scrod/TestSuite/Integration.hs
+git commit -m "Add integration tests for function argument items (#235)"
+```
+
+---
+
+### Task 7: Update existing constructor arg doc tests
+
+**Files:**
+- Modify: `source/library/Scrod/TestSuite/Integration.hs:1244-1268`
+
+**Step 1: Update "data constructor with arg doc" test**
+
+The existing test at line 1244 currently only checks the parent signature. Update it to also verify the Argument child items:
+
+```haskell
+    Spec.it s "data constructor with arg doc" $ do
+      check
+        s
+        """
+        data T2
+          = C2
+            Int -- ^ arg doc
+            Bool
+        """
+        [ ("/items/1/value/name", "\"C2\""),
+          ("/items/1/value/signature", "\"Int -> Bool -> T2\""),
+          -- Argument child items:
+          ("/items/2/value/kind/type", "\"Argument\""),
+          ("/items/2/value/signature", "\"Int\""),
+          ("/items/2/value/documentation/type", "\"Paragraph\""),
+          ("/items/3/value/kind/type", "\"Argument\""),
+          ("/items/3/value/signature", "\"Bool\""),
+          ("/items/3/value/documentation/type", "\"Empty\"")
+        ]
+```
+
+**Step 2: Update "data constructor GADT with arg doc" test**
+
+```haskell
+    Spec.it s "data constructor GADT with arg doc" $ do
+      check
+        s
+        """
+        data T3 where
+          C3 ::
+            Int -- ^ arg doc
+            -> T3
+        """
+        [ ("/items/1/value/name", "\"C3\""),
+          ("/items/1/value/signature", "\"Int -> T3\""),
+          ("/items/2/value/kind/type", "\"Argument\""),
+          ("/items/2/value/signature", "\"Int\""),
+          ("/items/2/value/documentation/type", "\"Paragraph\"")
+        ]
+```
+
+Note: Item indices may need adjustment depending on how keys are allocated. Run tests and adjust.
+
+**Step 3: Run tests**
+
+Run: `cabal test --test-options='--hide-successes -p "/data constructor/"'`
+
+Expected: All constructor tests PASS.
+
+**Step 4: Run full test suite**
+
+Run: `cabal test --test-options='--hide-successes'`
+
+Expected: ALL tests PASS. No regressions.
+
+**Step 5: Commit**
+
+```bash
+git add source/library/Scrod/TestSuite/Integration.hs
+git commit -m "Update constructor arg doc tests to verify Argument items (#235)"
+```
+
+---
+
+### Task 8: Final verification
+
+**Step 1: Run pedantic build**
+
+Run: `cabal build --flags=pedantic 2>&1 | tail -10`
+
+Expected: SUCCESS with no warnings.
+
+**Step 2: Run full test suite**
+
+Run: `cabal test --test-options='--hide-successes'`
+
+Expected: ALL tests PASS.
+
+**Step 3: Manual smoke test with the example from the issue**
+
+Run:
+```bash
+echo 'f :: a -- ^ i
+  -> a -- ^ o' | cabal run scrod
+```
+
+Verify:
+- The function item's `signature` field is `"a -> a"` (no doc comments)
+- Two Argument child items exist with `signature` of `"a"` and docs `"i"` / `"o"`
+
+**Step 4: Commit if any fixes were needed**
+
+```bash
+git add -A
+git commit -m "Fix issues found during final verification (#235)"
+```

--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -343,10 +343,38 @@ convertSigDeclM ::
 convertSigDeclM doc docSince lDecl sig = case sig of
   Syntax.TypeSig _ names _ ->
     let sigText = Names.extractSigSignature sig
-     in Maybe.catMaybes <$> traverse (convertSigNameM doc docSince sigText ItemKind.Function) names
+        args = Names.extractSigArguments sig
+     in fmap concat . flip traverse names $ \lName -> do
+          parentResult <- Internal.mkItemWithKeyM
+            (Annotation.getLocA lName)
+            Nothing
+            (Just $ Internal.extractIdPName lName)
+            doc
+            docSince
+            sigText
+            ItemKind.Function
+          case parentResult of
+            Nothing -> pure []
+            Just (parentItem, parentKey) -> do
+              argItems <- convertArguments (Just parentKey) (Annotation.getLocA lName) args
+              pure $ [parentItem] <> argItems
   Syntax.PatSynSig _ names _ ->
     let sigText = Names.extractSigSignature sig
-     in Maybe.catMaybes <$> traverse (convertSigNameM doc docSince sigText ItemKind.PatternSynonym) names
+        args = Names.extractSigArguments sig
+     in fmap concat . flip traverse names $ \lName -> do
+          parentResult <- Internal.mkItemWithKeyM
+            (Annotation.getLocA lName)
+            Nothing
+            (Just $ Internal.extractIdPName lName)
+            doc
+            docSince
+            sigText
+            ItemKind.PatternSynonym
+          case parentResult of
+            Nothing -> pure []
+            Just (parentItem, parentKey) -> do
+              argItems <- convertArguments (Just parentKey) (Annotation.getLocA lName) args
+              pure $ [parentItem] <> argItems
   Syntax.FixSig _ (Syntax.FixitySig _ names (SyntaxBasic.Fixity prec dir)) ->
     let fixityDoc = Doc.Paragraph . Doc.String $ fixityDirectionToText dir <> Text.pack (" " <> show prec)
         combinedDoc = combineDoc doc fixityDoc
@@ -366,16 +394,24 @@ convertSigDeclM doc docSince lDecl sig = case sig of
      in Maybe.maybeToList <$> Internal.mkItemM (Annotation.getLocA lDecl) Nothing Nothing doc docSince sigText ItemKind.CompletePragma
   _ -> Maybe.maybeToList <$> convertDeclWithDocM Nothing doc docSince (Names.extractSigName sig) Nothing lDecl
 
--- | Convert a single name from a signature.
-convertSigNameM ::
-  Doc.Doc ->
-  Maybe Since.Since ->
-  Maybe Text.Text ->
-  ItemKind.ItemKind ->
-  Syntax.LIdP Ghc.GhcPs ->
+-- | Convert extracted argument data into child Argument items.
+convertArguments ::
+  Maybe ItemKey.ItemKey ->
+  SrcLoc.SrcSpan ->
+  [(Text.Text, Maybe (HsDoc.LHsDoc Ghc.GhcPs))] ->
+  Internal.ConvertM [Located.Located Item.Item]
+convertArguments parentKey srcSpan args =
+  Maybe.catMaybes <$> traverse (convertOneArgument parentKey srcSpan) args
+
+-- | Convert a single argument to an Argument item.
+convertOneArgument ::
+  Maybe ItemKey.ItemKey ->
+  SrcLoc.SrcSpan ->
+  (Text.Text, Maybe (HsDoc.LHsDoc Ghc.GhcPs)) ->
   Internal.ConvertM (Maybe (Located.Located Item.Item))
-convertSigNameM doc docSince sig itemKind lName =
-  Internal.mkItemM (Annotation.getLocA lName) Nothing (Just $ Internal.extractIdPName lName) doc docSince sig itemKind
+convertOneArgument parentKey srcSpan (sigText, mDoc) =
+  let (argDoc, argSince) = maybe (Doc.Empty, Nothing) GhcDoc.convertLHsDoc mDoc
+   in Internal.mkItemM srcSpan parentKey Nothing argDoc argSince (Just sigText) ItemKind.Argument
 
 -- | Convert a single name from a fixity signature.
 convertFixityNameM ::

--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -12,6 +12,7 @@ import qualified Data.Map as Map
 import qualified Data.Maybe as Maybe
 import qualified Data.Set as Set
 import qualified Data.Text as Text
+import qualified Data.Traversable as Traversable
 import qualified Data.Tuple as Tuple
 import qualified Data.Version
 import qualified GHC.Data.FastString as FastString
@@ -344,15 +345,16 @@ convertSigDeclM doc docSince lDecl sig = case sig of
   Syntax.TypeSig _ names _ ->
     let sigText = Names.extractSigSignature sig
         args = Names.extractSigArguments sig
-     in fmap concat . flip traverse names $ \lName -> do
-          parentResult <- Internal.mkItemWithKeyM
-            (Annotation.getLocA lName)
-            Nothing
-            (Just $ Internal.extractIdPName lName)
-            doc
-            docSince
-            sigText
-            ItemKind.Function
+     in fmap concat . Traversable.for names $ \lName -> do
+          parentResult <-
+            Internal.mkItemWithKeyM
+              (Annotation.getLocA lName)
+              Nothing
+              (Just $ Internal.extractIdPName lName)
+              doc
+              docSince
+              sigText
+              ItemKind.Function
           case parentResult of
             Nothing -> pure []
             Just (parentItem, parentKey) -> do
@@ -361,15 +363,16 @@ convertSigDeclM doc docSince lDecl sig = case sig of
   Syntax.PatSynSig _ names _ ->
     let sigText = Names.extractSigSignature sig
         args = Names.extractSigArguments sig
-     in fmap concat . flip traverse names $ \lName -> do
-          parentResult <- Internal.mkItemWithKeyM
-            (Annotation.getLocA lName)
-            Nothing
-            (Just $ Internal.extractIdPName lName)
-            doc
-            docSince
-            sigText
-            ItemKind.PatternSynonym
+     in fmap concat . Traversable.for names $ \lName -> do
+          parentResult <-
+            Internal.mkItemWithKeyM
+              (Annotation.getLocA lName)
+              Nothing
+              (Just $ Internal.extractIdPName lName)
+              doc
+              docSince
+              sigText
+              ItemKind.PatternSynonym
           case parentResult of
             Nothing -> pure []
             Just (parentItem, parentKey) -> do
@@ -593,15 +596,16 @@ convertClassDeclWithDocM parentKey doc docSince lDecl = case SrcLoc.unLoc lDecl 
     Syntax.ClassOpSig _ _ names _ ->
       let sigText = Names.extractSigSignature sig
           args = Names.extractSigArguments sig
-       in fmap concat . flip traverse names $ \lName -> do
-            parentResult <- Internal.mkItemWithKeyM
-              (Annotation.getLocA lName)
-              parentKey
-              (Just $ Internal.extractIdPName lName)
-              doc
-              docSince
-              sigText
-              ItemKind.ClassMethod
+       in fmap concat . Traversable.for names $ \lName -> do
+            parentResult <-
+              Internal.mkItemWithKeyM
+                (Annotation.getLocA lName)
+                parentKey
+                (Just $ Internal.extractIdPName lName)
+                doc
+                docSince
+                sigText
+                ItemKind.ClassMethod
             case parentResult of
               Nothing -> pure []
               Just (methodItem, methodKey) -> do

--- a/source/library/Scrod/Convert/FromGhc/Names.hs
+++ b/source/library/Scrod/Convert/FromGhc/Names.hs
@@ -8,6 +8,7 @@ module Scrod.Convert.FromGhc.Names where
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Text as Text
 import GHC.Hs ()
+import qualified GHC.Hs.Doc as HsDoc
 import qualified GHC.Hs.Extension as Ghc
 import qualified GHC.Types.SrcLoc as SrcLoc
 import qualified GHC.Utils.Outputable as Outputable
@@ -120,12 +121,100 @@ extractSigName sig = case sig of
 
 -- | Extract signature text from a Sig. Only returns the type part, not the
 -- name. For example, @x :: Int@ produces @"Int"@.
+-- Strips 'HsDocTy' nodes so that embedded doc comments do not appear in the
+-- pretty-printed output.
 extractSigSignature :: Syntax.Sig Ghc.GhcPs -> Maybe Text.Text
 extractSigSignature sig = case sig of
-  Syntax.TypeSig _ _ ty -> Just . Text.pack . Outputable.showSDocUnsafe $ Outputable.ppr ty
-  Syntax.PatSynSig _ _ ty -> Just . Text.pack . Outputable.showSDocUnsafe $ Outputable.ppr ty
-  Syntax.ClassOpSig _ _ _ ty -> Just . Text.pack . Outputable.showSDocUnsafe $ Outputable.ppr ty
+  Syntax.TypeSig _ _ ty ->
+    Just . Text.pack . Outputable.showSDocUnsafe . Outputable.ppr $ stripHsSigWcType ty
+  Syntax.PatSynSig _ _ ty ->
+    Just . Text.pack . Outputable.showSDocUnsafe . Outputable.ppr $ stripHsSigType ty
+  Syntax.ClassOpSig _ _ _ ty ->
+    Just . Text.pack . Outputable.showSDocUnsafe . Outputable.ppr $ stripHsSigType ty
   _ -> Nothing
+
+-- | Strip 'HsDocTy' wrappers from a wildcard-wrapped signature type.
+stripHsSigWcType ::
+  Syntax.LHsSigWcType Ghc.GhcPs -> Syntax.LHsSigWcType Ghc.GhcPs
+stripHsSigWcType wc =
+  wc {Syntax.hswc_body = stripHsSigType (Syntax.hswc_body wc)}
+
+-- | Strip 'HsDocTy' wrappers from a signature type.
+stripHsSigType :: Syntax.LHsSigType Ghc.GhcPs -> Syntax.LHsSigType Ghc.GhcPs
+stripHsSigType lSigType = case SrcLoc.unLoc lSigType of
+  Syntax.HsSig {Syntax.sig_ext = ext, Syntax.sig_bndrs = bndrs, Syntax.sig_body = body} ->
+    let stripped = stripHsDocTy body
+     in SrcLoc.L
+          (SrcLoc.getLoc lSigType)
+          Syntax.HsSig
+            { Syntax.sig_ext = ext,
+              Syntax.sig_bndrs = bndrs,
+              Syntax.sig_body = stripped
+            }
+
+-- | Recursively strip 'HsDocTy' wrappers from a located type.
+-- Recurses into 'HsFunTy', 'HsForAllTy', 'HsQualTy', and 'HsParTy' to
+-- ensure all embedded doc comments are removed.
+stripHsDocTy :: Syntax.LHsType Ghc.GhcPs -> Syntax.LHsType Ghc.GhcPs
+stripHsDocTy lTy = case lTy of
+  SrcLoc.L ann hsType -> case hsType of
+    Syntax.HsDocTy _ inner _ -> stripHsDocTy inner
+    Syntax.HsFunTy x mult arg res ->
+      SrcLoc.L ann $ Syntax.HsFunTy x mult (stripHsDocTy arg) (stripHsDocTy res)
+    Syntax.HsForAllTy x tele body ->
+      SrcLoc.L ann $ Syntax.HsForAllTy x tele (stripHsDocTy body)
+    Syntax.HsQualTy x ctx body ->
+      SrcLoc.L ann $ Syntax.HsQualTy x ctx (stripHsDocTy body)
+    Syntax.HsParTy x inner ->
+      SrcLoc.L ann $ Syntax.HsParTy x (stripHsDocTy inner)
+    _ -> lTy
+
+-- | Extract argument types and their optional doc comments from a type
+-- signature. Walks the 'HsFunTy' chain, collecting each argument's
+-- pretty-printed type text and its 'LHsDoc' (if the argument was wrapped
+-- in 'HsDocTy'). The return type (final non-arrow part) is not included.
+--
+-- Handles 'TypeSig' (unwrap via 'hswc_body'), 'PatSynSig', and
+-- 'ClassOpSig' (unwrap via 'sig_body' on 'HsSigType').
+extractSigArguments ::
+  Syntax.Sig Ghc.GhcPs -> [(Text.Text, Maybe (HsDoc.LHsDoc Ghc.GhcPs))]
+extractSigArguments sig = case sig of
+  Syntax.TypeSig _ _ wc ->
+    extractArgsFromBody . Syntax.sig_body . SrcLoc.unLoc $ Syntax.hswc_body wc
+  Syntax.PatSynSig _ _ lSigType ->
+    extractArgsFromBody . Syntax.sig_body $ SrcLoc.unLoc lSigType
+  Syntax.ClassOpSig _ _ _ lSigType ->
+    extractArgsFromBody . Syntax.sig_body $ SrcLoc.unLoc lSigType
+  _ -> []
+
+-- | Skip through 'HsForAllTy' and 'HsQualTy' to reach the arrow chain,
+-- then extract arguments from the 'HsFunTy' chain.
+extractArgsFromBody ::
+  Syntax.LHsType Ghc.GhcPs -> [(Text.Text, Maybe (HsDoc.LHsDoc Ghc.GhcPs))]
+extractArgsFromBody lTy = case SrcLoc.unLoc lTy of
+  Syntax.HsForAllTy _ _ body -> extractArgsFromBody body
+  Syntax.HsQualTy _ _ body -> extractArgsFromBody body
+  Syntax.HsFunTy _ _ arg res -> extractArg arg : extractArgsFromBody res
+  Syntax.HsDocTy _ inner _doc -> case SrcLoc.unLoc inner of
+    Syntax.HsFunTy _ _ arg res -> extractArg arg : extractArgsFromBody res
+    _ -> extractArgsFromBody inner
+  _ -> []
+
+-- | Extract the type text and optional doc comment from a single argument.
+-- If the argument is wrapped in 'HsDocTy', the doc is extracted and the
+-- inner type is pretty-printed (with any nested doc annotations stripped).
+-- Otherwise, the argument is pretty-printed as-is with no doc.
+extractArg ::
+  Syntax.LHsType Ghc.GhcPs -> (Text.Text, Maybe (HsDoc.LHsDoc Ghc.GhcPs))
+extractArg lTy = case SrcLoc.unLoc lTy of
+  Syntax.HsDocTy _ inner doc ->
+    ( Text.pack . Outputable.showSDocUnsafe . Outputable.ppr $ stripHsDocTy inner,
+      Just doc
+    )
+  _ ->
+    ( Text.pack . Outputable.showSDocUnsafe . Outputable.ppr $ stripHsDocTy lTy,
+      Nothing
+    )
 
 -- | Extract name from an instance declaration.
 extractInstDeclName :: Syntax.InstDecl Ghc.GhcPs -> Maybe ItemName.ItemName

--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -687,6 +687,7 @@ itemContent item children =
 kindToString :: ItemKind.ItemKind -> String
 kindToString x = case x of
   ItemKind.Annotation -> "annotation"
+  ItemKind.Argument -> "argument"
   ItemKind.Class -> "class"
   ItemKind.ClassInstance -> "instance"
   ItemKind.ClassMethod -> "method"

--- a/source/library/Scrod/Core/ItemKind.hs
+++ b/source/library/Scrod/Core/ItemKind.hs
@@ -81,5 +81,7 @@ data ItemKind
     RoleAnnotation
   | -- | Named documentation chunk: @-- $name@
     DocumentationChunk
+  | -- | Positional argument of a function or constructor
+    Argument
   deriving (Eq, Generics.Generic, Ord, Show)
   deriving (ToJson.ToJson, Schema.ToSchema) via Generics.Generically ItemKind

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -1220,9 +1220,13 @@ spec s = Spec.describe s "integration" $ do
           ("/items/1/value/kind/type", "\"GADTConstructor\""),
           ("/items/1/value/name", "\"A\""),
           ("/items/1/value/signature", "\"Int -> T\""),
-          ("/items/2/value/kind/type", "\"GADTConstructor\""),
-          ("/items/2/value/name", "\"B\""),
-          ("/items/2/value/signature", "\"Int -> T\"")
+          ("/items/2/value/kind/type", "\"Argument\""),
+          ("/items/2/value/parentKey", "1"),
+          ("/items/3/value/kind/type", "\"GADTConstructor\""),
+          ("/items/3/value/name", "\"B\""),
+          ("/items/3/value/signature", "\"Int -> T\""),
+          ("/items/4/value/kind/type", "\"Argument\""),
+          ("/items/4/value/parentKey", "3")
         ]
 
     Spec.it s "data constructor GADT with doc" $ do
@@ -1555,9 +1559,11 @@ spec s = Spec.describe s "integration" $ do
         newtype N = MkN Int
         deriving newtype instance Show N
         """
-        [ ("/items/2/value/kind/type", "\"StandaloneDeriving\""),
-          ("/items/2/value/name", "\"Show N\""),
-          ("/items/2/value/parentKey", "0")
+        [ ("/items/2/value/kind/type", "\"Argument\""),
+          ("/items/2/value/parentKey", "1"),
+          ("/items/3/value/kind/type", "\"StandaloneDeriving\""),
+          ("/items/3/value/name", "\"Show N\""),
+          ("/items/3/value/parentKey", "0")
         ]
 
     Spec.it s "standalone deriving anyclass" $ do
@@ -1583,9 +1589,11 @@ spec s = Spec.describe s "integration" $ do
         newtype P = MkP Int
         deriving via Int instance Show P
         """
-        [ ("/items/2/value/kind/type", "\"StandaloneDeriving\""),
-          ("/items/2/value/name", "\"Show P\""),
-          ("/items/2/value/parentKey", "0")
+        [ ("/items/2/value/kind/type", "\"Argument\""),
+          ("/items/2/value/parentKey", "1"),
+          ("/items/3/value/kind/type", "\"StandaloneDeriving\""),
+          ("/items/3/value/name", "\"Show P\""),
+          ("/items/3/value/parentKey", "0")
         ]
 
     Spec.it s "data deriving" $ do
@@ -1983,8 +1991,12 @@ spec s = Spec.describe s "integration" $ do
           ("/items/1/value/name", "\":+:\""),
           ("/items/1/value/parentKey", "0"),
           ("/items/1/value/key", "1"),
-          ("/items/2/value/kind/type", "\"FixitySignature\""),
-          ("/items/2/value/name", "\":+:\"")
+          ("/items/2/value/kind/type", "\"Argument\""),
+          ("/items/2/value/parentKey", "1"),
+          ("/items/3/value/kind/type", "\"Argument\""),
+          ("/items/3/value/parentKey", "1"),
+          ("/items/4/value/kind/type", "\"FixitySignature\""),
+          ("/items/4/value/name", "\":+:\"")
         ]
 
     Spec.it s "inline pragma has parent set" $ do
@@ -2087,10 +2099,12 @@ spec s = Spec.describe s "integration" $ do
         """
         [ ("/items/0/value/kind/type", "\"Function\""),
           ("/items/0/value/name", "\"j2\""),
-          ("/items/1/value/kind/type", "\"SpecialiseSignature\""),
-          ("/items/1/value/name", "\"j2\""),
+          ("/items/1/value/kind/type", "\"Argument\""),
           ("/items/1/value/parentKey", "0"),
-          ("/items/1/value/signature", "\"() -> ()\"")
+          ("/items/2/value/kind/type", "\"SpecialiseSignature\""),
+          ("/items/2/value/name", "\"j2\""),
+          ("/items/2/value/parentKey", "0"),
+          ("/items/2/value/signature", "\"() -> ()\"")
         ]
 
     Spec.it s "orphaned specialize pragma" $ do
@@ -2170,12 +2184,16 @@ spec s = Spec.describe s "integration" $ do
         """
         [ ("/items/0/value/kind/type", "\"PatternSynonym\""),
           ("/items/0/value/name", "\"Nil\""),
-          ("/items/0/value/parentKey", "4"),
+          ("/items/0/value/parentKey", "6"),
           ("/items/1/value/kind/type", "\"PatternSynonym\""),
           ("/items/1/value/name", "\"Cons\""),
-          ("/items/1/value/parentKey", "4"),
-          ("/items/2/value/kind/type", "\"CompletePragma\""),
-          ("/items/2/value/signature", "\"Nil, Cons\"")
+          ("/items/1/value/parentKey", "6"),
+          ("/items/2/value/kind/type", "\"Argument\""),
+          ("/items/2/value/parentKey", "2"),
+          ("/items/3/value/kind/type", "\"Argument\""),
+          ("/items/3/value/parentKey", "2"),
+          ("/items/4/value/kind/type", "\"CompletePragma\""),
+          ("/items/4/value/signature", "\"Nil, Cons\"")
         ]
 
     Spec.it s "standalone kind signature" $ do
@@ -2397,9 +2415,11 @@ spec s = Spec.describe s "integration" $ do
         """
         [ ("/items/0/value/kind/type", "\"Function\""),
           ("/items/0/value/name", "\"x4\""),
-          ("/items/1/value/kind/type", "\"Rule\""),
-          ("/items/1/value/name", "\"q\""),
-          ("/items/1/value/signature", "\"x4 = id\"")
+          ("/items/1/value/kind/type", "\"Argument\""),
+          ("/items/1/value/parentKey", "0"),
+          ("/items/2/value/kind/type", "\"Rule\""),
+          ("/items/2/value/name", "\"q\""),
+          ("/items/2/value/signature", "\"x4 = id\"")
         ]
 
     Spec.it s "splice declaration" $ do
@@ -2514,12 +2534,14 @@ spec s = Spec.describe s "integration" $ do
         [ ("/items/0/value/name", "\"f\""),
           ("/items/0/value/kind/type", "\"Function\""),
           ("/items/0/value/key", "0"),
-          ("/items/1/value/name", "\"f\""),
-          ("/items/1/value/kind/type", "\"InlineSignature\""),
+          ("/items/1/value/kind/type", "\"Argument\""),
           ("/items/1/value/parentKey", "0"),
           ("/items/2/value/name", "\"f\""),
-          ("/items/2/value/kind/type", "\"SpecialiseSignature\""),
-          ("/items/2/value/parentKey", "0")
+          ("/items/2/value/kind/type", "\"InlineSignature\""),
+          ("/items/2/value/parentKey", "0"),
+          ("/items/3/value/name", "\"f\""),
+          ("/items/3/value/kind/type", "\"SpecialiseSignature\""),
+          ("/items/3/value/parentKey", "0")
         ]
 
     Spec.it s "warning and inline on same function" $ do
@@ -2534,12 +2556,14 @@ spec s = Spec.describe s "integration" $ do
         [ ("/items/0/value/name", "\"g\""),
           ("/items/0/value/kind/type", "\"Function\""),
           ("/items/0/value/key", "0"),
-          ("/items/1/value/name", "\"g\""),
-          ("/items/1/value/kind/type", "\"Warning\""),
+          ("/items/1/value/kind/type", "\"Argument\""),
           ("/items/1/value/parentKey", "0"),
           ("/items/2/value/name", "\"g\""),
-          ("/items/2/value/kind/type", "\"InlineSignature\""),
-          ("/items/2/value/parentKey", "0")
+          ("/items/2/value/kind/type", "\"Warning\""),
+          ("/items/2/value/parentKey", "0"),
+          ("/items/3/value/name", "\"g\""),
+          ("/items/3/value/kind/type", "\"InlineSignature\""),
+          ("/items/3/value/parentKey", "0")
         ]
 
     Spec.it s "multiple specialize pragmas on one function" $ do
@@ -2553,14 +2577,16 @@ spec s = Spec.describe s "integration" $ do
         """
         [ ("/items/0/value/name", "\"h\""),
           ("/items/0/value/kind/type", "\"Function\""),
-          ("/items/1/value/name", "\"h\""),
-          ("/items/1/value/kind/type", "\"SpecialiseSignature\""),
+          ("/items/1/value/kind/type", "\"Argument\""),
           ("/items/1/value/parentKey", "0"),
-          ("/items/1/value/signature", "\"() -> ()\""),
           ("/items/2/value/name", "\"h\""),
           ("/items/2/value/kind/type", "\"SpecialiseSignature\""),
           ("/items/2/value/parentKey", "0"),
-          ("/items/2/value/signature", "\"Int -> Int\"")
+          ("/items/2/value/signature", "\"() -> ()\""),
+          ("/items/3/value/name", "\"h\""),
+          ("/items/3/value/kind/type", "\"SpecialiseSignature\""),
+          ("/items/3/value/parentKey", "0"),
+          ("/items/3/value/signature", "\"Int -> Int\"")
         ]
 
     Spec.it s "fixity and inline and specialize on same operator" $ do
@@ -2576,15 +2602,19 @@ spec s = Spec.describe s "integration" $ do
         [ ("/items/0/value/name", "\"%\""),
           ("/items/0/value/kind/type", "\"Function\""),
           ("/items/0/value/key", "0"),
-          ("/items/1/value/name", "\"%\""),
-          ("/items/1/value/kind/type", "\"FixitySignature\""),
+          ("/items/1/value/kind/type", "\"Argument\""),
           ("/items/1/value/parentKey", "0"),
-          ("/items/2/value/name", "\"%\""),
-          ("/items/2/value/kind/type", "\"InlineSignature\""),
+          ("/items/2/value/kind/type", "\"Argument\""),
           ("/items/2/value/parentKey", "0"),
           ("/items/3/value/name", "\"%\""),
-          ("/items/3/value/kind/type", "\"SpecialiseSignature\""),
-          ("/items/3/value/parentKey", "0")
+          ("/items/3/value/kind/type", "\"FixitySignature\""),
+          ("/items/3/value/parentKey", "0"),
+          ("/items/4/value/name", "\"%\""),
+          ("/items/4/value/kind/type", "\"InlineSignature\""),
+          ("/items/4/value/parentKey", "0"),
+          ("/items/5/value/name", "\"%\""),
+          ("/items/5/value/kind/type", "\"SpecialiseSignature\""),
+          ("/items/5/value/parentKey", "0")
         ]
 
   Spec.describe s "html" $ do

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -2521,6 +2521,132 @@ spec s = Spec.describe s "integration" $ do
           ("/items/0/value/signature", "\"nominal\"")
         ]
 
+  Spec.describe s "arguments" $ do
+    Spec.it s "function with per-argument docs" $ do
+      check
+        s
+        """
+        f :: a -- ^ i
+          -> a -- ^ o
+        """
+        [ ("/items/0/value/kind/type", "\"Function\""),
+          ("/items/0/value/name", "\"f\""),
+          ("/items/0/value/signature", "\"a -> a\""),
+          ("/items/0/value/documentation/type", "\"Empty\""),
+          ("/items/1/value/kind/type", "\"Argument\""),
+          ("/items/1/value/parentKey", "0"),
+          ("/items/1/value/signature", "\"a\""),
+          ("/items/1/value/documentation/type", "\"Paragraph\""),
+          ("/items/1/value/documentation/value/value", "\"i\"")
+        ]
+
+    Spec.it s "function without arg docs" $ do
+      check
+        s
+        "f :: Int -> Bool -> String"
+        [ ("/items/0/value/kind/type", "\"Function\""),
+          ("/items/0/value/name", "\"f\""),
+          ("/items/0/value/signature", "\"Int -> Bool -> String\""),
+          ("/items/1/value/kind/type", "\"Argument\""),
+          ("/items/1/value/parentKey", "0"),
+          ("/items/1/value/signature", "\"Int\""),
+          ("/items/1/value/documentation/type", "\"Empty\""),
+          ("/items/2/value/kind/type", "\"Argument\""),
+          ("/items/2/value/parentKey", "0"),
+          ("/items/2/value/signature", "\"Bool\""),
+          ("/items/2/value/documentation/type", "\"Empty\"")
+        ]
+
+    Spec.it s "function with forall and constraints and arg docs" $ do
+      check
+        s
+        """
+        {-# language ExplicitForAll #-}
+        f :: forall a. Show a => a -- ^ input
+          -> String -- ^ output
+        """
+        [ ("/items/0/value/kind/type", "\"Function\""),
+          ("/items/0/value/name", "\"f\""),
+          ("/items/0/value/signature", "\"forall a. Show a => a -> String\""),
+          ("/items/1/value/kind/type", "\"Argument\""),
+          ("/items/1/value/parentKey", "0"),
+          ("/items/1/value/signature", "\"a\""),
+          ("/items/1/value/documentation/type", "\"Paragraph\""),
+          ("/items/1/value/documentation/value/value", "\"input\"")
+        ]
+
+    Spec.it s "data constructor with arg doc has argument children" $ do
+      check
+        s
+        """
+        data T2
+          = C2
+            Int -- ^ arg doc
+            Bool
+        """
+        [ ("/items/0/value/kind/type", "\"DataType\""),
+          ("/items/0/value/name", "\"T2\""),
+          ("/items/1/value/kind/type", "\"DataConstructor\""),
+          ("/items/1/value/name", "\"C2\""),
+          ("/items/1/value/signature", "\"Int -> Bool -> T2\""),
+          ("/items/2/value/kind/type", "\"Argument\""),
+          ("/items/2/value/parentKey", "1"),
+          ("/items/2/value/signature", "\"Int\""),
+          ("/items/2/value/documentation/type", "\"Paragraph\""),
+          ("/items/2/value/documentation/value/value", "\"arg doc\""),
+          ("/items/3/value/kind/type", "\"Argument\""),
+          ("/items/3/value/parentKey", "1"),
+          ("/items/3/value/signature", "\"Bool\""),
+          ("/items/3/value/documentation/type", "\"Empty\"")
+        ]
+
+    Spec.it s "GADT constructor with arg doc has argument children" $ do
+      check
+        s
+        """
+        data T3 where
+          C3 ::
+            Int -- ^ arg doc
+            -> T3
+        """
+        [ ("/items/0/value/kind/type", "\"DataType\""),
+          ("/items/0/value/name", "\"T3\""),
+          ("/items/1/value/kind/type", "\"GADTConstructor\""),
+          ("/items/1/value/name", "\"C3\""),
+          ("/items/1/value/signature", "\"Int -> T3\""),
+          ("/items/2/value/kind/type", "\"Argument\""),
+          ("/items/2/value/parentKey", "1"),
+          ("/items/2/value/signature", "\"Int\""),
+          ("/items/2/value/documentation/type", "\"Paragraph\""),
+          ("/items/2/value/documentation/value/value", "\"arg doc\"")
+        ]
+
+    Spec.it s "class method with arg docs has argument children" $ do
+      check
+        s
+        """
+        class C a where
+          m :: a -- ^ input
+            -> Bool -- ^ result
+            -> String
+        """
+        [ ("/items/0/value/kind/type", "\"Class\""),
+          ("/items/0/value/name", "\"C\""),
+          ("/items/1/value/kind/type", "\"ClassMethod\""),
+          ("/items/1/value/name", "\"m\""),
+          ("/items/1/value/signature", "\"a -> Bool -> String\""),
+          ("/items/2/value/kind/type", "\"Argument\""),
+          ("/items/2/value/parentKey", "1"),
+          ("/items/2/value/signature", "\"a\""),
+          ("/items/2/value/documentation/type", "\"Paragraph\""),
+          ("/items/2/value/documentation/value/value", "\"input\""),
+          ("/items/3/value/kind/type", "\"Argument\""),
+          ("/items/3/value/parentKey", "1"),
+          ("/items/3/value/signature", "\"Bool\""),
+          ("/items/3/value/documentation/type", "\"Paragraph\""),
+          ("/items/3/value/documentation/value/value", "\"result\"")
+        ]
+
   Spec.describe s "pragma combinations" $ do
     Spec.it s "inline and specialize on same function" $ do
       check


### PR DESCRIPTION
## Summary

- Adds `Argument` variant to `ItemKind` for positional function/constructor arguments
- Walks the GHC `HsFunTy`/`HsDocTy` AST to extract per-argument types and Haddock docs
- Strips inline doc comments from parent signatures so they render cleanly (e.g. `:: a -> a` instead of `:: a -- ^ i -> a -- ^ o`)
- Emits `Argument` child items for `TypeSig`, `PatSynSig`, `ClassOpSig`, and prefix constructors (H98 + GADT)
- Argument items render as nested cards via existing child-item infrastructure

Closes #235

## Test plan

- [x] `cabal build --flags=pedantic` passes with no warnings
- [x] All 738 tests pass (`cabal test --test-options='--hide-successes'`)
- [x] Smoke test: `printf 'f :: a -- ^ i\n  -> a -- ^ o' | cabal run scrod` shows clean signature and Argument child items
- [x] Visual check of HTML output for functions/constructors with arg docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)