### PR TITLE
Update documentation for recent changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,8 +25,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for build commands, test filtering, linti
 
 ### Key module groups
 
-- **`Scrod.Core.*`** — Data types for the intermediate representation (Module, Item, Doc, Export, etc.). Each type lives in its own module with a `Mk`-prefixed constructor (e.g., `MkModule`, `MkItem`).
-- **`Scrod.Convert.FromGhc`** — Converts GHC AST into Scrod Core types. Largest and most complex module. Uses a `ConvertM` state monad that assigns auto-incrementing `ItemKey`s.
+- **`Scrod.Core.*`** — Data types for the intermediate representation (Module, Item, Doc, ItemKind, Visibility, etc.). Each type lives in its own module with a `Mk`-prefixed constructor (e.g., `MkModule`, `MkItem`). Items carry a `Visibility` field (`Exported`, `Implicit`, or `Unexported`) and are ordered in the `Module.items` list to reflect export-list order.
+- **`Scrod.Convert.FromGhc`** — Converts GHC AST into Scrod Core types. Uses a `ConvertM` state monad that assigns auto-incrementing `ItemKey`s. Has many submodules (`ExportOrdering`, `Visibility`, `ItemKind`, `Exports`, `Names`, etc.) that handle specific conversion concerns.
 - **`Scrod.Convert.FromHaddock`** — Converts Haddock doc strings into Scrod's `Doc` type.
 - **`Scrod.Convert.ToHtml`** — Renders Core types as self-contained HTML (Bootstrap 5 + KaTeX).
 - **`Scrod.Convert.ToJson`** — Renders Core types to JSON output.

--- a/README.md
+++ b/README.md
@@ -49,20 +49,24 @@ scrod --format html < MyModule.hs  # HTML output
 
 ```
 $ scrod --help
-scrod version 0.2026.2.11
+scrod version 0.2026.2.18
 <https://scrod.fyi>
 
-  -h[BOOL]  --help[=BOOL]       Shows the help.
-            --version[=BOOL]    Shows the version.
-            --format=FORMAT     Sets the output format (json or html).
-            --literate[=BOOL]   Treats the input as Literate Haskell.
-            --signature[=BOOL]  Treats the input as a Backpack signature.
+  -h[BOOL]  --help[=BOOL]           Shows the help.
+            --version[=BOOL]        Shows the version.
+            --format=FORMAT         Sets the output format (json or html).
+            --ghc-option=OPTION     Sets a GHC option (e.g. -XOverloadedStrings).
+            --literate[=BOOL]       Treats the input as Literate Haskell.
+            --schema[=BOOL]         Shows the JSON output schema.
+            --signature[=BOOL]      Treats the input as a Backpack signature.
 ```
 
 - **`-h`, `--help`**: Prints the help then exits.
 - **`--version`**: Prints the version then exits.
 - **`--format`**: Sets the output format. Either `json` (the default) or `html`.
+- **`--ghc-option`**: Passes an option to the GHC parser (e.g. `-XOverloadedStrings`). Can be given multiple times.
 - **`--literate`**: Treats the input as literate Haskell, either Bird or LaTeX style.
+- **`--schema`**: Prints the JSON output schema then exits.
 - **`--signature`**: Treats the input as a Backpack signature.
 
 Boolean flags accept an optional `=BOOL` argument (`True` or `False`). Without the argument, the flag is set to `True`. This lets you override earlier flags, e.g. `--literate --literate=False`.


### PR DESCRIPTION
## Summary

- **README.md**: Add `--ghc-option` and `--schema` to the `--help` output block and options prose list. Bump example version to `0.2026.2.18`.
- **CLAUDE.md**: Update `Scrod.Core.*` description to reflect `Visibility` field on items and export-list ordering (replacing removed `Module.exports`). Update `Scrod.Convert.FromGhc` description to mention submodule structure.

## Test plan

- [ ] Verify README `--help` block matches actual `scrod --help` output
- [ ] Verify CLAUDE.md accurately describes current architecture

🤖 Generated with [Claude Code](https://claude.com/claude-code)