### PR TITLE
Add Operator item kind for symbolic names

### DIFF
--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -419,13 +419,11 @@ convertSigDeclM doc docSince lDecl sig = case sig of
     let sigText = Names.extractSigSignature sig
         args = Names.extractSigArguments sig
      in fmap concat . Traversable.for names $ \lName -> do
-          let name = Internal.extractIdPName lName
-              itemKind = if ItemName.isOperator name then ItemKind.Operator else ItemKind.Function
           parentResult <-
             Internal.mkItemWithKeyM
               (Annotation.getLocA lName)
               Nothing
-              (Just name)
+              (Just $ Internal.extractIdPName lName)
               doc
               docSince
               sigText
@@ -574,10 +572,7 @@ convertDeclWithDocM ::
   Syntax.LHsDecl Ghc.GhcPs ->
   Internal.ConvertM (Maybe (Located.Located Item.Item))
 convertDeclWithDocM parentKey doc docSince itemName sig lDecl =
-  let rawKind = ItemKindFrom.itemKindFromDecl $ SrcLoc.unLoc lDecl
-      itemKind = case (rawKind, itemName) of
-        (ItemKind.Function, Just n) | ItemName.isOperator n -> ItemKind.Operator
-        _ -> rawKind
+  let itemKind = ItemKindFrom.itemKindFromDecl $ SrcLoc.unLoc lDecl
    in Internal.mkItemM (Annotation.getLocA lDecl) parentKey itemName doc docSince sig itemKind
 
 -- | Convert rule declarations.

--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -419,11 +419,13 @@ convertSigDeclM doc docSince lDecl sig = case sig of
     let sigText = Names.extractSigSignature sig
         args = Names.extractSigArguments sig
      in fmap concat . Traversable.for names $ \lName -> do
+          let name = Internal.extractIdPName lName
+              itemKind = if ItemName.isOperator name then ItemKind.Operator else ItemKind.Function
           parentResult <-
             Internal.mkItemWithKeyM
               (Annotation.getLocA lName)
               Nothing
-              (Just $ Internal.extractIdPName lName)
+              (Just name)
               doc
               docSince
               sigText
@@ -572,7 +574,10 @@ convertDeclWithDocM ::
   Syntax.LHsDecl Ghc.GhcPs ->
   Internal.ConvertM (Maybe (Located.Located Item.Item))
 convertDeclWithDocM parentKey doc docSince itemName sig lDecl =
-  let itemKind = ItemKindFrom.itemKindFromDecl $ SrcLoc.unLoc lDecl
+  let rawKind = ItemKindFrom.itemKindFromDecl $ SrcLoc.unLoc lDecl
+      itemKind = case (rawKind, itemName) of
+        (ItemKind.Function, Just n) | ItemName.isOperator n -> ItemKind.Operator
+        _ -> rawKind
    in Internal.mkItemM (Annotation.getLocA lDecl) parentKey itemName doc docSince sig itemKind
 
 -- | Convert rule declarations.

--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -419,17 +419,15 @@ convertSigDeclM doc docSince lDecl sig = case sig of
     let sigText = Names.extractSigSignature sig
         args = Names.extractSigArguments sig
      in fmap concat . Traversable.for names $ \lName -> do
-          let name = Internal.extractIdPName lName
-              itemKind = if ItemName.isOperator name then ItemKind.Operator else ItemKind.Function
           parentResult <-
             Internal.mkItemWithKeyM
               (Annotation.getLocA lName)
               Nothing
-              (Just name)
+              (Just $ Internal.extractIdPName lName)
               doc
               docSince
               sigText
-              itemKind
+              (ItemKindFrom.functionOrOperator lName)
           case parentResult of
             Nothing -> pure []
             Just (parentItem, parentKey) -> do
@@ -574,10 +572,7 @@ convertDeclWithDocM ::
   Syntax.LHsDecl Ghc.GhcPs ->
   Internal.ConvertM (Maybe (Located.Located Item.Item))
 convertDeclWithDocM parentKey doc docSince itemName sig lDecl =
-  let rawKind = ItemKindFrom.itemKindFromDecl $ SrcLoc.unLoc lDecl
-      itemKind = case (rawKind, itemName) of
-        (ItemKind.Function, Just n) | ItemName.isOperator n -> ItemKind.Operator
-        _ -> rawKind
+  let itemKind = ItemKindFrom.itemKindFromDecl $ SrcLoc.unLoc lDecl
    in Internal.mkItemM (Annotation.getLocA lDecl) parentKey itemName doc docSince sig itemKind
 
 -- | Convert rule declarations.

--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -869,6 +869,7 @@ kindToString x = case x of
   ItemKind.ForeignExport -> "foreign export"
   ItemKind.ForeignImport -> "foreign import"
   ItemKind.Function -> "function"
+  ItemKind.Operator -> "operator"
   ItemKind.GADTConstructor -> "constructor"
   ItemKind.InlineSignature -> "inline"
   ItemKind.MinimalPragma -> "minimal"

--- a/source/library/Scrod/Core/ItemKind.hs
+++ b/source/library/Scrod/Core/ItemKind.hs
@@ -11,6 +11,8 @@ import qualified Scrod.Schema as Schema
 data ItemKind
   = -- | Function binding: @f x = expr@
     Function
+  | -- | Operator binding: @(+) x y = expr@
+    Operator
   | -- | Pattern binding: @(x, y) = tuple@
     PatternBinding
   | -- | Pattern synonym: @pattern P x = Just x@

