### PR TITLE
Fix redundant $ hlint warnings in Xml.Content spec

### DIFF
--- a/source/library/Scrod/Xml/Content.hs
+++ b/source/library/Scrod/Xml/Content.hs
@@ -44,13 +44,13 @@ spec s = do
       Spec.assertEq s (isEmpty $ Text Text.empty) True
 
     Spec.it s "returns False for non-empty Text" $ do
-      Spec.assertEq s (isEmpty $ Text $ Text.pack "hello") False
+      Spec.assertEq s (isEmpty . Text $ Text.pack "hello") False
 
     Spec.it s "returns True for empty Raw" $ do
       Spec.assertEq s (isEmpty $ Raw Text.empty) True
 
     Spec.it s "returns False for non-empty Raw" $ do
-      Spec.assertEq s (isEmpty $ Raw $ Text.pack "hello") False
+      Spec.assertEq s (isEmpty . Raw $ Text.pack "hello") False
 
     Spec.it s "returns False for Element" $ do
       Spec.assertEq s (isEmpty $ Element "test") False


### PR DESCRIPTION
## Summary
- Replace `isEmpty $ Text $ Text.pack "hello"` with `isEmpty . Text $ Text.pack "hello"` (and same for `Raw`) to fix two redundant `$` hlint warnings

## Test plan
- [x] `hlint source/` reports no hints
- [x] `cabal build --flags=pedantic` passes
- [x] All 767 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)