### PR TITLE
Improve display of big record constructor signatures

### DIFF
--- a/source/library/Scrod/Convert/FromGhc/Constructors.hs
+++ b/source/library/Scrod/Convert/FromGhc/Constructors.hs
@@ -153,11 +153,19 @@ h98ArgsToDoc details = case details of
         Outputable.<+> Outputable.text "->"
         Outputable.<+> Outputable.ppr (Syntax.cdf_type r)
   Syntax.RecCon lFields ->
-    Just $
-      Outputable.text "{"
-        Outputable.<+> Outputable.hsep
-          (Outputable.punctuate (Outputable.text ",") (fmap Outputable.ppr (SrcLoc.unLoc lFields)))
-        Outputable.<+> Outputable.text "}"
+    let fields = SrcLoc.unLoc lFields
+     in Just $ case fields of
+          [f] ->
+            Outputable.text "{"
+              Outputable.<+> Outputable.ppr f
+              Outputable.<+> Outputable.text "}"
+          (f : fs) ->
+            Outputable.vcat $
+              [Outputable.text "{" Outputable.<+> Outputable.ppr f]
+                <> fmap (\fld -> Outputable.text "," Outputable.<+> Outputable.ppr fld) fs
+                <> [Outputable.text "}"]
+          [] ->
+            Outputable.text "{}"
 
 -- | Strip documentation from H98 constructor details.
 stripH98DetailsDocs ::

--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -734,7 +734,7 @@ itemContent item children =
     ]
     [ element
         "div"
-        [("class", "align-items-center card-header d-flex")]
+        [("class", "align-items-start card-header d-flex")]
         $ [ element
               "div"
               []
@@ -813,10 +813,10 @@ itemContent item children =
       Just sig ->
         [ element
             "div"
-            [("class", "mx-2")]
+            [("class", "mx-2"), ("style", "min-width: 0")]
             [ element
                 "code"
-                [("class", "text-break text-secondary")]
+                [("class", "text-break text-secondary"), ("style", "white-space: pre-wrap")]
                 [Xml.text $ prefix <> sig]
             ]
         ]

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -1284,6 +1284,13 @@ spec s = Spec.describe s "integration" $ do
           ("/items/1/value/signature", "\"{ f4 :: Int } -> T4\"")
         ]
 
+    Spec.it s "data constructor with multiple record fields" $ do
+      check
+        s
+        "data T = C { f1 :: Int, f2 :: Bool }"
+        [ ("/items/1/value/signature", "\"{ f1 :: Int\\n, f2 :: Bool\\n} -> T\"")
+        ]
+
     Spec.it s "data constructor with existential" $ do
       check
         s


### PR DESCRIPTION
Fixes #246.

## Summary
- Record constructors with multiple fields now render one field per line using leading-comma style instead of all on one line
- Card header alignment changed from `align-items-center` to `align-items-start` so elements stay top-aligned when signatures span multiple lines
- Signature `<code>` element uses `white-space: pre-wrap` to preserve line breaks, with `min-width: 0` on the container div for proper flex shrinking
- Single-field records remain on one line (no behavior change)
- Added integration test for multi-field record constructor signature format

## Test plan
- [x] All 759 tests pass (758 existing + 1 new)
- [x] Pedantic build passes (`--flags=pedantic`)
- [ ] Verify visual appearance on https://scrod.fyi with the example from the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)