### PR TITLE
Add $schema reference to JSON output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,7 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     needs:
+      - build
       - meta
       - wasm
     concurrency:
@@ -199,6 +200,11 @@ jobs:
         with:
           node-version: 22
       - run: extra/github-pages/build.sh
+      - uses: actions/download-artifact@v7
+        with:
+          name: ${{ needs.meta.outputs.name }}-${{ github.sha }}-Linux
+      - run: tar --extract --file artifact.tar --strip-components=1 artifact/schema.json
+      - run: cp schema.json extra/github-pages/dist/
       - uses: actions/upload-pages-artifact@v4
         with:
           path: extra/github-pages/dist/

--- a/source/library/Scrod/Core/Module.hs
+++ b/source/library/Scrod/Core/Module.hs
@@ -34,6 +34,7 @@ data Module = MkModule
 instance ToJson.ToJson Module where
   toJson m =
     Json.object
+      . (("$schema", Json.string "https://scrod.fyi/schema.json") :)
       . filter (\(_, v) -> v /= Json.null)
       $ [ ("version", ToJson.toJson $ version m),
           ("language", ToJson.toJson $ language m),
@@ -65,7 +66,8 @@ instance Schema.ToSchema Module where
     importsS <- Schema.toSchema (Proxy.Proxy :: Proxy.Proxy [Import.Import])
     itemsS <- Schema.toSchema (Proxy.Proxy :: Proxy.Proxy [Located.Located Item.Item])
     let allProps =
-          [ ("version", Schema.unwrap versionS),
+          [ ("$schema", Json.object [("type", Json.string "string"), ("format", Json.string "uri")]),
+            ("version", Schema.unwrap versionS),
             ("language", Schema.unwrap languageS),
             ("extensions", Schema.unwrap extensionsS),
             ("documentation", Schema.unwrap documentationS),
@@ -77,7 +79,8 @@ instance Schema.ToSchema Module where
             ("items", Schema.unwrap itemsS)
           ]
     let reqNames =
-          [ Json.string "version",
+          [ Json.string "$schema",
+            Json.string "version",
             Json.string "extensions",
             Json.string "documentation",
             Json.string "signature",

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -28,6 +28,10 @@ spec s = Spec.describe s "integration" $ do
         ("/items", "[]")
       ]
 
+  Spec.describe s "$schema" $ do
+    Spec.it s "is present" $ do
+      check s "" [("/$schema", "\"https://scrod.fyi/schema.json\"")]
+
   Spec.describe s "version" $ do
     Spec.it s "works" $ do
       -- Note that we don't want this test to be too specific, otherwise we'd


### PR DESCRIPTION
Fixes #275.

## Summary

Adds a `$schema` field to the top-level JSON output pointing to `https://scrod.fyi/schema.json`. This lets consumers of the JSON output discover and validate against the schema.

Changes:
- Added `$schema` as the first key in the `ToJson Module` instance
- Updated the `ToSchema Module` instance to include `$schema` as a required property with `string`/`uri` type
- Added an integration test verifying the field is present