### PR TITLE
Merge standalone kind signatures into declarations

### DIFF
--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -226,10 +226,10 @@ extractItems referencedChunkNames lHsModule =
       familyInstanceNames = FamilyInstanceParents.extractFamilyInstanceNames lHsModule
       familyParentedItems = FamilyInstanceParents.associateFamilyInstanceParents familyInstanceNames roleParentedItems
       mergedItems = Merge.mergeItemsByName familyParentedItems
-      -- Standalone kind signature association runs after merging so
-      -- that type signatures and bindings are merged first. This
-      -- parents associated declarations to their corresponding
-      -- standalone kind signature (see 'KindSigParents').
+      -- Standalone kind signature merging runs after term-level
+      -- merging so that type signatures and bindings are merged first.
+      -- This merges standalone kind signatures into their corresponding
+      -- declarations (see 'KindSigParents').
       kindSigParentedItems = KindSigParents.associateKindSigParents mergedItems
       -- COMPLETE pragma association runs after merging and uses inverted
       -- semantics: pattern synonyms are parented to the COMPLETE pragma

--- a/source/library/Scrod/Convert/FromGhc/KindSigParents.hs
+++ b/source/library/Scrod/Convert/FromGhc/KindSigParents.hs
@@ -1,59 +1,113 @@
--- | Resolve standalone kind signature parent relationships.
+-- | Merge standalone kind signatures into their declarations.
 --
--- Associates type, data, newtype, class, type family, and data family
--- declarations with their corresponding standalone kind signature when
--- both are defined in the same module. This runs after merging so that
+-- When a standalone kind signature (@type T :: ...@) and a matching
+-- declaration (data, newtype, class, type synonym, type family, or
+-- data family) share the same name, the kind signature is merged
+-- into the declaration: the kind signature's text becomes the
+-- declaration's signature, and their documentation and \@since\@
+-- annotations are combined. The standalone kind signature item is
+-- then removed from the output. This runs after merging so that
 -- type signatures and bindings are merged first.
 module Scrod.Convert.FromGhc.KindSigParents where
 
 import qualified Data.Map as Map
 import qualified Data.Maybe as Maybe
+import qualified Data.Set as Set
+import qualified Scrod.Convert.FromGhc.Internal as Internal
 import qualified Scrod.Core.Item as Item
-import qualified Scrod.Core.ItemKey as ItemKey
 import qualified Scrod.Core.ItemKind as ItemKind
 import qualified Scrod.Core.ItemName as ItemName
 import qualified Scrod.Core.Located as Located
 
--- | Associate declarations with their standalone kind signatures.
+-- | Merge standalone kind signatures into their matching declarations.
 associateKindSigParents ::
   [Located.Located Item.Item] ->
   [Located.Located Item.Item]
 associateKindSigParents items =
-  let kindSigNameToKey = buildKindSigNameToKeyMap items
-   in fmap (resolveKindSigParent kindSigNameToKey) items
+  let kindSigMap = buildKindSigMap items
+      declNames = buildDeclNameSet items
+   in Maybe.mapMaybe (mergeOrRemoveKindSig kindSigMap declNames) items
 
--- | Build a map from standalone kind signature names to their keys.
-buildKindSigNameToKeyMap ::
+-- | Build a map from standalone kind signature names to their items.
+buildKindSigMap ::
   [Located.Located Item.Item] ->
-  Map.Map ItemName.ItemName ItemKey.ItemKey
-buildKindSigNameToKeyMap =
-  Map.fromList . Maybe.mapMaybe getKindSigNameAndKey
+  Map.Map ItemName.ItemName (Located.Located Item.Item)
+buildKindSigMap =
+  Map.fromList . Maybe.mapMaybe getKindSigEntry
   where
-    getKindSigNameAndKey locItem =
+    getKindSigEntry locItem =
       let val = Located.value locItem
        in case (Item.kind val, Item.name val) of
             (ItemKind.StandaloneKindSig, Just name) ->
-              Just (name, Item.key val)
+              Just (name, locItem)
             _ -> Nothing
 
--- | Set the parentKey on a declaration item if a standalone kind
--- signature with the same name exists.
-resolveKindSigParent ::
-  Map.Map ItemName.ItemName ItemKey.ItemKey ->
+-- | Collect names of top-level declarations that are not standalone
+-- kind signatures. Used to decide whether a kind signature has a
+-- matching declaration and should be consumed.
+buildDeclNameSet ::
+  [Located.Located Item.Item] ->
+  Set.Set ItemName.ItemName
+buildDeclNameSet =
+  Set.fromList . Maybe.mapMaybe getDeclName
+  where
+    getDeclName locItem =
+      let val = Located.value locItem
+       in if Item.kind val /= ItemKind.StandaloneKindSig
+            && Maybe.isNothing (Item.parentKey val)
+            then Item.name val
+            else Nothing
+
+-- | For each item, either merge a matching kind signature into it,
+-- remove a consumed kind signature, or pass it through unchanged.
+mergeOrRemoveKindSig ::
+  Map.Map ItemName.ItemName (Located.Located Item.Item) ->
+  Set.Set ItemName.ItemName ->
   Located.Located Item.Item ->
