### PR TITLE
Render exports with no matching item in HTML output

### DIFF
--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -503,7 +503,8 @@ declarationsContents :: Maybe [Export.Export] -> [Located.Located Item.Item] -> 
 declarationsContents exports items =
   [ element "h2" [] [Xml.string "Declarations"],
     case (exports, items) of
-      (_, []) -> Xml.string "None."
+      (Nothing, []) -> Xml.string "None."
+      (Just [], []) -> Xml.string "None."
       (Nothing, _) -> defaultDeclarations
       (Just [], _) -> defaultDeclarations
       (Just es, _) -> exportDrivenDeclarations es
@@ -587,25 +588,35 @@ declarationsContents exports items =
                     let (here, newKeys) = renderExportedItem subs li
                         (rest, used') = walkExports es (Set.union newKeys used)
                      in (here <> exportMeta <> rest, used')
-              _ ->
-                let here = case ExportName.kind exportName of
+              Just _ ->
+                let (rest, used') = walkExports es used
+                 in (exportMeta <> rest, used')
+              Nothing ->
+                let namePrefix = case ExportName.kind exportName of
+                      Just ExportNameKind.Module -> "module "
+                      Just ExportNameKind.Pattern -> "pattern "
+                      Just ExportNameKind.Type -> "type "
+                      Nothing -> ""
+                    badge = case ExportName.kind exportName of
                       Just ExportNameKind.Module ->
                         [ element
                             "div"
-                            [("class", "card my-3")]
-                            [ element
-                                "div"
-                                [("class", "card-header")]
-                                [ element "code" [("class", "text-break")] [Xml.string "module ", Xml.text name],
-                                  element
-                                    "div"
-                                    [("class", "mx-1")]
-                                    [element "span" [("class", "badge text-bg-secondary")] [Xml.string "re-export"]]
-                                ]
-                            ]
+                            [("class", "mx-1")]
+                            [element "span" [("class", "badge text-bg-secondary")] [Xml.string "re-export"]]
                         ]
-                          <> exportMeta
-                      _ -> exportMeta
+                      _ -> []
+                    here =
+                      [ element
+                          "div"
+                          [("class", "card my-3")]
+                          [ element
+                              "div"
+                              [("class", "card-header")]
+                              $ element "code" [("class", "text-break")] [Xml.string namePrefix, Xml.text name]
+                                : badge
+                          ]
+                      ]
+                        <> exportMeta
                     (rest, used') = walkExports es used
                  in (here <> rest, used')
       Export.Group section ->

--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -592,12 +592,13 @@ declarationsContents exports items =
                 let (rest, used') = walkExports es used
                  in (exportMeta <> rest, used')
               Nothing ->
-                let namePrefix = case ExportName.kind exportName of
+                let kind = ExportName.kind exportName
+                    namePrefix = case kind of
                       Just ExportNameKind.Module -> "module "
                       Just ExportNameKind.Pattern -> "pattern "
                       Just ExportNameKind.Type -> "type "
                       Nothing -> ""
-                    badge = case ExportName.kind exportName of
+                    badge = case kind of
                       Just ExportNameKind.Module ->
                         [ element
                             "div"

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -3203,6 +3203,14 @@ spec s = Spec.describe s "integration" $ do
         """
         [">myMethod<"]
 
+    Spec.it s "renders exports with no matching item" $ do
+      checkHtmlContains
+        s
+        """
+        module M ( missing ) where
+        """
+        [">missing<"]
+
 check :: (Stack.HasCallStack, Monad m) => Spec.Spec m n -> String -> [(String, String)] -> m ()
 check s = checkWith s []
 


### PR DESCRIPTION
## Summary

- When an export list entry has no corresponding declaration (e.g. `module Example ( missing ) where`), the HTML output now renders a card showing the export name instead of silently dropping it
- Module re-exports retain their "re-export" badge; duplicate exports are still suppressed
- Added integration test for the new behavior

Fixes #253.

## Test plan

- [x] New integration test: "renders exports with no matching item"
- [x] All 759 tests pass
- [x] Pedantic build (`--flags=pedantic`) passes with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)