### PR TITLE
Capture argument names from function bindings

### DIFF
--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -253,9 +253,9 @@ buildArgNameMap lHsModule =
         [ (name, argNames)
           | lDecl <- decls,
             Syntax.ValD _ bind <- [SrcLoc.unLoc lDecl],
-            Just name <- [Names.extractBindName bind],
             let argNames = Names.extractBindArgNames bind,
-            not (null argNames)
+            not (null argNames),
+            Just name <- [Names.extractBindName bind]
         ]
 
 -- | Patch argument names from function bindings into 'Argument' items.

--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -202,9 +202,11 @@ extractItems ::
   [Located.Located Item.Item]
 extractItems referencedChunkNames lHsModule =
   let rawItems = Internal.runConvert $ extractItemsM referencedChunkNames lHsModule
+      argNameMap = buildArgNameMap lHsModule
+      patchedItems = patchArgumentNames argNameMap rawItems
       instanceHeadTypes = InstanceParents.extractInstanceHeadTypeNames lHsModule
       instanceClassNames = InstanceParents.extractInstanceClassNames lHsModule
-      parentedItems = InstanceParents.associateInstanceParents instanceHeadTypes instanceClassNames rawItems
+      parentedItems = InstanceParents.associateInstanceParents instanceHeadTypes instanceClassNames patchedItems
       -- Parent-association passes: associate pragma/annotation items
       -- (warning, fixity, inline, specialise, type role) and family
       -- instance items with their target declarations by matching names.
@@ -237,6 +239,77 @@ extractItems referencedChunkNames lHsModule =
       -- are merged with their type signatures first.
       completeNames = CompleteParents.extractCompleteNames lHsModule
    in CompleteParents.associateCompleteParents completeNames kindSigParentedItems
+
+-- | Build a map from function name to argument names extracted from
+-- 'FunBind' patterns. Each function maps to a list of 'Maybe Text'
+-- with one entry per argument position.
+buildArgNameMap ::
+  SrcLoc.Located (Syntax.HsModule Ghc.GhcPs) ->
+  Map.Map ItemName.ItemName [Maybe Text.Text]
+buildArgNameMap lHsModule =
+  let hsModule = SrcLoc.unLoc lHsModule
+      decls = Syntax.hsmodDecls hsModule
+   in Map.fromList
+        [ (name, argNames)
+          | lDecl <- decls,
+            Syntax.ValD _ bind <- [SrcLoc.unLoc lDecl],
+            Just name <- [Names.extractBindName bind],
+            let argNames = Names.extractBindArgNames bind,
+            not (null argNames)
+        ]
+
+-- | Patch argument names from function bindings into 'Argument' items.
+--
+-- For each 'Function' item whose name appears in the map, finds its
+-- child 'Argument' items (by matching 'parentKey') and sets their
+-- 'name' field from the corresponding position in the argument name
+-- list.
+patchArgumentNames ::
+  Map.Map ItemName.ItemName [Maybe Text.Text] ->
+  [Located.Located Item.Item] ->
+  [Located.Located Item.Item]
+patchArgumentNames argNameMap items =
+  let -- Map from function key to arg names
+      funcKeyToArgNames =
+        Map.fromList
+          [ (Item.key val, names)
+            | locItem <- items,
+              let val = Located.value locItem,
+              Item.kind val == ItemKind.Function,
+              Just itemName <- [Item.name val],
+              Just names <- [Map.lookup itemName argNameMap]
+          ]
+      -- Group argument items by parent key, preserving order
+      argsByParent =
+        Map.fromListWith
+          (flip (<>))
+          [ (pk, [locItem])
+            | locItem <- items,
+              let val = Located.value locItem,
+              Item.kind val == ItemKind.Argument,
+              Just pk <- [Item.parentKey val]
+          ]
+      -- Build update map: item key -> updated item
+      updates =
+        Map.fromList
+          [ (Item.key (Located.value updated), updated)
+            | (funcKey, names) <- Map.toList funcKeyToArgNames,
+              Just argItems <- [Map.lookup funcKey argsByParent],
+              updated <- zipWith setArgName (names <> repeat Nothing) argItems
+          ]
+   in fmap (\item -> Maybe.fromMaybe item $ Map.lookup (Item.key (Located.value item)) updates) items
+
+-- | Set the name of an argument item if a name is provided.
+setArgName :: Maybe Text.Text -> Located.Located Item.Item -> Located.Located Item.Item
+setArgName mName locItem = case mName of
+  Nothing -> locItem
+  Just name ->
+    locItem
+      { Located.value =
+          (Located.value locItem)
+            { Item.name = Just $ ItemName.MkItemName name
+            }
+      }
 
 -- | Extract items in the conversion monad.
 extractItemsM ::

