### PR TITLE
Show documentation before children except arguments

### DIFF
--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -546,14 +546,19 @@ declarationsContents items =
             if Item.visibility (Located.value li) == Visibility.Unexported
               then children
               else filter (\c -> Item.visibility (Located.value c) /= Visibility.Unexported) children
-       in [ itemContent li (foldMap renderItemWithChildren visibleChildren)
+          isArgument c = Item.kind (Located.value c) == ItemKind.Argument
+          (argChildren, otherChildren) = List.partition isArgument visibleChildren
+       in [ itemContent
+              li
+              (foldMap renderItemWithChildren argChildren)
+              (foldMap renderItemWithChildren otherChildren)
           ]
 
     itemNatKey :: Located.Located Item.Item -> Natural.Natural
     itemNatKey = ItemKey.unwrap . Item.key . Located.value
 
-itemContent :: Located.Located Item.Item -> [Content.Content Element.Element] -> Content.Content Element.Element
-itemContent item children =
+itemContent :: Located.Located Item.Item -> [Content.Content Element.Element] -> [Content.Content Element.Element] -> Content.Content Element.Element
+itemContent item argChildren otherChildren =
   element
     "div"
     [ ("class", "card my-3"),
@@ -598,8 +603,9 @@ itemContent item children =
     cardBody =
       let contents =
             foldMap (List.singleton . sinceContent) (Item.since $ Located.value item)
-              <> children
+              <> argChildren
               <> docContents (Item.documentation $ Located.value item)
+              <> otherChildren
        in if all Content.isEmpty contents
             then []
             else


### PR DESCRIPTION
## Summary
- In the HTML output, documentation now appears after argument children but before other children (constructors, instances, etc.)
- Previously all children appeared before documentation, so `-- | doc` on `data Typ = Con deriving Cls` would show the constructor and derived instance before the documentation text
- Arguments still appear before documentation since they are part of the signature

Fixes #292.

## Test plan
- [x] `cabal build` succeeds
- [x] All 769 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)