### PR TITLE
Render unresolved named doc chunks as card items

### DIFF
--- a/source/library/Scrod/Convert/FromGhc/ExportOrdering.hs
+++ b/source/library/Scrod/Convert/FromGhc/ExportOrdering.hs
@@ -251,11 +251,11 @@ mkDocNamedItem ::
   Natural.Natural ->
   (Located.Located Item.Item, Natural.Natural)
 mkDocNamedItem name nextKey =
-  ( mkSyntheticItem nextKey Nothing doc Nothing ItemKind.DocumentationChunk,
+  ( mkSyntheticItem nextKey chunkName Doc.Empty Nothing ItemKind.DocumentationChunk,
     nextKey + 1
   )
   where
-    doc = Doc.Paragraph . Doc.String $ Text.pack "$" <> name
+    chunkName = Just . ItemName.MkItemName $ Text.pack "$" <> name
 
 -- | Create a synthetic item with a given key, not tied to any source
 -- location.

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -783,6 +783,22 @@ spec s = Spec.describe s "integration" $ do
           ("/items/1/value/kind/type", "\"Function\"")
         ]
 
+    Spec.it s "renders unresolved named doc chunks as named card items" $ do
+      check
+        s
+        """
+        module M
+          ( -- $x
+            y
+          ) where
+        y = ()
+        """
+        [ ("/items/0/value/kind/type", "\"DocumentationChunk\""),
+          ("/items/0/value/name", "\"$x\""),
+          ("/items/0/value/documentation/type", "\"Empty\""),
+          ("/items/1/value/name", "\"y\"")
+        ]
+
     Spec.it s "creates metadata items for export-level doc comments" $ do
       check
         s


### PR DESCRIPTION
## Summary
- Unresolved named documentation chunks (e.g. `-- $x` in an export list with no matching `-- $x` declaration) now render as "doc chunk" card items with the chunk name visible
- Previously these rendered as inconspicuous inline text that was easy to miss

Fixes #291.

## Test plan
- [x] `cabal build` succeeds
- [x] All 769 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)