-  Located.Located Item.Item
-resolveKindSigParent kindSigNameToKey locItem =
+  Maybe (Located.Located Item.Item)
+mergeOrRemoveKindSig kindSigMap declNames locItem =
   let val = Located.value locItem
    in case Item.name val of
-        Nothing -> locItem
-        Just name ->
-          if Maybe.isJust (Item.parentKey val)
-            || Item.kind val == ItemKind.StandaloneKindSig
-            then locItem
-            else case Map.lookup name kindSigNameToKey of
-              Nothing -> locItem
-              Just parentKey ->
-                locItem
-                  { Located.value =
-                      val {Item.parentKey = Just parentKey}
-                  }
+        Nothing -> Just locItem
+        Just name
+          | Item.kind val == ItemKind.StandaloneKindSig ->
+              if Set.member name declNames
+                then Nothing
+                else Just locItem
+          | Maybe.isJust (Item.parentKey val) ->
+              Just locItem
+          | otherwise ->
+              case Map.lookup name kindSigMap of
+                Nothing -> Just locItem
+                Just kindSigItem ->
+                  Just $ mergeKindSigInto kindSigItem locItem
+
+-- | Merge a standalone kind signature's metadata into a declaration.
+-- The kind signature's signature text, documentation, and \@since\@
+-- annotation take precedence when present.
+mergeKindSigInto ::
+  Located.Located Item.Item ->
+  Located.Located Item.Item ->
+  Located.Located Item.Item
+mergeKindSigInto kindSigItem declItem =
+  let kindSigVal = Located.value kindSigItem
+      declVal = Located.value declItem
+      mergedSig = case Item.signature kindSigVal of
+        Just s -> Just s
+        Nothing -> Item.signature declVal
+      mergedDoc =
+        Internal.appendDoc
+          (Item.documentation kindSigVal)
+          (Item.documentation declVal)
+      mergedSince =
+        Internal.appendSince
+          (Item.since kindSigVal)
+          (Item.since declVal)
+   in declItem
+        { Located.value =
+            declVal
+              { Item.signature = mergedSig,
+                Item.documentation = mergedDoc,
+                Item.since = mergedSince
+              }
+        }

--- a/source/library/Scrod/Convert/FromGhc/KindSigParents.hs
+++ b/source/library/Scrod/Convert/FromGhc/KindSigParents.hs
@@ -83,8 +83,10 @@ mergeOrRemoveKindSig kindSigMap declNames locItem =
                   Just $ mergeKindSigInto kindSigItem locItem
 
 -- | Merge a standalone kind signature's metadata into a declaration.
--- The kind signature's signature text, documentation, and \@since\@
--- annotation take precedence when present.
+-- The kind signature's signature text and \@since\@ annotation take
+-- precedence when present, and documentation is combined (kind
+-- signature first, then declaration). The earlier source location of
+-- the two items is used.
 mergeKindSigInto ::
   Located.Located Item.Item ->
   Located.Located Item.Item ->
@@ -103,8 +105,11 @@ mergeKindSigInto kindSigItem declItem =
         Internal.appendSince
           (Item.since kindSigVal)
           (Item.since declVal)
+      mergedLocation =
+        min (Located.location kindSigItem) (Located.location declItem)
    in declItem
