### PR TITLE
Eliminate Module.exports by absorbing export ordering into items

### DIFF
--- a/scrod.cabal
+++ b/scrod.cabal
@@ -93,6 +93,7 @@ library
     Scrod.Convert.FromGhc.CompleteParents
     Scrod.Convert.FromGhc.Constructors
     Scrod.Convert.FromGhc.Doc
+    Scrod.Convert.FromGhc.ExportOrdering
     Scrod.Convert.FromGhc.Exports
     Scrod.Convert.FromGhc.FamilyInstanceParents
     Scrod.Convert.FromGhc.FixityParents

--- a/source/library/Scrod/Convert/FromGhc/ExportOrdering.hs
+++ b/source/library/Scrod/Convert/FromGhc/ExportOrdering.hs
@@ -214,11 +214,10 @@ mkUnresolvedExport ident nextKey =
         Just ExportNameKind.Pattern -> Just (Text.pack "pattern")
         Just ExportNameKind.Type -> Just (Text.pack "type")
         Nothing -> Nothing
-      doc = Maybe.fromMaybe Doc.Empty (ExportIdentifier.doc ident)
    in ( mkSyntheticItem
           nextKey
           (Just (ItemName.MkItemName name))
-          doc
+          Doc.Empty
           namespaceSig
           ItemKind.UnresolvedExport,
         nextKey + 1

--- a/source/library/Scrod/Convert/FromGhc/ExportOrdering.hs
+++ b/source/library/Scrod/Convert/FromGhc/ExportOrdering.hs
@@ -1,0 +1,267 @@
+-- | Reorder items according to the module's export list.
+--
+-- When an export list is present, items are reordered so that exported
+-- items come first (in export-list order), followed by implicit items,
+-- then unexported items. Export-list-only entries (section headings,
+-- inline docs, re-exports with no matching declaration) become
+-- synthetic items.
+--
+-- When no export list is present, items are returned unchanged.
+module Scrod.Convert.FromGhc.ExportOrdering (reorderByExports) where
+
+import qualified Data.Map as Map
+import qualified Data.Maybe as Maybe
+import qualified Data.Set as Set
+import qualified Data.Text as Text
+import qualified Numeric.Natural as Natural
+import qualified Scrod.Core.Category as Category
+import qualified Scrod.Core.Column as Column
+import qualified Scrod.Core.Doc as Doc
+import qualified Scrod.Core.Export as Export
+import qualified Scrod.Core.ExportIdentifier as ExportIdentifier
+import qualified Scrod.Core.ExportName as ExportName
+import qualified Scrod.Core.ExportNameKind as ExportNameKind
+import qualified Scrod.Core.Item as Item
+import qualified Scrod.Core.ItemKey as ItemKey
+import qualified Scrod.Core.ItemKind as ItemKind
+import qualified Scrod.Core.ItemName as ItemName
+import qualified Scrod.Core.Line as Line
+import qualified Scrod.Core.Located as Located
+import qualified Scrod.Core.Location as Location
+import qualified Scrod.Core.Section as Section
+import qualified Scrod.Core.Visibility as Visibility
+import qualified Scrod.Core.Warning as Warning
+
+-- | Reorder items according to the module's export list.
+--
+-- When @Nothing@, return items unchanged. When @Just exports@,
+-- reorder items to match the export list and create synthetic items
+-- for export-list-only entries (sections, docs, re-exports).
+reorderByExports ::
+  Maybe [Export.Export] ->
+  [Located.Located Item.Item] ->
+  [Located.Located Item.Item]
+reorderByExports Nothing items = items
+reorderByExports (Just []) items = items
+reorderByExports (Just exports) items =
+  let nameMap = topLevelNameMap items
+      nextKey = nextItemKey items
+      (exportedItems, usedKeys, _) = walkExports exports nameMap Set.empty nextKey
+      implicitItems = collectImplicit usedKeys items
+      usedKeys2 = foldr (Set.insert . Item.key . Located.value) usedKeys implicitItems
+      unexportedItems = collectUnexported usedKeys2 items
+      childItems = filter (Maybe.isJust . Item.parentKey . Located.value) items
+   in exportedItems <> implicitItems <> unexportedItems <> childItems
+
+-- | Build a map from top-level item names to located items.
+topLevelNameMap :: [Located.Located Item.Item] -> Map.Map Text.Text (Located.Located Item.Item)
+topLevelNameMap items =
+  Map.fromList
+    [ (ItemName.unwrap n, li)
+    | li <- items,
+      Maybe.isNothing (Item.parentKey (Located.value li)),
+      Just n <- [Item.name (Located.value li)]
+    ]
+
+-- | Compute the next available item key (one past the maximum).
+nextItemKey :: [Located.Located Item.Item] -> Natural.Natural
+nextItemKey [] = 0
+nextItemKey items = 1 + maximum (fmap (ItemKey.unwrap . Item.key . Located.value) items)
+
+-- | Walk the export list, emitting items in export order. The @used@
+-- set tracks item keys already emitted to avoid duplicates. Returns
+-- the emitted items, the final used set, and the next available
+-- synthetic key.
+walkExports ::
+  [Export.Export] ->
+  Map.Map Text.Text (Located.Located Item.Item) ->
+  Set.Set ItemKey.ItemKey ->
+  Natural.Natural ->
+  ([Located.Located Item.Item], Set.Set ItemKey.ItemKey, Natural.Natural)
+walkExports [] _ used nextKey = ([], used, nextKey)
+walkExports (e : es) nameMap used nextKey = case e of
+  Export.Identifier ident ->
+    let name = ExportName.name (ExportIdentifier.name ident)
+     in case Map.lookup name nameMap of
+          Just li
+            | not (Set.member (Item.key (Located.value li)) used) ->
+                let meta = exportMetadataItems ident nextKey
+                    nextKey2 = nextKey + fromIntegral (length meta)
+                    used2 = Set.insert (Item.key (Located.value li)) used
+                    (rest, used3, nextKey3) = walkExports es nameMap used2 nextKey2
+                 in (li : meta <> rest, used3, nextKey3)
+          Just _ ->
+            -- Duplicate export: emit only metadata, skip the item.
+            let meta = exportMetadataItems ident nextKey
+                nextKey2 = nextKey + fromIntegral (length meta)
+                (rest, used2, nextKey3) = walkExports es nameMap used nextKey2
+             in (meta <> rest, used2, nextKey3)
+          Nothing ->
+            let (unresolvedItem, nextKey2) = mkUnresolvedExport ident nextKey
+                (rest, used2, nextKey3) = walkExports es nameMap used nextKey2
+             in (unresolvedItem : rest, used2, nextKey3)
+  Export.Group section ->
+    let (sectionItem, nextKey2) = mkSectionItem section nextKey
+        (rest, used2, nextKey3) = walkExports es nameMap used nextKey2
+     in (sectionItem : rest, used2, nextKey3)
+  Export.Doc doc ->
+    let (docItem, nextKey2) = mkDocItem doc nextKey
+        (rest, used2, nextKey3) = walkExports es nameMap used nextKey2
+     in (docItem : rest, used2, nextKey3)
+  Export.DocNamed name ->
+    let (docItem, nextKey2) = mkDocNamedItem name nextKey
+        (rest, used2, nextKey3) = walkExports es nameMap used nextKey2
+     in (docItem : rest, used2, nextKey3)
+
+-- | Collect implicit items that haven't been used yet.
+collectImplicit ::
+  Set.Set ItemKey.ItemKey ->
+  [Located.Located Item.Item] ->
+  [Located.Located Item.Item]
+collectImplicit usedKeys =
+  filter
+    ( \li ->
+        let item = Located.value li
+         in Maybe.isNothing (Item.parentKey item)
+              && Item.visibility item == Visibility.Implicit
+              && not (Set.member (Item.key item) usedKeys)
+    )
+
+-- | Collect unexported top-level items that haven't been used.
+collectUnexported ::
+  Set.Set ItemKey.ItemKey ->
+  [Located.Located Item.Item] ->
+  [Located.Located Item.Item]
+collectUnexported usedKeys =
+  filter
+    ( \li ->
+        let item = Located.value li
+         in Maybe.isNothing (Item.parentKey item)
+              && Item.visibility item == Visibility.Unexported
+              && not (Set.member (Item.key item) usedKeys)
+    )
+
+-- | Create synthetic items for export-level doc and/or warning metadata
+-- on an identifier.
+exportMetadataItems :: ExportIdentifier.ExportIdentifier -> Natural.Natural -> [Located.Located Item.Item]
+exportMetadataItems ident startKey =
+  let warningItems = case ExportIdentifier.warning ident of
+        Nothing -> []
+        Just w ->
+          [ mkSyntheticItem
+              startKey
+              Nothing
+              (warningToDoc w)
+              Nothing
+              ItemKind.DocumentationChunk
+          ]
+      warningCount :: Natural.Natural
+      warningCount = fromIntegral (length warningItems)
+      docItems = case ExportIdentifier.doc ident of
+        Nothing -> []
+        Just d ->
+          [ mkSyntheticItem
+              (startKey + warningCount)
+              Nothing
+              d
+              Nothing
+              ItemKind.DocumentationChunk
+          ]
+   in warningItems <> docItems
+
+-- | Convert a warning to a doc paragraph for inline display.
+warningToDoc :: Warning.Warning -> Doc.Doc
+warningToDoc w =
+  Doc.Paragraph
+    . Doc.Bold
+    . Doc.Append
+    $ [ Doc.String (Text.pack "Warning"),
+        Doc.String (Text.pack " ("),
+        Doc.String (Category.unwrap (Warning.category w)),
+        Doc.String (Text.pack "): "),
+        Doc.String (Warning.value w)
+      ]
+
+-- | Create an item for an unresolved export (no matching declaration).
+mkUnresolvedExport ::
+  ExportIdentifier.ExportIdentifier ->
+  Natural.Natural ->
+  (Located.Located Item.Item, Natural.Natural)
+mkUnresolvedExport ident nextKey =
+  let exportName = ExportIdentifier.name ident
+      name = ExportName.name exportName
+      namespaceSig = case ExportName.kind exportName of
+        Just ExportNameKind.Module -> Just (Text.pack "module")
+        Just ExportNameKind.Pattern -> Just (Text.pack "pattern")
+        Just ExportNameKind.Type -> Just (Text.pack "type")
+        Nothing -> Nothing
+      doc = Maybe.fromMaybe Doc.Empty (ExportIdentifier.doc ident)
+   in ( mkSyntheticItem
+          nextKey
+          (Just (ItemName.MkItemName name))
+          doc
+          namespaceSig
+          ItemKind.UnresolvedExport,
+        nextKey + 1
+      )
+
+-- | Create a section heading item from an export group.
+mkSectionItem ::
+  Section.Section ->
+  Natural.Natural ->
+  (Located.Located Item.Item, Natural.Natural)
+mkSectionItem section nextKey =
+  let hdr = Section.header section
+      doc = Doc.Header hdr
+   in ( mkSyntheticItem nextKey Nothing doc Nothing ItemKind.DocumentationChunk,
+        nextKey + 1
+      )
+
+-- | Create a documentation item from an inline export doc.
+mkDocItem ::
+  Doc.Doc ->
+  Natural.Natural ->
+  (Located.Located Item.Item, Natural.Natural)
+mkDocItem doc nextKey =
+  ( mkSyntheticItem nextKey Nothing doc Nothing ItemKind.DocumentationChunk,
+    nextKey + 1
+  )
+
+-- | Create a documentation item from an unresolved named doc reference.
+mkDocNamedItem ::
+  Text.Text ->
+  Natural.Natural ->
+  (Located.Located Item.Item, Natural.Natural)
+mkDocNamedItem _name nextKey =
+  ( mkSyntheticItem nextKey Nothing Doc.Empty Nothing ItemKind.DocumentationChunk,
+    nextKey + 1
+  )
+
+-- | Create a synthetic item with a given key, not tied to any source
+-- location.
+mkSyntheticItem ::
+  Natural.Natural ->
+  Maybe ItemName.ItemName ->
+  Doc.Doc ->
+  Maybe Text.Text ->
+  ItemKind.ItemKind ->
+  Located.Located Item.Item
+mkSyntheticItem key itemName doc sig kind =
+  Located.MkLocated
+    { Located.location =
+        Location.MkLocation
+          { Location.line = Line.MkLine 0,
+            Location.column = Column.MkColumn 0
+          },
+      Located.value =
+        Item.MkItem
+          { Item.key = ItemKey.MkItemKey key,
+            Item.kind = kind,
+            Item.parentKey = Nothing,
+            Item.name = itemName,
+            Item.documentation = doc,
+            Item.since = Nothing,
+            Item.signature = sig,
+            Item.visibility = Visibility.Exported
+          }
+    }

--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -495,7 +495,7 @@ declarationsContents items =
     topLevelItems :: [Located.Located Item.Item]
     topLevelItems = filter (Maybe.isNothing . Item.parentKey . Located.value) items
 
-    -- \| Render a top-level item. DocumentationChunk items without a
+    -- Render a top-level item. DocumentationChunk items without a
     -- name render their documentation inline (for section headings and
     -- export docs). UnresolvedExport items render with a namespace
     -- prefix and optional re-export badge. All other items render as

--- a/source/library/Scrod/Core/ItemKind.hs
+++ b/source/library/Scrod/Core/ItemKind.hs
@@ -8,6 +8,11 @@ import qualified Scrod.Json.ToJson as ToJson
 import qualified Scrod.Schema as Schema
 
 -- | The kind of Haskell declaration an Item represents.
+--
+-- This type must remain a simple enumeration: no constructor should
+-- carry arguments. Renderers and predicates pattern-match on it
+-- exhaustively, and keeping it argument-free avoids coupling the
+-- core representation to presentation details.
 data ItemKind
   = -- | Function binding: @f x = expr@
     Function
@@ -85,6 +90,9 @@ data ItemKind
     DocumentationChunk
   | -- | Positional argument of a function or constructor
     Argument
+  | -- | Export list entry with no matching declaration in this module
+    -- (e.g. a module re-export or an unresolved name).
+    UnresolvedExport
   deriving (Eq, Generics.Generic, Ord, Show)
   deriving (ToJson.ToJson, Schema.ToSchema) via Generics.Generically ItemKind
 

--- a/source/library/Scrod/Core/Module.hs
+++ b/source/library/Scrod/Core/Module.hs
@@ -4,7 +4,6 @@ import qualified Data.Map as Map
 import qualified Data.Proxy as Proxy
 import qualified Data.Text as Text
 import qualified Scrod.Core.Doc as Doc
-import qualified Scrod.Core.Export as Export
 import qualified Scrod.Core.Extension as Extension
 import qualified Scrod.Core.Import as Import
 import qualified Scrod.Core.Item as Item
@@ -27,7 +26,6 @@ data Module = MkModule
     signature :: Bool,
     name :: Maybe (Located.Located ModuleName.ModuleName),
     warning :: Maybe Warning.Warning,
-    exports :: Maybe [Export.Export],
     imports :: [Import.Import],
     items :: [Located.Located Item.Item]
   }
