### PR TITLE
Add Visibility field and move export logic from ToHtml to FromGhc

### DIFF
--- a/scrod.cabal
+++ b/scrod.cabal
@@ -106,6 +106,7 @@ library
     Scrod.Convert.FromGhc.ParentAssociation
     Scrod.Convert.FromGhc.RoleParents
     Scrod.Convert.FromGhc.SpecialiseParents
+    Scrod.Convert.FromGhc.Visibility
     Scrod.Convert.FromGhc.WarningParents
     Scrod.Convert.FromHaddock
     Scrod.Convert.ToHtml

--- a/scrod.cabal
+++ b/scrod.cabal
@@ -146,6 +146,7 @@ library
     Scrod.Core.Table
     Scrod.Core.TableCell
     Scrod.Core.Version
+    Scrod.Core.Visibility
     Scrod.Core.Warning
     Scrod.Cpp
     Scrod.Cpp.Directive

--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -264,7 +264,7 @@ computeVisibility ::
   Maybe [Export.Export] ->
   [Located.Located Item.Item] ->
   [Located.Located Item.Item]
-computeVisibility Nothing items = fmap (setImplicit Nothing) items
+computeVisibility Nothing items = fmap setImplicit items
 computeVisibility (Just exports) items =
   let exportedNames = extractExportedNames exports
       wildcardParentKeys = extractWildcardParentKeys exports items
@@ -292,8 +292,8 @@ computeVisibility (Just exports) items =
 
 -- | When there is no export list, tag implicit items and leave everything
 -- else as 'Exported' (the default set by 'mkItemM').
-setImplicit :: Maybe ItemKey.ItemKey -> Located.Located Item.Item -> Located.Located Item.Item
-setImplicit _ li =
+setImplicit :: Located.Located Item.Item -> Located.Located Item.Item
+setImplicit li =
   let item = Located.value li
    in if isAlwaysVisible (Item.kind item)
         then setVisibility Visibility.Implicit li

--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -48,12 +48,11 @@ import qualified Scrod.Convert.FromGhc.Names as Names
 import qualified Scrod.Convert.FromGhc.ParentAssociation as ParentAssociation
 import qualified Scrod.Convert.FromGhc.RoleParents as RoleParents
 import qualified Scrod.Convert.FromGhc.SpecialiseParents as SpecialiseParents
+import qualified Scrod.Convert.FromGhc.Visibility as Visibility
 import qualified Scrod.Convert.FromGhc.WarningParents as WarningParents
 import qualified Scrod.Core.Category as Category
 import qualified Scrod.Core.Doc as Doc
 import qualified Scrod.Core.Export as Export
-import qualified Scrod.Core.ExportIdentifier as ExportIdentifier
-import qualified Scrod.Core.ExportName as ExportName
 import qualified Scrod.Core.Extension as Extension
 import qualified Scrod.Core.Import as Import
 import qualified Scrod.Core.Item as Item
@@ -66,9 +65,7 @@ import qualified Scrod.Core.Module as Module
 import qualified Scrod.Core.ModuleName as ModuleName
 import qualified Scrod.Core.PackageName as PackageName
 import qualified Scrod.Core.Since as Since
-import qualified Scrod.Core.Subordinates as Subordinates
 import qualified Scrod.Core.Version as Version
-import qualified Scrod.Core.Visibility as Visibility
 import qualified Scrod.Core.Warning as Warning
 import qualified Scrod.Ghc.OnOff as OnOff
 
@@ -98,7 +95,7 @@ fromGhc isSignature ((language, extensions), lHsModule) = do
         Module.exports = resolveNamedDocExports namedDocChunks <$> rawExports,
         Module.imports = extractModuleImports lHsModule,
         Module.items =
-          computeVisibility (resolveNamedDocExports namedDocChunks <$> rawExports)
+          Visibility.computeVisibility (resolveNamedDocExports namedDocChunks <$> rawExports)
             . extractItems referencedChunkNames
             $ lHsModule
       }
