### PR TITLE
Handle documentation groups as headings

### DIFF
--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -344,7 +344,7 @@ convertDeclWithDocMaybeM doc docSince lDecl = case SrcLoc.unLoc lDecl of
         chunkDoc = GhcDoc.convertExportDoc lNamedDoc
      in Maybe.maybeToList <$> Internal.mkItemM (Annotation.getLocA lDecl) Nothing chunkName (Internal.appendDoc doc chunkDoc) docSince Nothing ItemKind.DocumentationChunk
   Syntax.DocD _ (Hs.DocGroup level lGroupDoc) ->
-    let groupDoc = Doc.Header Header.MkHeader {Header.level = intToLevel level, Header.title = GhcDoc.convertExportDoc lGroupDoc}
+    let groupDoc = Doc.Header Header.MkHeader {Header.level = Level.fromInt level, Header.title = GhcDoc.convertExportDoc lGroupDoc}
      in Maybe.maybeToList <$> Internal.mkItemM (Annotation.getLocA lDecl) Nothing Nothing (Internal.appendDoc doc groupDoc) docSince Nothing ItemKind.DocumentationChunk
   Syntax.DocD {} -> Maybe.maybeToList <$> convertDeclSimpleM lDecl
   Syntax.SigD _ sig -> convertSigDeclM doc docSince lDecl sig
@@ -573,16 +573,6 @@ fixityDirectionToText dir = case dir of
   SyntaxBasic.InfixL -> Text.pack "infixl"
   SyntaxBasic.InfixR -> Text.pack "infixr"
   SyntaxBasic.InfixN -> Text.pack "infix"
-
--- | Convert a GHC doc group level (1-based) to a 'Level'.
-intToLevel :: Int -> Level.Level
-intToLevel n
-  | n <= 1 = Level.One
-  | n == 2 = Level.Two
-  | n == 3 = Level.Three
-  | n == 4 = Level.Four
-  | n == 5 = Level.Five
-  | otherwise = Level.Six
 
 -- | Convert a GHC 'InlineSpec' to its pragma keyword text.
 inlineSpecToText :: Basic.InlineSpec -> Text.Text

--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -54,15 +54,15 @@ import qualified Scrod.Convert.FromGhc.WarningParents as WarningParents
 import qualified Scrod.Core.Category as Category
 import qualified Scrod.Core.Doc as Doc
 import qualified Scrod.Core.Export as Export
-import qualified Scrod.Core.Header as Header
 import qualified Scrod.Core.Extension as Extension
+import qualified Scrod.Core.Header as Header
 import qualified Scrod.Core.Import as Import
 import qualified Scrod.Core.Item as Item
 import qualified Scrod.Core.ItemKey as ItemKey
-import qualified Scrod.Core.Level as Level
 import qualified Scrod.Core.ItemKind as ItemKind
 import qualified Scrod.Core.ItemName as ItemName
 import qualified Scrod.Core.Language as Language
+import qualified Scrod.Core.Level as Level
 import qualified Scrod.Core.Located as Located
 import qualified Scrod.Core.Module as Module
 import qualified Scrod.Core.ModuleName as ModuleName
@@ -573,13 +573,13 @@ fixityDirectionToText dir = case dir of
 
 -- | Convert a GHC doc group level (1-based) to a 'Level'.
 intToLevel :: Int -> Level.Level
-intToLevel n = case n of
-  1 -> Level.One
-  2 -> Level.Two
-  3 -> Level.Three
-  4 -> Level.Four
-  5 -> Level.Five
-  _ -> Level.Six
+intToLevel n
+  | n <= 1 = Level.One
+  | n == 2 = Level.Two
+  | n == 3 = Level.Three
+  | n == 4 = Level.Four
+  | n == 5 = Level.Five
+  | otherwise = Level.Six
 
 -- | Convert a GHC 'InlineSpec' to its pragma keyword text.
 inlineSpecToText :: Basic.InlineSpec -> Text.Text