@@ -45,7 +43,6 @@ instance ToJson.ToJson Module where
           ("signature", ToJson.toJson $ signature m),
           ("name", ToJson.toJson $ name m),
           ("warning", ToJson.toJson $ warning m),
-          ("exports", ToJson.toJson $ exports m),
           ("imports", ToJson.toJson $ imports m),
           ("items", ToJson.toJson $ items m)
         ]
@@ -65,7 +62,6 @@ instance Schema.ToSchema Module where
     sinceS <- Schema.toSchema (Proxy.Proxy :: Proxy.Proxy Since.Since)
     nameS <- Schema.toSchema (Proxy.Proxy :: Proxy.Proxy (Located.Located ModuleName.ModuleName))
     warningS <- Schema.toSchema (Proxy.Proxy :: Proxy.Proxy Warning.Warning)
-    exportsS <- Schema.toSchema (Proxy.Proxy :: Proxy.Proxy [Export.Export])
     importsS <- Schema.toSchema (Proxy.Proxy :: Proxy.Proxy [Import.Import])
     itemsS <- Schema.toSchema (Proxy.Proxy :: Proxy.Proxy [Located.Located Item.Item])
     let allProps =
@@ -77,7 +73,6 @@ instance Schema.ToSchema Module where
             ("signature", Json.object [("type", Json.string "boolean")]),
             ("name", Schema.unwrap nameS),
             ("warning", Schema.unwrap warningS),
