### PR TITLE
Remove show/hide from declarations

### DIFF
--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -460,26 +460,17 @@ extensionUrlPaths =
 
 declarationsContents :: [Located.Located Item.Item] -> [Content.Content Element.Element]
 declarationsContents items =
-  [ element "h2" [] [Xml.string "Declarations"],
-    if null topLevelItems
-      then Xml.string "None."
+  element "h2" [] [Xml.string "Declarations"]
+    : if null topLevelItems
+      then [Xml.string "None."]
       else
         let (nonUnexported, unexported) = List.partition isNonUnexported topLevelItems
-         in element "details" [("open", "open")] $
-              element
-                "summary"
-                []
-                [ Xml.string "Show/hide ",
-                  Xml.string $ pluralize (length topLevelItems) "declaration",
-                  Xml.string "."
-                ]
-                : foldMap renderTopLevelItem nonUnexported
-                  <> if null unexported
-                    then []
-                    else
-                      element "h3" [] [Xml.string "Unexported"]
-                        : foldMap renderTopLevelItem unexported
-  ]
+         in foldMap renderTopLevelItem nonUnexported
+              <> if null unexported
+                then []
+                else
+                  element "h3" [] [Xml.string "Unexported"]
+                    : foldMap renderTopLevelItem unexported
   where
     isNonUnexported :: Located.Located Item.Item -> Bool
     isNonUnexported li = Item.visibility (Located.value li) /= Visibility.Unexported


### PR DESCRIPTION
## Summary
- Removes the `<details>`/`<summary>` show/hide toggle wrapper from the declarations section in HTML output
- Declarations are the primary content of the documentation, so there is no reason to allow hiding them
- Extensions and imports sections retain their show/hide toggles since they are secondary content

Fixes #284.

## Test plan
- [x] `cabal build` succeeds
- [x] All 769 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)