-        { Located.value =
+        { Located.location = mergedLocation,
+          Located.value =
             declVal
               { Item.signature = mergedSig,
                 Item.documentation = mergedDoc,

--- a/source/library/Scrod/Convert/FromGhc/Merge.hs
+++ b/source/library/Scrod/Convert/FromGhc/Merge.hs
@@ -39,9 +39,9 @@ buildMergeMap items =
 
 -- | Check if an item is eligible for merging.
 --
--- Standalone kind signatures are excluded because they should remain
--- as separate items with the associated declaration parented to them,
--- not merged into a single item (see 'KindSigParents').
+-- Standalone kind signatures are excluded because they are merged
+-- into their corresponding declarations in a separate pass (see
+-- 'KindSigParents').
 isMergeCandidate :: Located.Located Item.Item -> Bool
 isMergeCandidate item =
   let val = Located.value item

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -2203,12 +2203,9 @@ spec s = Spec.describe s "integration" $ do
         type O :: *
         data O
         """
-        [ ("/items/0/value/kind/type", "\"StandaloneKindSig\""),
+        [ ("/items/0/value/kind/type", "\"DataType\""),
           ("/items/0/value/name", "\"O\""),
-          ("/items/0/value/signature", "\"*\""),
-          ("/items/1/value/kind/type", "\"DataType\""),
-          ("/items/1/value/name", "\"O\""),
-          ("/items/1/value/parentKey", "0")
+          ("/items/0/value/signature", "\"*\"")
         ]
 
     Spec.it s "standalone kind signature with data" $ do
@@ -2218,16 +2215,12 @@ spec s = Spec.describe s "integration" $ do
         type X :: a -> a
         data X a = X
         """
-        [ ("/items/0/value/kind/type", "\"StandaloneKindSig\""),
+        [ ("/items/0/value/kind/type", "\"DataType\""),
           ("/items/0/value/name", "\"X\""),
           ("/items/0/value/signature", "\"a -> a\""),
-          ("/items/1/value/kind/type", "\"DataType\""),
+          ("/items/1/value/kind/type", "\"DataConstructor\""),
           ("/items/1/value/name", "\"X\""),
-          ("/items/1/value/parentKey", "0"),
-          ("/items/1/value/signature", "\"a\""),
-          ("/items/2/value/kind/type", "\"DataConstructor\""),
-          ("/items/2/value/name", "\"X\""),
-          ("/items/2/value/parentKey", "1")
+          ("/items/1/value/parentKey", "1")
         ]
 
     Spec.it s "standalone kind signature with newtype" $ do
@@ -2237,16 +2230,12 @@ spec s = Spec.describe s "integration" $ do
         type Phantom :: * -> *
         newtype Phantom a = MkPhantom ()
         """
-        [ ("/items/0/value/kind/type", "\"StandaloneKindSig\""),
+        [ ("/items/0/value/kind/type", "\"Newtype\""),
           ("/items/0/value/name", "\"Phantom\""),
           ("/items/0/value/signature", "\"* -> *\""),
-          ("/items/1/value/kind/type", "\"Newtype\""),
-          ("/items/1/value/name", "\"Phantom\""),
-          ("/items/1/value/parentKey", "0"),
-          ("/items/1/value/signature", "\"a\""),
-          ("/items/2/value/kind/type", "\"DataConstructor\""),
-          ("/items/2/value/name", "\"MkPhantom\""),
-          ("/items/2/value/parentKey", "1")
+          ("/items/1/value/kind/type", "\"DataConstructor\""),
+          ("/items/1/value/name", "\"MkPhantom\""),
+          ("/items/1/value/parentKey", "1")
         ]
 
     Spec.it s "standalone kind signature with type synonym" $ do
@@ -2256,12 +2245,9 @@ spec s = Spec.describe s "integration" $ do
         type T :: * -> *
         type T a = Maybe a
         """
-        [ ("/items/0/value/kind/type", "\"StandaloneKindSig\""),
+        [ ("/items/0/value/kind/type", "\"TypeSynonym\""),
           ("/items/0/value/name", "\"T\""),
-          ("/items/0/value/signature", "\"* -> *\""),
-          ("/items/1/value/kind/type", "\"TypeSynonym\""),
-          ("/items/1/value/name", "\"T\""),
-          ("/items/1/value/parentKey", "0")
+          ("/items/0/value/signature", "\"* -> *\"")
         ]
 
     Spec.it s "standalone kind signature with class" $ do
@@ -2272,12 +2258,9 @@ spec s = Spec.describe s "integration" $ do
         type C :: * -> Constraint
         class C a
         """
-        [ ("/items/0/value/kind/type", "\"StandaloneKindSig\""),
+        [ ("/items/0/value/kind/type", "\"Class\""),
           ("/items/0/value/name", "\"C\""),
-          ("/items/0/value/signature", "\"* -> Constraint\""),
-          ("/items/1/value/kind/type", "\"Class\""),
-          ("/items/1/value/name", "\"C\""),
-          ("/items/1/value/parentKey", "0")
+          ("/items/0/value/signature", "\"* -> Constraint\"")
         ]
 
     Spec.it s "standalone kind signature with type family" $ do
@@ -2288,12 +2271,9 @@ spec s = Spec.describe s "integration" $ do
         type F :: * -> *
         type family F a
         """
-        [ ("/items/0/value/kind/type", "\"StandaloneKindSig\""),
+        [ ("/items/0/value/kind/type", "\"OpenTypeFamily\""),
           ("/items/0/value/name", "\"F\""),
-          ("/items/0/value/signature", "\"* -> *\""),
-          ("/items/1/value/kind/type", "\"OpenTypeFamily\""),
-          ("/items/1/value/name", "\"F\""),
-          ("/items/1/value/parentKey", "0")
+          ("/items/0/value/signature", "\"* -> *\"")
         ]
 
     Spec.it s "default declaration" $ do


### PR DESCRIPTION
Fixes #250.

## Summary

- Standalone kind signatures (`type T :: ...`) are now merged into their corresponding declarations (data, newtype, class, type synonym, type family) instead of being kept as separate parent items
- The kind signature text becomes the declaration's `signature` field, paralleling how term-level type signatures are merged into their bindings
- Documentation and `@since` annotations from the kind signature are also transferred to the declaration
- Kind signatures without a matching declaration are preserved unchanged

## Test plan

- [x] All 758 tests pass
- [x] Pedantic build (`-Werror`) succeeds
- [x] Updated 6 integration tests covering: bare data, data with constructors, newtype, type synonym, class, and type family

🤖 Generated with [Claude Code](https://claude.com/claude-code)