-            ("exports", Schema.unwrap exportsS),
             ("imports", Schema.unwrap importsS),
             ("items", Schema.unwrap itemsS)
           ]

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -758,6 +758,57 @@ spec s = Spec.describe s "integration" $ do
           ("/items/1/value/kind/type", "\"Function\"")
         ]
 
+    Spec.it s "creates metadata items for export-level doc comments" $ do
+      check
+        s
+        """
+        module M
+          ( x -- ^ export doc
+          ) where
+        x = ()
+        """
+        [ ("/items/0/value/name", "\"x\""),
+          ("/items/1/value/kind/type", "\"DocumentationChunk\""),
+          ("/items/1/value/documentation/type", "\"Paragraph\""),
+          ("/items/1/value/documentation/value/value", "\"export doc\"")
+        ]
+
+    Spec.it s "creates metadata items for export-level warnings" $ do
+      check
+        s
+        """
+        module M ( {-# warning "deprecated" #-} x ) where
+        x = ()
+        """
+        [ ("/items/0/value/name", "\"x\""),
+          ("/items/1/value/kind/type", "\"DocumentationChunk\""),
+          ("/items/1/value/documentation/type", "\"Paragraph\"")
+        ]
+
+    Spec.it s "deduplicates repeated exports" $ do
+      check
+        s
+        """
+        module M ( x, x ) where
+        x = ()
+        """
+        [ ("/items/0/value/name", "\"x\""),
+          ("/items/0/value/kind/type", "\"Function\"")
+        ]
+
+    Spec.it s "places implicit items after exported items" $ do
+      check
+        s
+        """
+        module M ( MyClass ) where
+        class MyClass a
+        instance MyClass Int
+        """
+        [ ("/items/0/value/name", "\"MyClass\""),
+          ("/items/0/value/visibility/type", "\"Exported\""),
+          ("/items/1/value/visibility/type", "\"Implicit\"")
+        ]
+
   Spec.describe s "named chunks" $ do
     Spec.it s "creates items for unreferenced named chunks" $ do
       check

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -3208,4 +3208,3 @@ checkHtml s arguments input = do
   output <- either (Spec.assertFailure s) pure result
   Monad.when (null $ Builder.toString output) $
     Spec.assertFailure s "expected non-empty HTML output"
-


### PR DESCRIPTION
## Summary

- Items in `Module.items` are now reordered to match the export list, and export-list-only entries (sections, docs, re-exports) become synthetic items
- Removes the `exports` field from `Module` entirely, simplifying the core surface and letting both renderers see items in presentation order without duplicating ordering logic
- Adds `UnresolvedExport` to `ItemKind` for export entries with no matching declaration
- Adds `FromGhc.ExportOrdering` module with `reorderByExports`
- Simplifies `ToHtml.declarationsContents` (~200 lines of export-walking code → ~60 lines of visibility-based partitioning)
- Migrates export-driven HTML tests to JSON assertions on item ordering

## Test plan

- [x] `cabal build` succeeds
- [x] `cabal test` passes (758 tests)
- [x] Verified export ordering, section headings, inline docs, module re-exports, missing declarations, named chunk resolution, export-level metadata, duplicate deduplication, and implicit item ordering via JSON tests
- [x] HTML smoke test retained

🤖 Generated with [Claude Code](https://claude.com/claude-code)