### PR TITLE
Hide empty card body for undocumented items

### DIFF
--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -765,8 +765,8 @@ itemContent item children =
                        ]
                    ]
                ]
-        ]
-    <> cardBody
+      ]
+      <> cardBody
   where
     cardBody =
       let contents =

--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -773,7 +773,7 @@ itemContent item children =
             foldMap (List.singleton . sinceContent) (Item.since $ Located.value item)
               <> docContents (Item.documentation $ Located.value item)
               <> children
-       in if null contents
+       in if all Content.isEmpty contents
             then []
             else
               [ element
@@ -874,7 +874,11 @@ kindToString x = case x of
 
 docContents :: Doc.Doc -> [Content.Content Element.Element]
 docContents doc = case doc of
-  Doc.Empty -> []
+  -- The empty string node prevents the XML renderer from emitting a
+  -- self-closing tag (e.g. <div/>) on any parent element, which is not valid
+  -- HTML. Use 'Content.isEmpty' rather than 'null' to test whether the
+  -- resulting content list is effectively empty.
+  Doc.Empty -> [Xml.string ""]
   Doc.Append xs -> foldMap docContents xs
   Doc.String x -> [element "span" [("class", "text-break")] [Xml.text x]]
   Doc.Paragraph x -> [element "p" [] $ docContents x]

--- a/source/library/Scrod/Xml/Content.hs
+++ b/source/library/Scrod/Xml/Content.hs
@@ -39,6 +39,25 @@ encode encodeElement c = case c of
 
 spec :: (Applicative m, Monad n) => Spec.Spec m n -> n ()
 spec s = do
+  Spec.named s 'isEmpty $ do
+    Spec.it s "returns True for empty Text" $ do
+      Spec.assertEq s (isEmpty $ Text Text.empty) True
+
+    Spec.it s "returns False for non-empty Text" $ do
+      Spec.assertEq s (isEmpty $ Text $ Text.pack "hello") False
+
+    Spec.it s "returns True for empty Raw" $ do
+      Spec.assertEq s (isEmpty $ Raw Text.empty) True
+
+    Spec.it s "returns False for non-empty Raw" $ do
+      Spec.assertEq s (isEmpty $ Raw $ Text.pack "hello") False
+
+    Spec.it s "returns False for Element" $ do
+      Spec.assertEq s (isEmpty $ Element "test") False
+
+    Spec.it s "returns False for Comment" $ do
+      Spec.assertEq s (isEmpty $ Comment (Comment.MkComment $ Text.pack " test ")) False
+
   Spec.named s 'encode $ do
     let encodeElement :: String -> Builder.Builder
         encodeElement _ = Builder.stringUtf8 "<test/>"

--- a/source/library/Scrod/Xml/Content.hs
+++ b/source/library/Scrod/Xml/Content.hs
@@ -19,6 +19,16 @@ data Content a
   | Text Text.Text
   deriving (Eq, Ord, Show)
 
+-- | Returns 'True' for content nodes that render as the empty string (empty
+-- 'Text' or 'Raw' nodes). Useful for checking whether a list of content is
+-- effectively empty without stripping the nodes themselves (which may be
+-- needed to prevent self-closing tags).
+isEmpty :: Content a -> Bool
+isEmpty c = case c of
+  Text t -> Text.null t
+  Raw r -> Text.null r
+  _ -> False
+
 -- | Encode content, parameterized by element encoder.
 encode :: (a -> Builder.Builder) -> Content a -> Builder.Builder
 encode encodeElement c = case c of


### PR DESCRIPTION
Fixes #247.

## Summary

Items without documentation (no doc comment, no `@since` annotation, and no children) were rendering an empty `<div class="card-body"></div>` in the HTML output, which looked weird as an empty white box below the card header.

This PR:

- **Conditionally renders the card-body div** — only included when there's actual content (documentation, since annotation, or children)
- **Returns `[]` from `docContents Doc.Empty`** instead of `[Xml.string ""]`, so empty documentation doesn't produce a phantom text node

Before: every item card always had a card-body div, even when empty.
After: undocumented items without children render as just a card header.