### PR TITLE
Add OpenGraph and Twitter Card meta tags to web app

### DIFF
--- a/extra/github-pages/build.mjs
+++ b/extra/github-pages/build.mjs
@@ -70,7 +70,11 @@ const styleResult = await build({
 
 const styleFilename = entryOutput(styleResult.metafile);
 
-// Phase 5: Generate index.html with hashed references
+// Phase 5: Copy static assets
+
+await copyFile(join(root, 'og-image.svg'), join(dist, 'og-image.svg'));
+
+// Phase 6: Generate index.html with hashed references
 
 const html = await readFile(join(root, 'index.html'), 'utf8');
 const outputHtml = html

--- a/extra/github-pages/index.html
+++ b/extra/github-pages/index.html
@@ -15,7 +15,7 @@
   <meta name='twitter:title' content='Scrod'>
   <meta name='twitter:description' content='A Haskell documentation tool with a live editor'>
   <meta name='twitter:image' content='https://scrod.fyi/og-image.svg'>
-  <link rel='icon' href='og-image.svg'>
+  <link rel='icon' href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#x1f41f;</text></svg>">
   <link rel='stylesheet' href='https://esm.sh/bootstrap@5.3.8/dist/css/bootstrap.min.css'
     integrity='sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB' crossorigin='anonymous'>
   <link rel='stylesheet' href='style.css'>

--- a/extra/github-pages/index.html
+++ b/extra/github-pages/index.html
@@ -5,6 +5,14 @@
   <meta charset='utf-8'>
   <meta name='viewport' content='initial-scale = 1, width = device-width'>
   <title>Scrod</title>
+  <meta name='description' content='A Haskell documentation tool with a live editor'>
+  <meta property='og:title' content='Scrod'>
+  <meta property='og:description' content='A Haskell documentation tool with a live editor'>
+  <meta property='og:type' content='website'>
+  <meta property='og:url' content='https://tfausak.github.io/scrod/'>
+  <meta name='twitter:card' content='summary'>
+  <meta name='twitter:title' content='Scrod'>
+  <meta name='twitter:description' content='A Haskell documentation tool with a live editor'>
   <link rel='stylesheet' href='https://esm.sh/bootstrap@5.3.8/dist/css/bootstrap.min.css'
     integrity='sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB' crossorigin='anonymous'>
   <link rel='stylesheet' href='style.css'>

--- a/extra/github-pages/index.html
+++ b/extra/github-pages/index.html
@@ -9,7 +9,7 @@
   <meta property='og:title' content='Scrod'>
   <meta property='og:description' content='A Haskell documentation tool with a live editor'>
   <meta property='og:type' content='website'>
-  <meta property='og:url' content='https://tfausak.github.io/scrod/'>
+  <meta property='og:url' content='https://scrod.fyi'>
   <meta name='twitter:card' content='summary'>
   <meta name='twitter:title' content='Scrod'>
   <meta name='twitter:description' content='A Haskell documentation tool with a live editor'>
@@ -60,10 +60,12 @@
   </nav>
   <ul class='nav nav-tabs d-md-none px-3 pt-2 bg-body-tertiary' role='tablist'>
     <li class='nav-item' role='presentation'>
-      <button type='button' id='tab-input' class='nav-link active' role='tab' aria-selected='true' aria-controls='input-pane' tabindex='0'>Input</button>
+      <button type='button' id='tab-input' class='nav-link active' role='tab' aria-selected='true'
+        aria-controls='input-pane' tabindex='0'>Input</button>
     </li>
     <li class='nav-item' role='presentation'>
-      <button type='button' id='tab-output' class='nav-link' role='tab' aria-selected='false' aria-controls='output-pane' tabindex='-1'>Output</button>
+      <button type='button' id='tab-output' class='nav-link' role='tab' aria-selected='false'
+        aria-controls='output-pane' tabindex='-1'>Output</button>
     </li>
   </ul>
   <div id='panes' class='d-flex flex-grow-1 overflow-hidden'>

--- a/extra/github-pages/index.html
+++ b/extra/github-pages/index.html
@@ -15,7 +15,7 @@
   <meta name='twitter:title' content='Scrod'>
   <meta name='twitter:description' content='A Haskell documentation tool with a live editor'>
   <meta name='twitter:image' content='https://scrod.fyi/og-image.svg'>
-  <link rel='icon' href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#x1f41f;</text></svg>">
+  <link rel='icon' href='og-image.svg'>
   <link rel='stylesheet' href='https://esm.sh/bootstrap@5.3.8/dist/css/bootstrap.min.css'
     integrity='sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB' crossorigin='anonymous'>
   <link rel='stylesheet' href='style.css'>

--- a/extra/github-pages/index.html
+++ b/extra/github-pages/index.html
@@ -10,9 +10,12 @@
   <meta property='og:description' content='A Haskell documentation tool with a live editor'>
   <meta property='og:type' content='website'>
   <meta property='og:url' content='https://scrod.fyi'>
+  <meta property='og:image' content='https://scrod.fyi/og-image.svg'>
   <meta name='twitter:card' content='summary'>
   <meta name='twitter:title' content='Scrod'>
   <meta name='twitter:description' content='A Haskell documentation tool with a live editor'>
+  <meta name='twitter:image' content='https://scrod.fyi/og-image.svg'>
+  <link rel='icon' href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#x1f41f;</text></svg>">
   <link rel='stylesheet' href='https://esm.sh/bootstrap@5.3.8/dist/css/bootstrap.min.css'
     integrity='sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB' crossorigin='anonymous'>
   <link rel='stylesheet' href='style.css'>

--- a/extra/github-pages/og-image.svg
+++ b/extra/github-pages/og-image.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='1200' height='630' viewBox='0 0 1200 630'>
+  <rect width='1200' height='630' fill='#f8f9fa'/>
+  <text x='600' y='260' font-size='200' text-anchor='middle'>&#x1f41f;</text>
+  <text x='600' y='420' font-size='80' font-family='system-ui, sans-serif' font-weight='bold' text-anchor='middle' fill='#212529'>Scrod</text>
+  <text x='600' y='490' font-size='36' font-family='system-ui, sans-serif' text-anchor='middle' fill='#6c757d'>A Haskell documentation tool</text>
+</svg>


### PR DESCRIPTION
Fixes #280.

Adds OpenGraph (`og:title`, `og:description`, `og:type`, `og:url`) and Twitter Card (`twitter:card`, `twitter:title`, `twitter:description`) meta tags to the web app's `index.html`, along with a standard `meta description` tag. This enables rich link previews when the app URL is shared in Slack, Discord, and similar platforms.