@@ -246,154 +243,6 @@ extractItems referencedChunkNames lHsModule =
       -- are merged with their type signatures first.
       completeNames = CompleteParents.extractCompleteNames lHsModule
    in CompleteParents.associateCompleteParents completeNames kindSigParentedItems
-
--- | Whether an item kind is always visible regardless of the export list.
-isAlwaysVisible :: ItemKind.ItemKind -> Bool
-isAlwaysVisible k = case k of
-  ItemKind.ClassInstance -> True
-  ItemKind.CompletePragma -> True
-  ItemKind.StandaloneDeriving -> True
-  ItemKind.DerivedInstance -> True
-  ItemKind.Rule -> True
-  ItemKind.Default -> True
-  ItemKind.Annotation -> True
-  ItemKind.Splice -> True
-  _ -> False
-
--- | Compute visibility for each item based on the module's export list.
-computeVisibility ::
-  Maybe [Export.Export] ->
-  [Located.Located Item.Item] ->
-  [Located.Located Item.Item]
-computeVisibility Nothing items = fmap setImplicit items
-computeVisibility (Just exports) items =
-  let exportedNames = extractExportedNames exports
-      wildcardParentKeys = extractWildcardParentKeys exports items
-      exportedParentSubs = extractExportedParentSubs exports items
-   in fmap (classifyItem exportedNames wildcardParentKeys exportedParentSubs) items
-  where
-    classifyItem ::
-      Set.Set Text.Text ->
-      Set.Set ItemKey.ItemKey ->
-      Map.Map ItemKey.ItemKey (Maybe Subordinates.Subordinates) ->
-      Located.Located Item.Item ->
-      Located.Located Item.Item
-    classifyItem exportedNames wildcardKeys parentSubs li =
-      let item = Located.value li
-       in if isAlwaysVisible (Item.kind item)
-            then setVisibility Visibility.Implicit li
-            else case Item.parentKey item of
-              Just pk
-                | Set.member pk wildcardKeys ->
-                    setVisibility Visibility.Exported li
-                | Just subs <- Map.lookup pk parentSubs ->
-                    classifyChild subs item li
-              _ ->
-                case Item.name item of
-                  Just n
-                    | Set.member (ItemName.unwrap n) exportedNames ->
-                        setVisibility Visibility.Exported li
-                  _ -> setVisibility Visibility.Unexported li
-
-    -- Classify a child of an exported parent based on subordinate
-    -- restrictions. Non-traditional subordinates (e.g. associated type
-    -- families) are always exported. Traditional subordinates
-    -- (constructors, record fields, class methods) follow the export
-    -- list's subordinate restrictions.
-    classifyChild ::
-      Maybe Subordinates.Subordinates ->
-      Item.Item ->
-      Located.Located Item.Item ->
-      Located.Located Item.Item
-    classifyChild subs item li
-      | not (ItemKind.isTraditionalSubordinate (Item.kind item)) =
-          setVisibility Visibility.Exported li
-      | otherwise = case subs of
-          Nothing -> setVisibility Visibility.Unexported li
-          Just (Subordinates.MkSubordinates True _) ->
-            setVisibility Visibility.Exported li
-          Just (Subordinates.MkSubordinates False explicit) ->
-            case Item.name item of
-              Just n
-                | Set.member (ItemName.unwrap n) explicitNames ->
-                    setVisibility Visibility.Exported li
-                where
-                  explicitNames = Set.fromList $ fmap ExportName.name explicit
-              _ -> setVisibility Visibility.Unexported li
-
--- | When there is no export list, tag implicit items and leave everything
--- else as 'Exported' (the default set by 'mkItemM').
-setImplicit :: Located.Located Item.Item -> Located.Located Item.Item
-setImplicit li =
-  let item = Located.value li
-   in if isAlwaysVisible (Item.kind item)
-        then setVisibility Visibility.Implicit li
-        else li
-
--- | Set the visibility field on a located item.
-setVisibility :: Visibility.Visibility -> Located.Located Item.Item -> Located.Located Item.Item
-setVisibility v li =
-  li {Located.value = (Located.value li) {Item.visibility = v}}
-
--- | Extract the set of names that are directly exported (including
--- explicitly named subordinates like @Foo(Bar, Baz)@).
-extractExportedNames :: [Export.Export] -> Set.Set Text.Text
-extractExportedNames = foldMap go
-  where
-    go :: Export.Export -> Set.Set Text.Text
-    go (Export.Identifier ident) =
-      let name = ExportName.name (ExportIdentifier.name ident)
-          explicitSubs = case ExportIdentifier.subordinates ident of
-            Nothing -> Set.empty
-            Just (Subordinates.MkSubordinates _ explicit) ->
-              Set.fromList $ fmap ExportName.name explicit
-       in Set.insert name explicitSubs
-    go _ = Set.empty
-
--- | Extract the set of parent item keys whose children are exported via
--- a @(..)@ wildcard.
-extractWildcardParentKeys ::
-  [Export.Export] ->
-  [Located.Located Item.Item] ->
-  Set.Set ItemKey.ItemKey
-extractWildcardParentKeys exports items =
-  let wildcardNames =
-        Set.fromList
-          [ ExportName.name (ExportIdentifier.name ident)
-          | Export.Identifier ident <- exports,
-            Just (Subordinates.MkSubordinates True _) <- [ExportIdentifier.subordinates ident]
-          ]
-   in Set.fromList
-        . Maybe.mapMaybe (\n -> Map.lookup n (topLevelNameToKey items))
-        $ Set.toList wildcardNames
-
--- | Extract a map from exported parent item keys to their subordinate
--- restrictions. The value is 'Nothing' when the parent is exported with
--- no subordinates at all (e.g. @Foo@), or 'Just' when subordinates are
--- present (e.g. @Foo(..)@ or @Foo(Bar)@).
-extractExportedParentSubs ::
-  [Export.Export] ->
-  [Located.Located Item.Item] ->
-  Map.Map ItemKey.ItemKey (Maybe Subordinates.Subordinates)
-extractExportedParentSubs exports items =
-  let exportSubs =
-        [ (ExportName.name (ExportIdentifier.name ident), ExportIdentifier.subordinates ident)
-        | Export.Identifier ident <- exports
-        ]
-      nk = topLevelNameToKey items
-   in Map.fromList
-        . Maybe.mapMaybe (\(n, subs) -> (\k -> (k, subs)) <$> Map.lookup n nk)
-        $ exportSubs
-
--- | Build a map from top-level item names to their keys.
-topLevelNameToKey :: [Located.Located Item.Item] -> Map.Map Text.Text ItemKey.ItemKey
-topLevelNameToKey items =
-  Map.fromList
-    [ (ItemName.unwrap n, Item.key (Located.value li))
-    | li <- items,
-      Maybe.isNothing (Item.parentKey (Located.value li)),
-      Just n <- [Item.name (Located.value li)]
-    ]
 
 -- | Build a map from function name to argument names extracted from
 -- 'FunBind' patterns. Each function maps to a list of 'Maybe Text'