--- a/source/library/Scrod/Core/ItemName.hs
+++ b/source/library/Scrod/Core/ItemName.hs
@@ -11,3 +11,14 @@ newtype ItemName = MkItemName
   }
   deriving (Eq, Ord, Show)
   deriving (ToJson.ToJson, Schema.ToSchema) via Text.Text
+
+-- | Check whether an item name represents an operator.
+--
+-- GHC pretty-prints operator names without parentheses (e.g. @>>=@,
+-- @+++@), so we detect them by checking whether the first character
+-- is a Haskell symbol character.
+isOperator :: ItemName -> Bool
+isOperator = maybe False (isSymbolChar . fst) . Text.uncons . unwrap
+
+isSymbolChar :: Char -> Bool
+isSymbolChar c = c `elem` ("!#$%&*+./<=>?@\\^|-~:" :: [Char])

--- a/source/library/Scrod/Core/ItemName.hs
+++ b/source/library/Scrod/Core/ItemName.hs
@@ -11,14 +11,3 @@ newtype ItemName = MkItemName
   }
   deriving (Eq, Ord, Show)
   deriving (ToJson.ToJson, Schema.ToSchema) via Text.Text
-
--- | Check whether an item name represents an operator.
---
--- GHC pretty-prints operator names without parentheses (e.g. @>>=@,
--- @+++@), so we detect them by checking whether the first character
--- is a Haskell symbol character.
-isOperator :: ItemName -> Bool
-isOperator = maybe False (isSymbolChar . fst) . Text.uncons . unwrap
-
-isSymbolChar :: Char -> Bool
-isSymbolChar c = c `elem` ("!#$%&*+./<=>?@\\^|-~:" :: [Char])

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -1091,6 +1091,44 @@ spec s = Spec.describe s "integration" $ do
           [ ("/items/0/value/since", "")
           ]
 
+    Spec.describe s "operator" $ do
+      Spec.it s "works with a type signature" $ do
+        check
+          s
+          "(+++) :: Int -> Int -> Int"
+          [ ("/items/0/value/kind/type", "\"Operator\""),
+            ("/items/0/value/name", "\"+++\""),
+            ("/items/0/value/signature", "\"Int -> Int -> Int\"")
+          ]
+
+      Spec.it s "works with a binding" $ do
+        check
+          s
+          "(+++) a b = a"
+          [ ("/items/0/value/kind/type", "\"Operator\""),
+            ("/items/0/value/name", "\"+++\"")
+          ]
+
+      Spec.it s "works with both signature and binding" $ do
+        check
+          s
+          """
+          (+++) :: Int -> Int -> Int
+          (+++) a b = a
+          """
+          [ ("/items/0/value/kind/type", "\"Operator\""),
+            ("/items/0/value/name", "\"+++\""),
+            ("/items/0/value/signature", "\"Int -> Int -> Int\"")
+          ]
+
+      Spec.it s "does not affect regular functions" $ do
+        check
+          s
+          "f :: Int -> Int"
+          [ ("/items/0/value/kind/type", "\"Function\""),
+            ("/items/0/value/name", "\"f\"")
+          ]
+
     Spec.it s "open type family" $ do
       check s "{-# language TypeFamilies #-} type family A" [("/items/0/value/kind/type", "\"OpenTypeFamily\"")]
 
@@ -1909,7 +1947,7 @@ spec s = Spec.describe s "integration" $ do
         infixl 0 %
         """
         [ ("/items/0/value/name", "\"%\""),
-          ("/items/0/value/kind/type", "\"Function\""),
+          ("/items/0/value/kind/type", "\"Operator\""),
           ("/items/1/value/name", "\"%\""),
           ("/items/1/value/kind/type", "\"FixitySignature\""),
           ("/items/1/value/parentKey", "0"),
@@ -1929,7 +1967,7 @@ spec s = Spec.describe s "integration" $ do
           ("/items/0/value/parentKey", "1"),
           ("/items/0/value/documentation/value/value", "\"infixl 5\""),
           ("/items/1/value/name", "\"%\""),
-          ("/items/1/value/kind/type", "\"Function\""),
+          ("/items/1/value/kind/type", "\"Operator\""),
           ("/items/1/value/signature", "\"() -> () -> ()\"")
         ]
 
@@ -2745,7 +2783,7 @@ spec s = Spec.describe s "integration" $ do
         {-# specialize (%) :: () -> () -> () #-}
         """
         [ ("/items/0/value/name", "\"%\""),
-          ("/items/0/value/kind/type", "\"Function\""),
+          ("/items/0/value/kind/type", "\"Operator\""),
           ("/items/0/value/key", "0"),
           ("/items/1/value/kind/type", "\"Argument\""),
           ("/items/1/value/parentKey", "0"),


### PR DESCRIPTION
## Summary
- Adds an `Operator` constructor to `ItemKind` for declarations with symbolic names (e.g. `+++`, `>>=`, `%`)
- Detects operators by checking if the first character of the item name is a Haskell symbol character
- Applies to both type signature declarations and standalone bindings
- Updates HTML badge to display "operator" for these items
- Adds integration tests covering operator type sigs, bindings, merged sig+binding, and a negative case for regular functions

Relates to #266.

## Test plan
- [x] All 806 tests pass (including 4 new operator tests and 3 updated existing tests)
- [x] Pedantic build (`--flags=pedantic`) succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)