### PR TITLE
Include type variables in class names

### DIFF
--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -384,7 +384,7 @@ convertTyClDeclWithDocM doc docSince lDecl tyClDecl = case tyClDecl of
     childItems <- convertDataDefnM parentKey parentType dataDefn
     pure $ Maybe.maybeToList parentItem <> childItems
   Syntax.ClassDecl {Syntax.tcdSigs = sigs, Syntax.tcdATs = ats, Syntax.tcdDocs = docs} -> do
-    parentItem <- convertDeclWithDocM Nothing doc docSince (Names.extractTyClDeclName tyClDecl) (Names.extractTyClDeclTyVars tyClDecl) lDecl
+    parentItem <- convertDeclWithDocM Nothing doc docSince (Names.extractTyClDeclName tyClDecl) Nothing lDecl
     let parentKey = fmap (Item.key . Located.value) parentItem
     methodItems <- convertClassSigsWithDocsM parentKey sigs docs
     defaultSigItems <- convertDefaultSigsM methodItems sigs docs

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -829,7 +829,7 @@ spec s = Spec.describe s "integration" $ do
         class MyClass a
         instance MyClass Int
         """
-        [ ("/items/0/value/name", "\"MyClass\""),
+        [ ("/items/0/value/name", "\"MyClass a\""),
           ("/items/0/value/visibility/type", "\"Exported\""),
           ("/items/1/value/visibility/type", "\"Implicit\"")
         ]
@@ -1408,8 +1408,7 @@ spec s = Spec.describe s "integration" $ do
         s
         "class C a"
         [ ("/items/0/value/kind/type", "\"Class\""),
-          ("/items/0/value/name", "\"C\""),
-          ("/items/0/value/signature", "\"a\"")
+          ("/items/0/value/name", "\"C a\"")
         ]
 
     Spec.it s "class instance" $ do
@@ -1891,7 +1890,7 @@ spec s = Spec.describe s "integration" $ do
           t = undefined
         """
         [ ("/items/0/value/kind/type", "\"Class\""),
-          ("/items/0/value/name", "\"S\""),
+          ("/items/0/value/name", "\"S a\""),
           ("/items/0/value/key", "0"),
           ("/items/1/value/kind/type", "\"ClassMethod\""),
           ("/items/1/value/name", "\"t\""),
@@ -2166,7 +2165,7 @@ spec s = Spec.describe s "integration" $ do
           {-# minimal l2m #-}
         """
         [ ("/items/0/value/kind/type", "\"Class\""),
-          ("/items/0/value/name", "\"L2\""),
+          ("/items/0/value/name", "\"L2 a\""),
           ("/items/1/value/kind/type", "\"ClassMethod\""),
           ("/items/1/value/parentKey", "0"),
           ("/items/2/value/kind/type", "\"MinimalPragma\""),
@@ -2286,7 +2285,7 @@ spec s = Spec.describe s "integration" $ do
         class C a
         """
         [ ("/items/0/value/kind/type", "\"Class\""),
-          ("/items/0/value/name", "\"C\""),
+          ("/items/0/value/name", "\"C a\""),
           ("/items/0/value/signature", "\"* -> Constraint\"")
         ]
 
@@ -2670,7 +2669,7 @@ spec s = Spec.describe s "integration" $ do
             -> String
         """
         [ ("/items/0/value/kind/type", "\"Class\""),
-          ("/items/0/value/name", "\"C\""),
+          ("/items/0/value/name", "\"C a\""),
           ("/items/1/value/kind/type", "\"ClassMethod\""),
           ("/items/1/value/name", "\"m\""),
           ("/items/1/value/signature", "\"a -> Bool -> String\""),
@@ -3015,7 +3014,7 @@ spec s = Spec.describe s "integration" $ do
         """
         [ ("/signature", "true"),
           ("/items/0/value/kind/type", "\"Class\""),
-          ("/items/0/value/name", "\"C\""),
+          ("/items/0/value/name", "\"C a\""),
           ("/items/1/value/kind/type", "\"ClassMethod\""),
           ("/items/1/value/name", "\"bar\"")
         ]


### PR DESCRIPTION
## Summary
- Class declarations like `class C a` now produce name `"C a"` instead of `"C"` with signature `"a"`, preventing standalone kind signatures from overwriting the type variable information
- Updated name matching in export ordering, visibility, instance parents, and kind signature merging to support base-name lookups for names containing type variables
- Updated 7 integration test expectations to reflect the new class naming convention

Closes #289

## Test plan
- [x] All 769 tests pass
- [ ] Verify `class C1 a` and `type C2 :: Type -> Constraint; class C2 a` render correctly on scrod.fyi

🤖 Generated with [Claude Code](https://claude.com/claude-code)