--- a/source/library/Scrod/Convert/FromGhc/Exports.hs
+++ b/source/library/Scrod/Convert/FromGhc/Exports.hs
@@ -98,7 +98,7 @@ convertIE lIe = case SrcLoc.unLoc lIe of
       Section.MkSection
         { Section.header =
             Header.MkHeader
-              { Header.level = levelFromInt level,
+              { Header.level = Level.fromInt level,
                 Header.title = GhcDoc.convertExportDoc lDoc
               }
         }
@@ -149,14 +149,3 @@ convertWrappedName lWrapped = case SrcLoc.unLoc lWrapped of
       { ExportName.kind = Nothing,
         ExportName.name = Internal.extractRdrName lId
       }
-
--- | Convert an int to a Level.
-levelFromInt :: Int -> Level.Level
-levelFromInt n = case n of
-  1 -> Level.One
-  2 -> Level.Two
-  3 -> Level.Three
-  4 -> Level.Four
-  5 -> Level.Five
-  6 -> Level.Six
-  _ -> Level.One

--- a/source/library/Scrod/Convert/FromHaddock.hs
+++ b/source/library/Scrod/Convert/FromHaddock.hs
@@ -102,7 +102,7 @@ convertDoc doc = case doc of
   Haddock.DocHeader h ->
     Doc.Header
       Header.MkHeader
-        { Header.level = convertLevel $ Haddock.headerLevel h,
+        { Header.level = Level.fromInt $ Haddock.headerLevel h,
           Header.title = convertDoc $ Haddock.headerTitle h
         }
   Haddock.DocTable t ->
@@ -111,16 +111,6 @@ convertDoc doc = case doc of
         { Table.headerRows = convertTableRow <$> Haddock.tableHeaderRows t,
           Table.bodyRows = convertTableRow <$> Haddock.tableBodyRows t
         }
-
-convertLevel :: Int -> Level.Level
-convertLevel n = case n of
-  1 -> Level.One
-  2 -> Level.Two
-  3 -> Level.Three
-  4 -> Level.Four
-  5 -> Level.Five
-  6 -> Level.Six
-  _ -> Level.One -- Default to level one if out of range.
 
 convertTableRow :: Haddock.TableRow (Haddock.DocH Void.Void Identifier.Identifier) -> [TableCell.Cell Doc.Doc]
 convertTableRow = fmap convertTableCell . Haddock.tableRowCells

--- a/source/library/Scrod/Core/Level.hs
+++ b/source/library/Scrod/Core/Level.hs
@@ -1,8 +1,11 @@
+{-# LANGUAGE TemplateHaskellQuotes #-}
+
 module Scrod.Core.Level where
 
 import qualified Scrod.Json.ToJson as ToJson
 import qualified Scrod.Json.Value as Json
 import qualified Scrod.Schema as Schema
+import qualified Scrod.Spec as Spec
 
 -- | A header level from 1 to 6 inclusive.
 data Level
@@ -13,6 +16,16 @@ data Level
   | Five
   | Six
   deriving (Eq, Ord, Show)
+
+-- | Convert an integer to a 'Level', clamping to the valid range.
+fromInt :: Int -> Level
+fromInt n
+  | n <= 1 = One
+  | n == 2 = Two
+  | n == 3 = Three
+  | n == 4 = Four
+  | n == 5 = Five
+  | otherwise = Six
 
 instance ToJson.ToJson Level where
   toJson l = Json.integer $ case l of
@@ -31,3 +44,36 @@ instance Schema.ToSchema Level where
           ("minimum", Json.integer 1),
           ("maximum", Json.integer 6)
         ]
+
+spec :: (Applicative m, Monad n) => Spec.Spec m n -> n ()
+spec s = do
+  Spec.named s 'fromInt $ do
+    Spec.it s "maps 1 to One" $ do
+      Spec.assertEq s (fromInt 1) One
+
+    Spec.it s "maps 2 to Two" $ do
+      Spec.assertEq s (fromInt 2) Two
+
+    Spec.it s "maps 3 to Three" $ do
+      Spec.assertEq s (fromInt 3) Three
+
+    Spec.it s "maps 4 to Four" $ do
+      Spec.assertEq s (fromInt 4) Four
+
+    Spec.it s "maps 5 to Five" $ do
+      Spec.assertEq s (fromInt 5) Five
+
+    Spec.it s "maps 6 to Six" $ do
+      Spec.assertEq s (fromInt 6) Six
+
+    Spec.it s "clamps zero to One" $ do
+      Spec.assertEq s (fromInt 0) One
+
+    Spec.it s "clamps negative to One" $ do
+      Spec.assertEq s (fromInt (-1)) One
+
+    Spec.it s "clamps 7 to Six" $ do
+      Spec.assertEq s (fromInt 7) Six
+
+    Spec.it s "clamps large value to Six" $ do
+      Spec.assertEq s (fromInt 100) Six

--- a/source/library/Scrod/TestSuite/All.hs
+++ b/source/library/Scrod/TestSuite/All.hs
@@ -3,6 +3,7 @@ module Scrod.TestSuite.All where
 import qualified Scrod.Cabal
 import qualified Scrod.Convert.FromHaddock
 import qualified Scrod.Convert.ToJsonSchema
+import qualified Scrod.Core.Level
 import qualified Scrod.Cpp
 import qualified Scrod.Cpp.Directive
 import qualified Scrod.Cpp.Expr
@@ -51,6 +52,7 @@ spec s = do
   Scrod.Cabal.spec s
   Scrod.Convert.FromHaddock.spec s
   Scrod.Convert.ToJsonSchema.spec s
+  Scrod.Core.Level.spec s
   Scrod.Cpp.spec s
   Scrod.Cpp.Directive.spec s
   Scrod.Cpp.Expr.spec s

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -910,6 +910,38 @@ spec s = Spec.describe s "integration" $ do
           ("/items/2/value/documentation/value/value", "\"quux\"")
         ]
 
+  Spec.describe s "doc groups" $ do
+    Spec.it s "converts doc groups in the module body to headings" $ do
+      check
+        s
+        """
+        a = 1
+        -- * My Section
+        c = 2
+        """
+        [ ("/items/0/value/name", "\"a\""),
+          ("/items/1/value/kind/type", "\"DocumentationChunk\""),
+          ("/items/1/value/documentation/type", "\"Header\""),
+          ("/items/1/value/documentation/value/level", "1"),
+          ("/items/1/value/documentation/value/title/type", "\"Paragraph\""),
+          ("/items/1/value/documentation/value/title/value/value", "\"My Section\""),
+          ("/items/2/value/name", "\"c\"")
+        ]
+
+    Spec.it s "handles level 2 doc groups" $ do
+      check
+        s
+        """
+        -- ** Sub Section
+        x = ()
+        """
+        [ ("/items/0/value/kind/type", "\"DocumentationChunk\""),
+          ("/items/0/value/documentation/type", "\"Header\""),
+          ("/items/0/value/documentation/value/level", "2"),
+          ("/items/0/value/documentation/value/title/value/value", "\"Sub Section\""),
+          ("/items/1/value/name", "\"x\"")
+        ]
+
   Spec.describe s "imports" $ do
     Spec.it s "defaults to empty list" $ do
       check s "" [("/imports", "[]")]


### PR DESCRIPTION
## Summary
- Documentation groups (`-- * foo`) outside export lists are now converted to `DocumentationChunk` items with a `Header` doc
- Previously these showed up as empty `Function` items with no name
- The heading level maps from the GHC doc group level (e.g. `-- *` is level 1, `-- **` is level 2)

Fixes #290.

## Test plan
- [x] `cabal build` succeeds
- [x] All 769 tests pass
- [x] Verified `a=1 / -- *b / c=2` now produces a `DocumentationChunk` with `Header` level 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)