### PR TITLE
Emit timing information in web app and VSCode extension

### DIFF
--- a/extra/github-pages/worker.js
+++ b/extra/github-pages/worker.js
@@ -56,10 +56,9 @@ onmessage = async function (e) {
       const args = ['--format', msg.format];
       if (msg.literate) args.push('--literate');
       if (msg.signature) args.push('--signature');
-      const start = performance.now();
+      console.time('scrod');
       const result = await scrod(args, msg.source);
-      const elapsed = performance.now() - start;
-      console.log('scrod: finished in ' + Math.round(elapsed) + ' ms');
+      console.timeEnd('scrod');
       postMessage({ tag: 'result', value: result, format: msg.format });
     } catch (err) {
       postMessage({ tag: 'error', message: err.message });

--- a/extra/github-pages/worker.js
+++ b/extra/github-pages/worker.js
@@ -56,9 +56,10 @@ onmessage = async function (e) {
       const args = ['--format', msg.format];
       if (msg.literate) args.push('--literate');
       if (msg.signature) args.push('--signature');
-      console.time('scrod');
+      const start = performance.now();
       const result = await scrod(args, msg.source);
-      console.timeEnd('scrod');
+      const elapsed = performance.now() - start;
+      console.log('scrod: finished in ' + Math.round(elapsed) + ' ms');
       postMessage({ tag: 'result', value: result, format: msg.format });
     } catch (err) {
       postMessage({ tag: 'error', message: err.message });

--- a/extra/github-pages/worker.js
+++ b/extra/github-pages/worker.js
@@ -56,7 +56,11 @@ onmessage = async function (e) {
       const args = ['--format', msg.format];
       if (msg.literate) args.push('--literate');
       if (msg.signature) args.push('--signature');
+      const inputBytes = new TextEncoder().encode(msg.source).length;
+      const start = performance.now();
       const result = await scrod(args, msg.source);
+      const elapsed = performance.now() - start;
+      console.log('scrod: finished in ' + Math.round(elapsed) + ' ms (' + inputBytes + ' bytes input, ' + result.length + ' bytes output)');
       postMessage({ tag: 'result', value: result, format: msg.format });
     } catch (err) {
       postMessage({ tag: 'error', message: err.message });

--- a/extra/github-pages/worker.js
+++ b/extra/github-pages/worker.js
@@ -56,11 +56,10 @@ onmessage = async function (e) {
       const args = ['--format', msg.format];
       if (msg.literate) args.push('--literate');
       if (msg.signature) args.push('--signature');
-      const inputBytes = new TextEncoder().encode(msg.source).length;
       const start = performance.now();
       const result = await scrod(args, msg.source);
       const elapsed = performance.now() - start;
-      console.log('scrod: finished in ' + Math.round(elapsed) + ' ms (' + inputBytes + ' bytes input, ' + result.length + ' bytes output)');
+      console.log('scrod: finished in ' + Math.round(elapsed) + ' ms');
       postMessage({ tag: 'result', value: result, format: msg.format });
     } catch (err) {
       postMessage({ tag: 'error', message: err.message });

--- a/extra/vscode/src/extension.ts
+++ b/extra/vscode/src/extension.ts
@@ -9,8 +9,11 @@ let debounceTimer: ReturnType<typeof setTimeout> | undefined;
 let webviewReady = false;
 let pendingHtml: string | undefined;
 let previewDocumentUri: vscode.Uri | undefined;
+let outputChannel: vscode.OutputChannel | undefined;
 
 export function activate(context: vscode.ExtensionContext): void {
+  outputChannel = vscode.window.createOutputChannel("Scrod");
+  context.subscriptions.push(outputChannel);
   engine = loadWasmEngine(context.extensionPath);
 
   context.subscriptions.push(
@@ -104,7 +107,14 @@ async function update(document: vscode.TextDocument): Promise<void> {
   let html: string;
   try {
     const process = await engine;
-    html = await process(document.getText(), literate, isSignature);
+    const source = document.getText();
+    const inputBytes = Buffer.byteLength(source, "utf8");
+    const start = performance.now();
+    html = await process(source, literate, isSignature);
+    const elapsed = performance.now() - start;
+    outputChannel?.appendLine(
+      `${path.basename(document.fileName)}: finished in ${Math.round(elapsed)} ms (${inputBytes} bytes input, ${html.length} bytes output)`
+    );
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     const escaped = message

--- a/extra/vscode/src/extension.ts
+++ b/extra/vscode/src/extension.ts
@@ -108,12 +108,11 @@ async function update(document: vscode.TextDocument): Promise<void> {
   try {
     const process = await engine;
     const source = document.getText();
-    const inputBytes = Buffer.byteLength(source, "utf8");
     const start = performance.now();
     html = await process(source, literate, isSignature);
     const elapsed = performance.now() - start;
     outputChannel?.appendLine(
-      `${path.basename(document.fileName)}: finished in ${Math.round(elapsed)} ms (${inputBytes} bytes input, ${html.length} bytes output)`
+      `${path.basename(document.fileName)}: finished in ${Math.round(elapsed)} ms`
     );
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
Fixes #267.

## Summary

- **Web app** (`extra/github-pages/worker.js`): After each WASM render, logs a line to the browser console like `scrod: finished in 42 ms (123 bytes input, 4567 bytes output)`.
- **VSCode extension** (`extra/vscode/src/extension.ts`): Creates a "Scrod" output channel and logs a similar line after each render, like `Example.hs: finished in 42 ms (123 bytes input, 4567 bytes output)`. Viewable via the Output panel in VSCode.

Both include input size (bytes) and output size (characters) alongside the elapsed time.