### PR TITLE
Only show argument items when any have documentation

### DIFF
--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -477,13 +477,16 @@ convertSigDeclM doc docSince lDecl sig = case sig of
   _ -> Maybe.maybeToList <$> convertDeclWithDocM Nothing doc docSince (Names.extractSigName sig) Nothing lDecl
 
 -- | Convert extracted argument data into child Argument items.
+-- Returns no items if none of the arguments have documentation.
 convertArguments ::
   Maybe ItemKey.ItemKey ->
   SrcLoc.SrcSpan ->
   [(Text.Text, Maybe (HsDoc.LHsDoc Ghc.GhcPs))] ->
   Internal.ConvertM [Located.Located Item.Item]
-convertArguments parentKey srcSpan args =
-  Maybe.catMaybes <$> traverse (convertOneArgument parentKey srcSpan) args
+convertArguments parentKey srcSpan args
+  | any (Maybe.isJust . snd) args =
+      Maybe.catMaybes <$> traverse (convertOneArgument parentKey srcSpan) args
+  | otherwise = pure []
 
 -- | Convert a single argument to an Argument item.
 convertOneArgument ::

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -2586,15 +2586,11 @@ spec s = Spec.describe s "integration" $ do
           ("/items/0/value/name", "\"f\""),
           ("/items/0/value/signature", "\"a -> a\""),
           ("/items/0/value/documentation/type", "\"Empty\""),
-          ("/items/1/value/kind/type", "\"Argument\""),
+          ("/items/1/value/kind/type", "\"ReturnType\""),
           ("/items/1/value/parentKey", "0"),
           ("/items/1/value/signature", "\"a\""),
-          ("/items/1/value/documentation/type", "\"Empty\""),
-          ("/items/2/value/kind/type", "\"ReturnType\""),
-          ("/items/2/value/parentKey", "0"),
-          ("/items/2/value/signature", "\"a\""),
-          ("/items/2/value/documentation/type", "\"Paragraph\""),
-          ("/items/2/value/documentation/value/value", "\"lost\"")
+          ("/items/1/value/documentation/type", "\"Paragraph\""),
+          ("/items/1/value/documentation/value/value", "\"lost\"")
         ]
 
     Spec.it s "data constructor with arg doc has argument children" $ do
@@ -3012,38 +3008,50 @@ spec s = Spec.describe s "integration" $ do
       check
         s
         """
-        f :: a -> a
+        f :: a {- ^ doc -} -> a
         f x = x
         """
         [ ("/items/0/value/kind/type", "\"Function\""),
-          ("/items/0/value/name", "\"f\"")
+          ("/items/0/value/name", "\"f\""),
+          ("/items/1/value/kind/type", "\"Argument\""),
+          ("/items/1/value/name", "\"x\"")
         ]
 
     Spec.it s "picks first variable name across equations" $ do
       check
         s
         """
-        or :: Bool -> Bool -> Bool
+        or :: Bool {- ^ doc -} -> Bool -> Bool
         or True _ = True
         or _ x = x
         """