--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -275,14 +275,14 @@ computeVisibility (Just exports) items =
       Set.Set ItemKey.ItemKey ->
       Located.Located Item.Item ->
       Located.Located Item.Item
-    classifyItem exportedNames wildcardParentKeys li =
+    classifyItem exportedNames wildcardKeys li =
       let item = Located.value li
        in if isAlwaysVisible (Item.kind item)
             then setVisibility Visibility.Implicit li
             else case Item.parentKey item of
               Just pk
-                | Set.member pk wildcardParentKeys ->
-                    setVisibility Visibility.Wildcard li
+                | Set.member pk wildcardKeys ->
+                    setVisibility Visibility.Exported li
               _ ->
                 case Item.name item of
                   Just n

--- a/source/library/Scrod/Convert/FromGhc/Internal.hs
+++ b/source/library/Scrod/Convert/FromGhc/Internal.hs
@@ -35,6 +35,7 @@ import qualified Scrod.Core.ModuleName as ModuleName
 import qualified Scrod.Core.PackageName as PackageName
 import qualified Scrod.Core.Since as Since
 import qualified Scrod.Core.Version as Version
+import qualified Scrod.Core.Visibility as Visibility
 import qualified Scrod.Core.Warning as Warning
 
 -- | State for tracking item keys during conversion.