--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -251,11 +251,11 @@ buildArgNameMap lHsModule =
       decls = Syntax.hsmodDecls hsModule
    in Map.fromList
         [ (name, argNames)
-          | lDecl <- decls,
-            Syntax.ValD _ bind <- [SrcLoc.unLoc lDecl],
-            let argNames = Names.extractBindArgNames bind,
-            not (null argNames),
-            Just name <- [Names.extractBindName bind]
+        | lDecl <- decls,
+          Syntax.ValD _ bind <- [SrcLoc.unLoc lDecl],
+          let argNames = Names.extractBindArgNames bind,
+          not (null argNames),
+          Just name <- [Names.extractBindName bind]
         ]
 
 -- | Patch argument names from function bindings into 'Argument' items.
@@ -273,29 +273,29 @@ patchArgumentNames argNameMap items =
       funcKeyToArgNames =
         Map.fromList
           [ (Item.key val, names)
-            | locItem <- items,
-              let val = Located.value locItem,
-              Item.kind val == ItemKind.Function,
-              Just itemName <- [Item.name val],
-              Just names <- [Map.lookup itemName argNameMap]
+          | locItem <- items,
+            let val = Located.value locItem,
+            Item.kind val == ItemKind.Function,
+            Just itemName <- [Item.name val],
+            Just names <- [Map.lookup itemName argNameMap]
           ]
       -- Group argument items by parent key, preserving order
       argsByParent =
         Map.fromListWith
           (flip (<>))
           [ (pk, [locItem])
-            | locItem <- items,
-              let val = Located.value locItem,
-              Item.kind val == ItemKind.Argument,
-              Just pk <- [Item.parentKey val]
+          | locItem <- items,
+            let val = Located.value locItem,
+            Item.kind val == ItemKind.Argument,
+            Just pk <- [Item.parentKey val]
           ]
       -- Build update map: item key -> updated item
       updates =
         Map.fromList
           [ (Item.key (Located.value updated), updated)
-            | (funcKey, names) <- Map.toList funcKeyToArgNames,
-              Just argItems <- [Map.lookup funcKey argsByParent],
-              updated <- zipWith setArgName (names <> repeat Nothing) argItems
+          | (funcKey, names) <- Map.toList funcKeyToArgNames,
+            Just argItems <- [Map.lookup funcKey argsByParent],
+            updated <- zipWith setArgName (names <> repeat Nothing) argItems
           ]
    in fmap (\item -> Maybe.fromMaybe item $ Map.lookup (Item.key (Located.value item)) updates) items
 

--- a/source/library/Scrod/Convert/FromGhc/Names.hs
+++ b/source/library/Scrod/Convert/FromGhc/Names.hs
@@ -147,6 +147,7 @@ extractPatVarName pat = case pat of
   Syntax.BangPat _ lPat -> extractPatVarName $ SrcLoc.unLoc lPat
   Syntax.LazyPat _ lPat -> extractPatVarName $ SrcLoc.unLoc lPat
   Syntax.ParPat _ lPat -> extractPatVarName $ SrcLoc.unLoc lPat
+  Syntax.SigPat _ lPat _ -> extractPatVarName $ SrcLoc.unLoc lPat
   _ -> Nothing
 
 -- | Merge pattern names across multiple equations.

--- a/source/library/Scrod/Convert/FromGhc/Names.hs
+++ b/source/library/Scrod/Convert/FromGhc/Names.hs
@@ -5,7 +5,9 @@
 -- by the main conversion module and by 'Scrod.Convert.FromGhc.Constructors'.
 module Scrod.Convert.FromGhc.Names where
 
+import qualified Data.List as List
 import qualified Data.List.NonEmpty as NonEmpty
+import qualified Data.Maybe as Maybe
 import qualified Data.Text as Text
 import GHC.Hs ()
 import qualified GHC.Hs.Doc as HsDoc
@@ -110,6 +112,61 @@ extractBindName bind = case bind of
 -- | Extract name from a pattern synonym binding.
 extractPatSynName :: Syntax.PatSynBind Ghc.GhcPs Ghc.GhcPs -> ItemName.ItemName
 extractPatSynName patSyn = Internal.extractIdPName $ Syntax.psb_id patSyn
