### PR TITLE
Show derived as signature for unstratified deriving

### DIFF
--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -896,7 +896,8 @@ extractDerivedTypeDocAndSince lSigTy =
 extractDerivStrategy ::
   Maybe (Syntax.LDerivStrategy Ghc.GhcPs) ->
   Maybe Text.Text
-extractDerivStrategy = fmap (Text.pack . Outputable.showSDocUnsafe . Outputable.ppr . SrcLoc.unLoc)
+extractDerivStrategy Nothing = Just (Text.pack "derived")
+extractDerivStrategy (Just s) = Just (Text.pack . Outputable.showSDocUnsafe . Outputable.ppr $ SrcLoc.unLoc s)
 
 -- | Extract named documentation chunks from module declarations.
 extractNamedDocChunks ::

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -1672,7 +1672,7 @@ spec s = Spec.describe s "integration" $ do
         "data R6 deriving Show"
         [ ("/items/1/value/kind/type", "\"DerivedInstance\""),
           ("/items/1/value/name", "\"Show\""),
-          ("/items/1/value/signature", "")
+          ("/items/1/value/signature", "\"derived\"")
         ]
 
     Spec.it s "data GADT deriving" $ do


### PR DESCRIPTION
## Summary
- When a deriving clause has no explicit strategy (e.g. `deriving Eq`), the instance signature now shows `:: derived` instead of being empty
- Instances with explicit strategies (`stock`, `newtype`, `anyclass`, `via`) continue to show those strategies as before

Fixes #287.

## Test plan
- [x] `cabal build` succeeds
- [x] All 769 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)