-        [ ("/items/0/value/name", "\"or\"")
+        [ ("/items/0/value/name", "\"or\""),
+          ("/items/1/value/kind/type", "\"Argument\""),
+          ("/items/1/value/name", ""),
+          ("/items/2/value/kind/type", "\"Argument\""),
+          ("/items/2/value/name", "\"x\"")
         ]
 
     Spec.it s "handles all-wildcard arguments" $ do
       check
         s
         """
-        f :: a -> a
+        f :: a {- ^ doc -} -> a
         f _ = undefined
         """
-        []
+        [ ("/items/1/value/kind/type", "\"Argument\""),
+          ("/items/1/value/name", "")
+        ]
 
     Spec.it s "handles signature without binding" $ do
       check
         s
-        "f :: a -> a"
-        []
+        """
+        f :: a {- ^ doc -} -> a
+        """
+        [ ("/items/1/value/kind/type", "\"Argument\""),
+          ("/items/1/value/name", "")
+        ]
 
   Spec.describe s "visibility" $ do
     Spec.it s "marks exported items as Exported" $ do

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -2126,12 +2126,10 @@ spec s = Spec.describe s "integration" $ do
         """
         [ ("/items/0/value/kind/type", "\"Function\""),
           ("/items/0/value/name", "\"j2\""),
-          ("/items/1/value/kind/type", "\"Argument\""),
+          ("/items/1/value/kind/type", "\"SpecialiseSignature\""),
+          ("/items/1/value/name", "\"j2\""),
           ("/items/1/value/parentKey", "0"),
-          ("/items/2/value/kind/type", "\"SpecialiseSignature\""),
-          ("/items/2/value/name", "\"j2\""),
-          ("/items/2/value/parentKey", "0"),
-          ("/items/2/value/signature", "\"() -> ()\"")
+          ("/items/1/value/signature", "\"() -> ()\"")
         ]
 
     Spec.it s "orphaned specialize pragma" $ do
@@ -2211,16 +2209,12 @@ spec s = Spec.describe s "integration" $ do
         """
         [ ("/items/0/value/kind/type", "\"PatternSynonym\""),
           ("/items/0/value/name", "\"Nil\""),
-          ("/items/0/value/parentKey", "6"),
+          ("/items/0/value/parentKey", "4"),
           ("/items/1/value/kind/type", "\"PatternSynonym\""),
           ("/items/1/value/name", "\"Cons\""),
-          ("/items/1/value/parentKey", "6"),
-          ("/items/2/value/kind/type", "\"Argument\""),
-          ("/items/2/value/parentKey", "2"),
-          ("/items/3/value/kind/type", "\"Argument\""),
-          ("/items/3/value/parentKey", "2"),
-          ("/items/4/value/kind/type", "\"CompletePragma\""),
-          ("/items/4/value/signature", "\"Nil, Cons\"")
+          ("/items/1/value/parentKey", "4"),
+          ("/items/2/value/kind/type", "\"CompletePragma\""),
+          ("/items/2/value/signature", "\"Nil, Cons\"")
         ]
 
     Spec.it s "standalone kind signature" $ do
@@ -2422,11 +2416,9 @@ spec s = Spec.describe s "integration" $ do
         """
         [ ("/items/0/value/kind/type", "\"Function\""),
           ("/items/0/value/name", "\"x4\""),
-          ("/items/1/value/kind/type", "\"Argument\""),
-          ("/items/1/value/parentKey", "0"),
-          ("/items/2/value/kind/type", "\"Rule\""),
-          ("/items/2/value/name", "\"q\""),
-          ("/items/2/value/signature", "\"x4 = id\"")
+          ("/items/1/value/kind/type", "\"Rule\""),
+          ("/items/1/value/name", "\"q\""),
+          ("/items/1/value/signature", "\"x4 = id\"")
         ]
 
     Spec.it s "splice declaration" $ do
@@ -2558,15 +2550,7 @@ spec s = Spec.describe s "integration" $ do
         "f :: Int -> Bool -> String"
         [ ("/items/0/value/kind/type", "\"Function\""),
           ("/items/0/value/name", "\"f\""),
-          ("/items/0/value/signature", "\"Int -> Bool -> String\""),
-          ("/items/1/value/kind/type", "\"Argument\""),
-          ("/items/1/value/parentKey", "0"),
-          ("/items/1/value/signature", "\"Int\""),
-          ("/items/1/value/documentation/type", "\"Empty\""),
-          ("/items/2/value/kind/type", "\"Argument\""),
-          ("/items/2/value/parentKey", "0"),
-          ("/items/2/value/signature", "\"Bool\""),
-          ("/items/2/value/documentation/type", "\"Empty\"")
+          ("/items/0/value/signature", "\"Int -> Bool -> String\"")
         ]
 
     Spec.it s "function with forall and constraints and arg docs" $ do
@@ -2699,14 +2683,12 @@ spec s = Spec.describe s "integration" $ do
         [ ("/items/0/value/name", "\"f\""),
           ("/items/0/value/kind/type", "\"Function\""),
           ("/items/0/value/key", "0"),
-          ("/items/1/value/kind/type", "\"Argument\""),
+          ("/items/1/value/name", "\"f\""),
+          ("/items/1/value/kind/type", "\"InlineSignature\""),
           ("/items/1/value/parentKey", "0"),
           ("/items/2/value/name", "\"f\""),
-          ("/items/2/value/kind/type", "\"InlineSignature\""),
-          ("/items/2/value/parentKey", "0"),
-          ("/items/3/value/name", "\"f\""),
-          ("/items/3/value/kind/type", "\"SpecialiseSignature\""),
-          ("/items/3/value/parentKey", "0")
+          ("/items/2/value/kind/type", "\"SpecialiseSignature\""),
+          ("/items/2/value/parentKey", "0")
         ]
 
     Spec.it s "warning and inline on same function" $ do
@@ -2721,14 +2703,12 @@ spec s = Spec.describe s "integration" $ do
         [ ("/items/0/value/name", "\"g\""),
           ("/items/0/value/kind/type", "\"Function\""),
           ("/items/0/value/key", "0"),
-          ("/items/1/value/kind/type", "\"Argument\""),
+          ("/items/1/value/name", "\"g\""),
+          ("/items/1/value/kind/type", "\"Warning\""),
           ("/items/1/value/parentKey", "0"),
           ("/items/2/value/name", "\"g\""),
-          ("/items/2/value/kind/type", "\"Warning\""),
-          ("/items/2/value/parentKey", "0"),
-          ("/items/3/value/name", "\"g\""),
-          ("/items/3/value/kind/type", "\"InlineSignature\""),
-          ("/items/3/value/parentKey", "0")
+          ("/items/2/value/kind/type", "\"InlineSignature\""),
+          ("/items/2/value/parentKey", "0")
         ]
 
     Spec.it s "multiple specialize pragmas on one function" $ do
@@ -2742,16 +2722,14 @@ spec s = Spec.describe s "integration" $ do
         """
         [ ("/items/0/value/name", "\"h\""),
           ("/items/0/value/kind/type", "\"Function\""),
-          ("/items/1/value/kind/type", "\"Argument\""),
+          ("/items/1/value/name", "\"h\""),
+          ("/items/1/value/kind/type", "\"SpecialiseSignature\""),
           ("/items/1/value/parentKey", "0"),
+          ("/items/1/value/signature", "\"() -> ()\""),
           ("/items/2/value/name", "\"h\""),
           ("/items/2/value/kind/type", "\"SpecialiseSignature\""),
           ("/items/2/value/parentKey", "0"),
-          ("/items/2/value/signature", "\"() -> ()\""),
-          ("/items/3/value/name", "\"h\""),
-          ("/items/3/value/kind/type", "\"SpecialiseSignature\""),
-          ("/items/3/value/parentKey", "0"),
-          ("/items/3/value/signature", "\"Int -> Int\"")
+          ("/items/2/value/signature", "\"Int -> Int\"")
         ]
 
     Spec.it s "fixity and inline and specialize on same operator" $ do
@@ -2767,19 +2745,15 @@ spec s = Spec.describe s "integration" $ do
         [ ("/items/0/value/name", "\"%\""),
           ("/items/0/value/kind/type", "\"Operator\""),
           ("/items/0/value/key", "0"),
-          ("/items/1/value/kind/type", "\"Argument\""),
+          ("/items/1/value/name", "\"%\""),
+          ("/items/1/value/kind/type", "\"FixitySignature\""),
           ("/items/1/value/parentKey", "0"),
-          ("/items/2/value/kind/type", "\"Argument\""),
+          ("/items/2/value/name", "\"%\""),
+          ("/items/2/value/kind/type", "\"InlineSignature\""),
           ("/items/2/value/parentKey", "0"),
           ("/items/3/value/name", "\"%\""),
-          ("/items/3/value/kind/type", "\"FixitySignature\""),
-          ("/items/3/value/parentKey", "0"),
-          ("/items/4/value/name", "\"%\""),
-          ("/items/4/value/kind/type", "\"InlineSignature\""),
-          ("/items/4/value/parentKey", "0"),
-          ("/items/5/value/name", "\"%\""),
-          ("/items/5/value/kind/type", "\"SpecialiseSignature\""),
-          ("/items/5/value/parentKey", "0")
+          ("/items/3/value/kind/type", "\"SpecialiseSignature\""),
+          ("/items/3/value/parentKey", "0")
         ]
 
   Spec.describe s "html" $ do
@@ -3043,10 +3017,7 @@ spec s = Spec.describe s "integration" $ do
         f x = x
         """
         [ ("/items/0/value/kind/type", "\"Function\""),
-          ("/items/0/value/name", "\"f\""),
-          ("/items/1/value/kind/type", "\"Argument\""),
-          ("/items/1/value/name", "\"x\""),
-          ("/items/1/value/signature", "\"a\"")
+          ("/items/0/value/name", "\"f\"")
         ]
 
     Spec.it s "picks first variable name across equations" $ do
@@ -3057,13 +3028,7 @@ spec s = Spec.describe s "integration" $ do
         or True _ = True
         or _ x = x
         """
-        [ ("/items/0/value/name", "\"or\""),
-          ("/items/1/value/kind/type", "\"Argument\""),
-          ("/items/1/value/name", ""),
-          ("/items/1/value/signature", "\"Bool\""),
-          ("/items/2/value/kind/type", "\"Argument\""),
-          ("/items/2/value/name", "\"x\""),
-          ("/items/2/value/signature", "\"Bool\"")
+        [ ("/items/0/value/name", "\"or\"")
         ]
 
     Spec.it s "handles all-wildcard arguments" $ do
@@ -3073,17 +3038,13 @@ spec s = Spec.describe s "integration" $ do
         f :: a -> a
         f _ = undefined
         """
-        [ ("/items/1/value/kind/type", "\"Argument\""),
-          ("/items/1/value/name", "")
-        ]
+        []
 
     Spec.it s "handles signature without binding" $ do
       check
         s
         "f :: a -> a"
-        [ ("/items/1/value/kind/type", "\"Argument\""),
-          ("/items/1/value/name", "")
-        ]
+        []
 
   Spec.describe s "visibility" $ do
     Spec.it s "marks exported items as Exported" $ do


### PR DESCRIPTION
## Summary
- When no function/pattern arguments have documentation comments, argument child items are no longer created (e.g. `hide :: a -> b -> a` with no doc comments produces no argument items)
- When any argument has documentation, all arguments are shown for completeness (e.g. `show :: a -> b {- ^ x -} -> a` shows both arguments)

Fixes #288.

## Test plan
- [x] `cabal build` succeeds
- [x] All 769 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)