### PR TITLE
Add --guess-extensions CLI flag

### DIFF
--- a/source/library/Scrod/Executable/Flag.hs
+++ b/source/library/Scrod/Executable/Flag.hs
@@ -11,6 +11,7 @@ import qualified System.Console.GetOpt as GetOpt
 data Flag
   = Format String
   | GhcOption String
+  | GuessExtensions (Maybe String)
   | Help (Maybe String)
   | Literate (Maybe String)
   | Schema (Maybe String)
@@ -33,6 +34,7 @@ optDescrs =
     GetOpt.Option [] ["version"] (GetOpt.OptArg Version "BOOL") "Shows the version.",
     GetOpt.Option [] ["format"] (GetOpt.ReqArg Format "FORMAT") "Sets the output format (json or html).",
     GetOpt.Option [] ["ghc-option"] (GetOpt.ReqArg GhcOption "OPTION") "Sets a GHC option (e.g. -XOverloadedStrings).",
+    GetOpt.Option [] ["guess-extensions"] (GetOpt.OptArg GuessExtensions "BOOL") "Guesses language extensions when parsing fails.",
     GetOpt.Option [] ["literate"] (GetOpt.OptArg Literate "BOOL") "Treats the input as Literate Haskell.",
     GetOpt.Option [] ["schema"] (GetOpt.OptArg Schema "BOOL") "Shows the JSON output schema.",
     GetOpt.Option [] ["signature"] (GetOpt.OptArg Signature "BOOL") "Treats the input as a Backpack signature."
@@ -94,6 +96,13 @@ spec s = do
 
       Spec.it s "works with an argument" $ do
         Spec.assertEq s (fromArguments ["--version="]) $ Just [Version $ Just ""]
+
+    Spec.describe s "guess-extensions" $ do
+      Spec.it s "works with no argument" $ do
+        Spec.assertEq s (fromArguments ["--guess-extensions"]) $ Just [GuessExtensions Nothing]
+
+      Spec.it s "works with an argument" $ do
+        Spec.assertEq s (fromArguments ["--guess-extensions="]) $ Just [GuessExtensions $ Just ""]
 
     Spec.describe s "ghc-option" $ do
       Spec.it s "works with an argument" $ do

--- a/source/library/Scrod/Executable/Main.hs
+++ b/source/library/Scrod/Executable/Main.hs
@@ -65,7 +65,8 @@ mainWith name arguments myGetContents = ExceptT.runExceptT $ do
       else pure contents
   let isSignature = Config.signature config
   let ghcOpts = Foldable.toList (Config.ghcOptions config)
-  result <- Either.throw . Bifunctor.first userError $ Parse.parse isSignature ghcOpts source
+  let parser = if Config.guessExtensions config then Parse.parseGuessing else Parse.parse
+  result <- Either.throw . Bifunctor.first userError $ parser isSignature ghcOpts source
   module_ <- Either.throw . Bifunctor.first userError $ FromGhc.fromGhc isSignature result
   let convert = case Config.format config of
         Format.Json -> Json.encode . ToJson.toJson


### PR DESCRIPTION
Fixes #274.

## Summary

When parsing fails, `--guess-extensions` retries with all [stolen-syntax extensions](https://downloads.haskell.org/~ghc/9.14.1/docs/users_guide/exts/stolen_syntax.html) enabled:

- Arrows, BangPatterns, ExtendedLiterals, ForeignFunctionInterface, ImplicitParams, MagicHash, PatternSynonyms, QuasiQuotes, RecursiveDo, StaticPointers, TemplateHaskell, UnboxedTuples

This allows the web app and VSCode extension to pass `--guess-extensions` so that code using syntax-altering extensions (e.g. `$(splice)`, `0#`, `?x`) can be documented without requiring explicit `LANGUAGE` pragmas.

## Changes

- **`Scrod.Ghc.Parse`**: Added `parseGuessing` (tries normal parse, falls back to enabling all stolen-syntax extensions) and `stolenSyntaxExtensions` list.
- **`Scrod.Executable.Flag`**: Added `GuessExtensions (Maybe String)` flag (`--guess-extensions`).
- **`Scrod.Executable.Config`**: Added `guessExtensions :: Bool` field.
- **`Scrod.Executable.Main`**: Uses `parseGuessing` when the flag is set.
- Tests added for all new functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)