### PR TITLE
Render function arguments before documentation

### DIFF
--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -769,8 +769,8 @@ itemContent item children =
         "div"
         [("class", "card-body")]
         $ foldMap (List.singleton . sinceContent) (Item.since $ Located.value item)
-          <> docContents (Item.documentation $ Located.value item)
           <> children
+          <> docContents (Item.documentation $ Located.value item)
     ]
   where
     badgeColor = case kind of


### PR DESCRIPTION
Fixes #249.

## Summary

In the HTML rendering (`ToHtml.hs`), the `itemContent` function was rendering an item's documentation before its children (arguments). This swaps the order so that child items (function arguments) appear before the parent item's documentation in the card body, matching the expected behavior described in the issue.

## Test plan

- [x] `cabal build` succeeds
- [x] All 758 tests pass (`cabal test --test-options='--hide-successes'`)
- [ ] Verify visually at https://scrod.fyi/ with the example from the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)