### PR TITLE
Preserve documentation on function return types

### DIFF
--- a/source/library/Scrod/Convert/FromGhc/Names.hs
+++ b/source/library/Scrod/Convert/FromGhc/Names.hs
@@ -230,7 +230,7 @@ stripHsDocTy lTy = case lTy of
 -- | Extract argument types and their optional doc comments from a type
 -- signature. Walks the 'HsFunTy' chain, collecting each argument's
 -- pretty-printed type text and its 'LHsDoc' (if the argument was wrapped
--- in 'HsDocTy'). The return type (final non-arrow part) is not included.
+-- in 'HsDocTy'). The return type is included only when it has documentation.
 --
 -- Handles 'TypeSig' (unwrap via 'hswc_body'), 'PatSynSig', and
 -- 'ClassOpSig' (unwrap via 'sig_body' on 'HsSigType').
@@ -255,7 +255,7 @@ extractArgsFromBody lTy = case SrcLoc.unLoc lTy of
   Syntax.HsFunTy _ _ arg res -> extractArg arg : extractArgsFromBody res
   Syntax.HsDocTy _ inner _doc -> case SrcLoc.unLoc inner of
     Syntax.HsFunTy _ _ arg res -> extractArg arg : extractArgsFromBody res
-    _ -> extractArgsFromBody inner
+    _ -> [extractArg lTy]
   _ -> []
 
 -- | Extract the type text and optional doc comment from a single argument.

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -2537,7 +2537,12 @@ spec s = Spec.describe s "integration" $ do
           ("/items/1/value/parentKey", "0"),
           ("/items/1/value/signature", "\"a\""),
           ("/items/1/value/documentation/type", "\"Paragraph\""),
-          ("/items/1/value/documentation/value/value", "\"i\"")
+          ("/items/1/value/documentation/value/value", "\"i\""),
+          ("/items/2/value/kind/type", "\"Argument\""),
+          ("/items/2/value/parentKey", "0"),
+          ("/items/2/value/signature", "\"a\""),
+          ("/items/2/value/documentation/type", "\"Paragraph\""),
+          ("/items/2/value/documentation/value/value", "\"o\"")
         ]
 
     Spec.it s "function without arg docs" $ do
@@ -2572,7 +2577,34 @@ spec s = Spec.describe s "integration" $ do
           ("/items/1/value/parentKey", "0"),
           ("/items/1/value/signature", "\"a\""),
           ("/items/1/value/documentation/type", "\"Paragraph\""),
-          ("/items/1/value/documentation/value/value", "\"input\"")
+          ("/items/1/value/documentation/value/value", "\"input\""),
+          ("/items/2/value/kind/type", "\"Argument\""),
+          ("/items/2/value/parentKey", "0"),
+          ("/items/2/value/signature", "\"String\""),
+          ("/items/2/value/documentation/type", "\"Paragraph\""),
+          ("/items/2/value/documentation/value/value", "\"output\"")
+        ]
+
+    Spec.it s "function with return value doc only" $ do
+      check
+        s
+        """
+        f :: a
+          -> a -- ^ lost
+        """
+        [ ("/items/0/value/kind/type", "\"Function\""),
+          ("/items/0/value/name", "\"f\""),
+          ("/items/0/value/signature", "\"a -> a\""),
+          ("/items/0/value/documentation/type", "\"Empty\""),
+          ("/items/1/value/kind/type", "\"Argument\""),
+          ("/items/1/value/parentKey", "0"),
+          ("/items/1/value/signature", "\"a\""),
+          ("/items/1/value/documentation/type", "\"Empty\""),
+          ("/items/2/value/kind/type", "\"Argument\""),
+          ("/items/2/value/parentKey", "0"),
+          ("/items/2/value/signature", "\"a\""),
+          ("/items/2/value/documentation/type", "\"Paragraph\""),
+          ("/items/2/value/documentation/value/value", "\"lost\"")
         ]
 
     Spec.it s "data constructor with arg doc has argument children" $ do


### PR DESCRIPTION
Fixes #251.

## Summary

When a function's return type had a Haddock comment (e.g. `-> a -- ^ doc`), the documentation was silently discarded. The `extractArgsFromBody` function in `Names.hs` matched the `HsDocTy` wrapper around the return type but then recursed into the inner type without capturing the doc, hitting the `_ -> []` base case.

The fix changes one line: instead of discarding the documented return type, it treats it as an argument entry via `extractArg`, which correctly extracts both the type text and the doc comment. This means documented return types now appear as `Argument` child items, consistent with how documented function parameters are already handled.

- Updated two existing tests that were missing return-type doc assertions
- Added a new test matching the exact example from the issue

## Test plan

- [x] `cabal build` succeeds
- [x] `cabal build --flags=pedantic` succeeds (no warnings)
- [x] `cabal test --test-options='--hide-successes'` — all 759 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)