@@ -203,7 +204,8 @@ mkItemWithKeyM srcSpan parentKey itemName doc itemSince sig itemKind =
                       Item.name = itemName,
                       Item.documentation = doc,
                       Item.since = itemSince,
-                      Item.signature = sig
+                      Item.signature = sig,
+                      Item.visibility = Visibility.Exported
                     }
               },
             key

--- a/source/library/Scrod/Convert/FromGhc/Visibility.hs
+++ b/source/library/Scrod/Convert/FromGhc/Visibility.hs
@@ -1,0 +1,165 @@
+-- | Compute visibility for each item based on the module's export list.
+module Scrod.Convert.FromGhc.Visibility (computeVisibility) where
+
+import qualified Data.Map as Map
+import qualified Data.Maybe as Maybe
+import qualified Data.Set as Set
+import qualified Data.Text as Text
+import qualified Scrod.Core.Export as Export
+import qualified Scrod.Core.ExportIdentifier as ExportIdentifier
+import qualified Scrod.Core.ExportName as ExportName
+import qualified Scrod.Core.Item as Item
+import qualified Scrod.Core.ItemKey as ItemKey
+import qualified Scrod.Core.ItemKind as ItemKind
+import qualified Scrod.Core.ItemName as ItemName
+import qualified Scrod.Core.Located as Located
+import qualified Scrod.Core.Subordinates as Subordinates
+import qualified Scrod.Core.Visibility as Visibility
+
+-- | Whether an item kind is always visible regardless of the export list.
+isAlwaysVisible :: ItemKind.ItemKind -> Bool
+isAlwaysVisible k = case k of
+  ItemKind.ClassInstance -> True
+  ItemKind.CompletePragma -> True
+  ItemKind.StandaloneDeriving -> True
+  ItemKind.DerivedInstance -> True
+  ItemKind.Rule -> True
+  ItemKind.Default -> True
+  ItemKind.Annotation -> True
+  ItemKind.Splice -> True
+  _ -> False
+
+-- | Compute visibility for each item based on the module's export list.
+computeVisibility ::
+  Maybe [Export.Export] ->
+  [Located.Located Item.Item] ->
+  [Located.Located Item.Item]
+computeVisibility Nothing items = fmap setImplicit items
+computeVisibility (Just exports) items =
+  let exportedNames = extractExportedNames exports
+      wildcardParentKeys = extractWildcardParentKeys exports items
+      exportedParentSubs = extractExportedParentSubs exports items
+   in fmap (classifyItem exportedNames wildcardParentKeys exportedParentSubs) items
+  where
+    classifyItem ::
+      Set.Set Text.Text ->
+      Set.Set ItemKey.ItemKey ->
+      Map.Map ItemKey.ItemKey (Maybe Subordinates.Subordinates) ->
+      Located.Located Item.Item ->
+      Located.Located Item.Item
+    classifyItem exportedNames wildcardKeys parentSubs li =
+      let item = Located.value li
+       in if isAlwaysVisible (Item.kind item)
+            then setVisibility Visibility.Implicit li
+            else case Item.parentKey item of
+              Just pk
+                | Set.member pk wildcardKeys ->
+                    setVisibility Visibility.Exported li
+                | Just subs <- Map.lookup pk parentSubs ->
+                    classifyChild subs item li
+              _ ->
+                case Item.name item of
+                  Just n
+                    | Set.member (ItemName.unwrap n) exportedNames ->
+                        setVisibility Visibility.Exported li
+                  _ -> setVisibility Visibility.Unexported li
+
+    -- Classify a child of an exported parent based on subordinate
+    -- restrictions. Non-traditional subordinates (e.g. associated type
+    -- families) are always exported. Traditional subordinates
+    -- (constructors, record fields, class methods) follow the export
+    -- list's subordinate restrictions.
+    classifyChild ::
+      Maybe Subordinates.Subordinates ->
+      Item.Item ->
+      Located.Located Item.Item ->
+      Located.Located Item.Item
+    classifyChild subs item li
+      | not (ItemKind.isTraditionalSubordinate (Item.kind item)) =
+          setVisibility Visibility.Exported li
+      | otherwise = case subs of
+          Nothing -> setVisibility Visibility.Unexported li
+          Just (Subordinates.MkSubordinates True _) ->
+            setVisibility Visibility.Exported li
+          Just (Subordinates.MkSubordinates False explicit) ->
+            case Item.name item of
+              Just n
+                | Set.member (ItemName.unwrap n) explicitNames ->
+                    setVisibility Visibility.Exported li
+                where
+                  explicitNames = Set.fromList $ fmap ExportName.name explicit
+              _ -> setVisibility Visibility.Unexported li
+
+-- | When there is no export list, tag implicit items and leave everything
+-- else as 'Exported' (the default set by 'mkItemM').
+setImplicit :: Located.Located Item.Item -> Located.Located Item.Item
+setImplicit li =
+  let item = Located.value li
+   in if isAlwaysVisible (Item.kind item)
+        then setVisibility Visibility.Implicit li
+        else li
+
+-- | Set the visibility field on a located item.
+setVisibility :: Visibility.Visibility -> Located.Located Item.Item -> Located.Located Item.Item
+setVisibility v li =
+  li {Located.value = (Located.value li) {Item.visibility = v}}
+
+-- | Extract the set of names that are directly exported (including
+-- explicitly named subordinates like @Foo(Bar, Baz)@).
+extractExportedNames :: [Export.Export] -> Set.Set Text.Text
+extractExportedNames = foldMap go
+  where
+    go :: Export.Export -> Set.Set Text.Text
+    go (Export.Identifier ident) =
+      let name = ExportName.name (ExportIdentifier.name ident)
+          explicitSubs = case ExportIdentifier.subordinates ident of
+            Nothing -> Set.empty
+            Just (Subordinates.MkSubordinates _ explicit) ->
+              Set.fromList $ fmap ExportName.name explicit
+       in Set.insert name explicitSubs
+    go _ = Set.empty
+
+-- | Extract the set of parent item keys whose children are exported via
+-- a @(..)@ wildcard.
+extractWildcardParentKeys ::
+  [Export.Export] ->
+  [Located.Located Item.Item] ->
+  Set.Set ItemKey.ItemKey
+extractWildcardParentKeys exports items =
+  let wildcardNames =
+        Set.fromList
+          [ ExportName.name (ExportIdentifier.name ident)
+          | Export.Identifier ident <- exports,
+            Just (Subordinates.MkSubordinates True _) <- [ExportIdentifier.subordinates ident]
+          ]
+   in Set.fromList
+        . Maybe.mapMaybe (\n -> Map.lookup n (topLevelNameToKey items))
+        $ Set.toList wildcardNames
+
+-- | Extract a map from exported parent item keys to their subordinate
+-- restrictions. The value is 'Nothing' when the parent is exported with
+-- no subordinates at all (e.g. @Foo@), or 'Just' when subordinates are
+-- present (e.g. @Foo(..)@ or @Foo(Bar)@).
+extractExportedParentSubs ::
+  [Export.Export] ->
+  [Located.Located Item.Item] ->
+  Map.Map ItemKey.ItemKey (Maybe Subordinates.Subordinates)
+extractExportedParentSubs exports items =
+  let exportSubs =
+        [ (ExportName.name (ExportIdentifier.name ident), ExportIdentifier.subordinates ident)
+        | Export.Identifier ident <- exports
+        ]
+      nk = topLevelNameToKey items
+   in Map.fromList
+        . Maybe.mapMaybe (\(n, subs) -> (\k -> (k, subs)) <$> Map.lookup n nk)
+        $ exportSubs
+
+-- | Build a map from top-level item names to their keys.
+topLevelNameToKey :: [Located.Located Item.Item] -> Map.Map Text.Text ItemKey.ItemKey
+topLevelNameToKey items =
+  Map.fromList
+    [ (ItemName.unwrap n, Item.key (Located.value li))
+    | li <- items,
+      Maybe.isNothing (Item.parentKey (Located.value li)),
+      Just n <- [Item.name (Located.value li)]
+    ]

