### PR TITLE
Hide empty extensions and imports sections

### DIFF
--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -153,12 +153,12 @@ bodyElement x =
             <> foldMap (List.singleton . sinceContent) (Module.since x)
             <> docContents (Module.documentation x)
             <> ( if Maybe.isNothing (Module.language x) && Map.null (Module.extensions x)
-                  then []
-                  else [element "section" [("class", "my-3")] . extensionsContents (Module.language x) $ Module.extensions x]
+                   then []
+                   else [element "section" [("class", "my-3")] . extensionsContents (Module.language x) $ Module.extensions x]
                )
             <> ( if null (Module.imports x)
-                  then []
-                  else [element "section" [("class", "my-3")] . importsContents $ Module.imports x]
+                   then []
+                   else [element "section" [("class", "my-3")] . importsContents $ Module.imports x]
                )
             <> [element "section" [("class", "my-3")] $ declarationsContents (Module.exports x) (Module.items x)]
             <> [footerContent x]

--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -152,8 +152,14 @@ bodyElement x =
             <> foldMap (List.singleton . warningContent) (Module.warning x)
             <> foldMap (List.singleton . sinceContent) (Module.since x)
             <> docContents (Module.documentation x)
-            <> [element "section" [("class", "my-3")] . extensionsContents (Module.language x) $ Module.extensions x]
-            <> [element "section" [("class", "my-3")] . importsContents $ Module.imports x]
+            <> ( if Maybe.isNothing (Module.language x) && Map.null (Module.extensions x)
+                  then []
+                  else [element "section" [("class", "my-3")] . extensionsContents (Module.language x) $ Module.extensions x]
+               )
+            <> ( if null (Module.imports x)
+                  then []
+                  else [element "section" [("class", "my-3")] . importsContents $ Module.imports x]
+               )
             <> [element "section" [("class", "my-3")] $ declarationsContents (Module.exports x) (Module.items x)]
             <> [footerContent x]
         )


### PR DESCRIPTION
Fixes #243.

## Summary

- Skip rendering the Extensions section when there is no language pragma and no extensions
- Skip rendering the Imports section when there are no imports
- The Declarations section is always shown (even when empty), per the issue discussion

## Test plan

- All 758 existing tests pass
- Verified with `echo "" | cabal run scrod -- --format html` that empty input only shows the Declarations section
- Verified that modules with extensions/imports still render those sections