+
+-- | Extract argument names from a function binding's patterns.
+--
+-- For each argument position, scans across all equations and picks
+-- the first variable pattern name found (skipping wildcards,
+-- constructor patterns, and literals). Returns one entry per
+-- argument position; 'Nothing' when no variable name was found.
+extractBindArgNames :: Syntax.HsBindLR Ghc.GhcPs Ghc.GhcPs -> [Maybe Text.Text]
+extractBindArgNames bind = case bind of
+  Syntax.FunBind {Syntax.fun_matches = mg} ->
+    let lMatches = SrcLoc.unLoc (Syntax.mg_alts mg)
+        patNameLists = fmap extractMatchPatNames lMatches
+     in mergePatNames patNameLists
+  _ -> []
+
+-- | Extract the variable name (if any) from each pattern in a match.
+extractMatchPatNames ::
+  SrcLoc.GenLocated l (Syntax.Match Ghc.GhcPs body) ->
+  [Maybe Text.Text]
+extractMatchPatNames lMatch =
+  let match = SrcLoc.unLoc lMatch
+   in fmap (extractPatVarName . SrcLoc.unLoc) (SrcLoc.unLoc (Syntax.m_pats match))
+
+-- | Extract a variable name from a pattern, unwrapping wrapper nodes.
+--
+-- Handles 'VarPat' directly, and recurses through 'AsPat' (using the
+-- as-binding name), 'BangPat', 'LazyPat', 'ParPat', and 'SigPat'.
+-- Returns 'Nothing' for wildcards, constructor patterns, literals, etc.
+extractPatVarName :: Syntax.Pat Ghc.GhcPs -> Maybe Text.Text
+extractPatVarName pat = case pat of
+  Syntax.VarPat _ lId -> Just $ Internal.extractRdrName lId
+  Syntax.AsPat _ lId _ -> Just $ Internal.extractRdrName lId
+  Syntax.BangPat _ lPat -> extractPatVarName $ SrcLoc.unLoc lPat
+  Syntax.LazyPat _ lPat -> extractPatVarName $ SrcLoc.unLoc lPat
+  Syntax.ParPat _ lPat -> extractPatVarName $ SrcLoc.unLoc lPat
+  _ -> Nothing
+
+-- | Merge pattern names across multiple equations.
+--
+-- For each argument position, takes the first 'Just' name found
+-- across the equations. This handles cases like:
+--
+-- @
+-- or True _ = True
+-- or _ x = x
+-- @
+--
+-- where position 0 yields 'Nothing' (no variable in either equation)
+-- and position 1 yields @Just "x"@ (from the second equation).
+mergePatNames :: [[Maybe Text.Text]] -> [Maybe Text.Text]
+mergePatNames [] = []
+mergePatNames patNameLists =
+  let maxLen = maximum (fmap length patNameLists)
+      padded = fmap (\ns -> ns <> replicate (maxLen - length ns) Nothing) patNameLists
+   in fmap (Maybe.listToMaybe . Maybe.catMaybes) (List.transpose padded)
 
 -- | Extract name from a signature.
 extractSigName :: Syntax.Sig Ghc.GhcPs -> Maybe ItemName.ItemName

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -2995,6 +2995,57 @@ spec s = Spec.describe s "integration" $ do
           ("/documentation/value/value", "\"Module doc\"")
         ]
 
+  Spec.describe s "argument names" $ do
+    Spec.it s "captures argument name from binding" $ do
+      check
+        s
+        """
+        f :: a -> a
+        f x = x
+        """
+        [ ("/items/0/value/kind/type", "\"Function\""),
+          ("/items/0/value/name", "\"f\""),
+          ("/items/1/value/kind/type", "\"Argument\""),
+          ("/items/1/value/name", "\"x\""),
+          ("/items/1/value/signature", "\"a\"")
+        ]
+
+    Spec.it s "picks first variable name across equations" $ do
+      check
+        s
+        """
+        or :: Bool -> Bool -> Bool
+        or True _ = True
+        or _ x = x
+        """
+        [ ("/items/0/value/name", "\"or\""),
+          ("/items/1/value/kind/type", "\"Argument\""),
+          ("/items/1/value/name", ""),
+          ("/items/1/value/signature", "\"Bool\""),
+          ("/items/2/value/kind/type", "\"Argument\""),
+          ("/items/2/value/name", "\"x\""),
+          ("/items/2/value/signature", "\"Bool\"")
+        ]
+
+    Spec.it s "handles all-wildcard arguments" $ do
+      check
+        s
+        """
+        f :: a -> a
+        f _ = undefined
+        """
+        [ ("/items/1/value/kind/type", "\"Argument\""),
+          ("/items/1/value/name", "")
+        ]
+
+    Spec.it s "handles signature without binding" $ do
+      check
+        s
+        "f :: a -> a"
+        [ ("/items/1/value/kind/type", "\"Argument\""),
+          ("/items/1/value/name", "")
+        ]
+
 check :: (Stack.HasCallStack, Monad m) => Spec.Spec m n -> String -> [(String, String)] -> m ()
 check s = checkWith s []
 


### PR DESCRIPTION
Fixes #239.

## Summary

- Extracts variable pattern names from `FunBind` equations and patches them into `Argument` items that were created from the corresponding type signature
- For functions with multiple equations (e.g. `or True _ = True; or _ x = x`), picks the first variable name per argument position across all clauses, skipping wildcards, constructor patterns, and literals
- Handles wrapper patterns: `BangPat` (`!x`), `LazyPat` (`~x`), `ParPat` (`(x)`), and `AsPat` (`xs@(...)`)
- Arguments that have no variable name in any equation get no name (null in JSON)

## Test plan

- [x] Added 4 integration tests: simple binding, multiple equations, all-wildcard, signature-only
- [x] All 742 tests pass (738 existing + 4 new)
- [x] Manual verification with both examples from the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)