--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -50,6 +50,7 @@ import qualified Scrod.Core.Subordinates as Subordinates
 import qualified Scrod.Core.Table as Table
 import qualified Scrod.Core.TableCell as TableCell
 import qualified Scrod.Core.Version as Version
+import qualified Scrod.Core.Visibility as Visibility
 import qualified Scrod.Core.Warning as Warning
 import qualified Scrod.Xml.Content as Content
 import qualified Scrod.Xml.Declaration as XmlDeclaration
@@ -479,19 +480,6 @@ extensionUrlPaths =
       ("ViewPatterns", "exts/view_patterns.html#extension-ViewPatterns")
     ]
 
--- | Whether an item kind is "always visible" — implicitly exported
--- regardless of the export list.
-isAlwaysVisible :: ItemKind.ItemKind -> Bool
-isAlwaysVisible k = case k of
-  ItemKind.ClassInstance -> True
-  ItemKind.StandaloneDeriving -> True
-  ItemKind.DerivedInstance -> True
-  ItemKind.Rule -> True
-  ItemKind.Default -> True
-  ItemKind.Annotation -> True
-  ItemKind.Splice -> True
-  _ -> False
-
 -- | Whether an item kind is a traditional subordinate that can be
 -- filtered by export subordinate restrictions.
 isTraditionalSubordinate :: ItemKind.ItemKind -> Bool
