### PR TITLE
Don't render code block for unnamed arguments

### DIFF
--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -565,8 +565,10 @@ itemContent item children =
           $ [ element
                 "div"
                 []
-                [ element "code" [("class", "text-break")] [Xml.text . foldMap ItemName.unwrap . Item.name $ Located.value item]
-                ]
+                ( case Item.name $ Located.value item of
+                    Nothing -> []
+                    Just n -> [element "code" [("class", "text-break")] [Xml.text $ ItemName.unwrap n]]
+                )
             ]
             <> earlySignature
             <> [ element


### PR DESCRIPTION
## Summary
- When an argument item has no name, the card header now renders an empty `<div>` instead of a `<code>` element with empty text
- For example, `f::a->a` previously showed an empty `<code></code>` element for each argument; now it shows just an empty `<div>`

Fixes #285.

## Test plan
- [x] `cabal build` succeeds
- [x] All 769 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)