### PR TITLE
Remove top padding from HTML output in web app

### DIFF
--- a/extra/github-pages/index.js
+++ b/extra/github-pages/index.js
@@ -32,6 +32,7 @@ function effectiveTheme() {
 }
 
 function setShadowMessage(element) {
+  output.classList.add('p-3');
   shadow.textContent = '';
   shadow.appendChild(bootstrapLink());
   var wrapper = document.createElement('div');
@@ -116,10 +117,8 @@ worker.onmessage = function (e) {
     if (msg.format === 'json') {
       showJson(msg.value);
     } else {
+      output.classList.remove('p-3');
       shadow.innerHTML = msg.value;
-      var style = document.createElement('style');
-      style.textContent = '.py-5 { padding-top: 0 !important; }';
-      shadow.prepend(style);
       syncShadowTheme();
       renderMath();
     }

--- a/extra/github-pages/index.js
+++ b/extra/github-pages/index.js
@@ -117,6 +117,9 @@ worker.onmessage = function (e) {
       showJson(msg.value);
     } else {
       shadow.innerHTML = msg.value;
+      var style = document.createElement('style');
+      style.textContent = '.py-5 { padding-top: 0 !important; }';
+      shadow.prepend(style);
       syncShadowTheme();
       renderMath();
     }


### PR DESCRIPTION
Fixes #244.

## Summary

The generated HTML wraps content in a `<div class="container py-5">` which adds 3rem (48px) of top padding. This looks fine in standalone HTML output but is excessive when embedded in the web app, where the `#output` pane already provides 1rem (16px) of padding via its `p-3` class. Combined, that's 64px of top whitespace.

This PR injects a `<style>` into the shadow DOM after rendering HTML output to override `.py-5 { padding-top: 0 }`, reducing the top spacing to just the outer 1rem. The standalone HTML output is unaffected.

## Test plan

- [ ] Open the web app and enter some Haskell source
- [ ] Verify the top padding is reduced from ~64px to ~16px
- [ ] Verify standalone HTML output (`cabal run scrod -- --format html`) still has normal padding
- [ ] Verify JSON output and error messages are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)