@@ -694,7 +682,7 @@ declarationsContents exports items =
             [ li
             | li <- topLevelItems,
               not (Set.member (itemNatKey li) used),
-              isAlwaysVisible (Item.kind (Located.value li))
+              Item.visibility (Located.value li) == Visibility.Implicit
             ]
           (html, keys) =
             foldr
@@ -727,7 +715,7 @@ declarationsContents exports items =
             [ li
             | li <- topLevelItems,
               not (Set.member (itemNatKey li) used),
-              not (isAlwaysVisible (Item.kind (Located.value li)))
+              Item.visibility (Located.value li) /= Visibility.Implicit
             ]
        in if null unexported
             then []

--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -46,7 +46,6 @@ import qualified Scrod.Core.PackageName as PackageName
 import qualified Scrod.Core.Picture as Picture
 import qualified Scrod.Core.Section as Section
 import qualified Scrod.Core.Since as Since
-import qualified Scrod.Core.Subordinates as Subordinates
 import qualified Scrod.Core.Table as Table
 import qualified Scrod.Core.TableCell as TableCell
 import qualified Scrod.Core.Version as Version
@@ -480,17 +479,6 @@ extensionUrlPaths =
       ("ViewPatterns", "exts/view_patterns.html#extension-ViewPatterns")
     ]
 
--- | Whether an item kind is a traditional subordinate that can be
--- filtered by export subordinate restrictions.
-isTraditionalSubordinate :: ItemKind.ItemKind -> Bool
-isTraditionalSubordinate k = case k of
-  ItemKind.DataConstructor -> True
-  ItemKind.GADTConstructor -> True
-  ItemKind.RecordField -> True
-  ItemKind.ClassMethod -> True
-  ItemKind.DefaultMethodSignature -> True
-  _ -> False
-
 -- Declarations section
 
 declarationsContents :: Maybe [Export.Export] -> [Located.Located Item.Item] -> [Content.Content Element.Element]
@@ -552,8 +540,7 @@ declarationsContents exports items =
     exportDrivenDeclarations es =
       let (exportedHtml, usedAfterExports) = walkExports es Set.empty
           (alwaysVisibleHtml, usedAfterVisible) = renderAlwaysVisible usedAfterExports
-          usedAfterComplete = handleCompletePragmas usedAfterVisible
-          unexportedHtml = renderUnexported usedAfterComplete
+          unexportedHtml = renderUnexported usedAfterVisible
        in element "details" [("open", "open")] $
             element
               "summary"
@@ -572,14 +559,13 @@ declarationsContents exports items =
       Export.Identifier ident ->
         let exportName = ExportIdentifier.name ident
             name = ExportName.name exportName
-            subs = ExportIdentifier.subordinates ident
             exportMeta =
               foldMap (List.singleton . warningContent) (ExportIdentifier.warning ident)
                 <> foldMap docContents (ExportIdentifier.doc ident)
          in case Map.lookup name nameMap of
               Just li
                 | not (Set.member (itemNatKey li) used) ->
-                    let (here, newKeys) = renderExportedItem subs li
+                    let (here, newKeys) = renderExportedItem li
                         (rest, used') = walkExports es (Set.union newKeys used)
                      in (here <> exportMeta <> rest, used')
               Just _ ->
@@ -627,11 +613,11 @@ declarationsContents exports items =
             (rest, used') = walkExports es used
          in (here <> rest, used')
 
-    renderExportedItem :: Maybe Subordinates.Subordinates -> Located.Located Item.Item -> ([Content.Content Element.Element], Set.Set Natural.Natural)
-    renderExportedItem subs li =
+    renderExportedItem :: Located.Located Item.Item -> ([Content.Content Element.Element], Set.Set Natural.Natural)
+    renderExportedItem li =
       let k = itemNatKey li
           allChildren = Map.findWithDefault [] k childrenMap
-          visibleChildren = filter (shouldShowChild subs) allChildren
+          visibleChildren = filter (\c -> Item.visibility (Located.value c) /= Visibility.Unexported) allChildren
           (childHtml, childKeys) =
             foldr
               ( \c (accHtml, accKeys) ->
@@ -662,20 +648,6 @@ declarationsContents exports items =
             Set.insert k childKeys
           )
 
-    shouldShowChild :: Maybe Subordinates.Subordinates -> Located.Located Item.Item -> Bool
-    shouldShowChild subs li =
-      let item = Located.value li
-       in not (isTraditionalSubordinate (Item.kind item))
-            || case subs of
-              Nothing -> False
-              Just (Subordinates.MkSubordinates True _) -> True
-              Just (Subordinates.MkSubordinates False explicit) ->
-                case Item.name item of
-                  Nothing -> False
-                  Just n -> Set.member (ItemName.unwrap n) explicitNames
-                    where
-                      explicitNames = Set.fromList $ fmap ExportName.name explicit
-
     renderAlwaysVisible :: Set.Set Natural.Natural -> ([Content.Content Element.Element], Set.Set Natural.Natural)
     renderAlwaysVisible used =
       let visible =
@@ -693,21 +665,6 @@ declarationsContents exports items =
               ([], used)
               visible
        in (html, keys)
-
-    handleCompletePragmas :: Set.Set Natural.Natural -> Set.Set Natural.Natural
-    handleCompletePragmas used =
-      foldr
-        ( \li acc ->
-            let k = itemNatKey li
-                cs = Map.findWithDefault [] k childrenMap
-             in if Item.kind (Located.value li) == ItemKind.CompletePragma
-                  && not (null cs)
-                  && all (\c -> Set.member (itemNatKey c) acc) cs
-                  then Set.insert k acc
-                  else acc
-        )
-        used
-        topLevelItems
 
     renderUnexported :: Set.Set Natural.Natural -> [Content.Content Element.Element]
     renderUnexported used =

--- a/source/library/Scrod/Core/Item.hs
+++ b/source/library/Scrod/Core/Item.hs
@@ -10,6 +10,7 @@ import qualified Scrod.Core.ItemKey as ItemKey
 import qualified Scrod.Core.ItemKind as ItemKind
 import qualified Scrod.Core.ItemName as ItemName
 import qualified Scrod.Core.Since as Since
+import qualified Scrod.Core.Visibility as Visibility
 import qualified Scrod.Json.ToJson as ToJson
 import qualified Scrod.Schema as Schema
 
@@ -20,7 +21,8 @@ data Item = MkItem
     name :: Maybe ItemName.ItemName,
     documentation :: Doc.Doc,
     since :: Maybe Since.Since,
-    signature :: Maybe Text.Text
+    signature :: Maybe Text.Text,
+    visibility :: Visibility.Visibility
   }
   deriving (Eq, Generics.Generic, Ord, Show)
   deriving (ToJson.ToJson, Schema.ToSchema) via Generics.Generically Item

--- a/source/library/Scrod/Core/ItemKind.hs
+++ b/source/library/Scrod/Core/ItemKind.hs
@@ -87,3 +87,15 @@ data ItemKind
     Argument
   deriving (Eq, Generics.Generic, Ord, Show)
   deriving (ToJson.ToJson, Schema.ToSchema) via Generics.Generically ItemKind
+
+-- | Whether an item kind is a traditional subordinate that can be
+-- filtered by export subordinate restrictions (e.g. @Foo(Bar)@ or
+-- @Foo(..)@).
+isTraditionalSubordinate :: ItemKind -> Bool
+isTraditionalSubordinate k = case k of
+  DataConstructor -> True
+  GADTConstructor -> True
+  RecordField -> True
+  ClassMethod -> True
+  DefaultMethodSignature -> True
+  _ -> False

--- a/source/library/Scrod/Core/Visibility.hs
+++ b/source/library/Scrod/Core/Visibility.hs
@@ -9,13 +9,10 @@ import qualified Scrod.Schema as Schema
 
 -- | The visibility of an item with respect to the module's export list.
 data Visibility
-  = -- | Directly named in the export list (including subordinates named
-    -- explicitly like @Foo(Bar, Baz)@), or every top-level item when
-    -- there is no export list.
+  = -- | In the export list (directly named, via subordinates like
+    -- @Foo(Bar)@, or via wildcard like @Foo(..)@), or every top-level
+    -- item when there is no export list.
     Exported
-  | -- | Visible because a parent is exported with a @(..)@ wildcard
-    -- (e.g. constructors via @Foo(..)@, class methods, record fields).
-    Wildcard
   | -- | Always visible regardless of the export list (class instances,
     -- standalone deriving, derived instances, rules, defaults,
     -- annotations, splices).

--- a/source/library/Scrod/Core/Visibility.hs
+++ b/source/library/Scrod/Core/Visibility.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+
+module Scrod.Core.Visibility where
+
+import qualified GHC.Generics as Generics
+import qualified Scrod.Json.ToJson as ToJson
+import qualified Scrod.Schema as Schema
+
+-- | The visibility of an item with respect to the module's export list.
+data Visibility
+  = -- | Directly named in the export list (including subordinates named
+    -- explicitly like @Foo(Bar, Baz)@), or every top-level item when
+    -- there is no export list.
+    Exported
+  | -- | Visible because a parent is exported with a @(..)@ wildcard
+    -- (e.g. constructors via @Foo(..)@, class methods, record fields).
+    Wildcard
+  | -- | Always visible regardless of the export list (class instances,
+    -- standalone deriving, derived instances, rules, defaults,
+    -- annotations, splices).
+    Implicit
+  | -- | Not in the export list.
+    Unexported
+  deriving (Eq, Generics.Generic, Ord, Show)
+  deriving (ToJson.ToJson, Schema.ToSchema) via Generics.Generically Visibility


### PR DESCRIPTION
## Summary
- Adds `Scrod.Core.Visibility` with three constructors: `Exported`, `Implicit`, `Unexported`
- Adds a `visibility` field to `Item`, computed in `FromGhc` based on the module's export list
- Moves `isAlwaysVisible` from `ToHtml` into `FromGhc`
- Moves `isTraditionalSubordinate` from `ToHtml` to `ItemKind`
- Computes child visibility based on export subordinate restrictions (`Foo(..)`, `Foo(Bar)`, `Foo`)
- Replaces `shouldShowChild` in `ToHtml` with a simple `visibility /= Unexported` check
- Treats `CompletePragma` as always implicit (like class instances)
- Removes `handleCompletePragmas` from `ToHtml`

## Test plan
- [x] All 771 tests pass
- [x] Verified JSON output for all visibility cases: exported, unexported, implicit, wildcard-exported, no-export-list
- [x] Verified subordinate export cases: `Foo(Bar)`, `Foo(..)`, `Foo` with no subordinates

🤖 Generated with [Claude Code](https://claude.com/claude-code)