### PR TITLE
Use shorter line length for signature pretty-printing

### DIFF
--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -352,7 +352,7 @@ convertDeclWithDocMaybeM doc docSince lDecl = case SrcLoc.unLoc lDecl of
         sig = Just $ Names.extractForeignDeclSignature foreignDecl
      in Maybe.maybeToList <$> convertDeclWithDocM Nothing doc docSince name sig lDecl
   Syntax.SpliceD _ spliceDecl ->
-    let sig = Just . Text.pack . Outputable.showSDocUnsafe . Outputable.ppr $ spliceDecl
+    let sig = Just . Text.pack . Internal.showSDocShort . Outputable.ppr $ spliceDecl
      in Maybe.maybeToList <$> convertDeclWithDocM Nothing doc docSince Nothing sig lDecl
   Syntax.WarningD _ warnDecls -> convertWarnDeclsM warnDecls
   Syntax.RoleAnnotD _ roleAnnotDecl -> Maybe.maybeToList <$> convertRoleAnnotM roleAnnotDecl
@@ -406,7 +406,7 @@ convertInstDeclWithDocM doc docSince lDecl inst = case inst of
     let parentKey = fmap (Item.key . Located.value) parentItem
         eqn = Syntax.dfid_eqn dataFamInst
         parentType =
-          Just . Text.pack . Outputable.showSDocUnsafe $
+          Just . Text.pack . Internal.showSDocShort $
             Outputable.ppr (Syntax.feqn_tycon eqn)
               Outputable.<+> Outputable.hsep (pprHsTypeArg <$> Syntax.feqn_pats eqn)
     childItems <- convertDataDefnM parentKey parentType (Syntax.feqn_rhs eqn)
@@ -465,12 +465,12 @@ convertSigDeclM doc docSince lDecl sig = case sig of
     let sigText = Just . inlineSpecToText $ Basic.inl_inline inlinePragma
      in Maybe.maybeToList <$> convertInlineNameM doc docSince sigText lName
   Syntax.SpecSig _ lName sigTypes _ ->
-    let sigText = Just . Text.pack . Outputable.showSDocUnsafe $ Outputable.hsep (Outputable.punctuate (Outputable.text ",") (fmap Outputable.ppr sigTypes))
+    let sigText = Just . Text.pack . Internal.showSDocShort $ Outputable.hsep (Outputable.punctuate (Outputable.text ",") (fmap Outputable.ppr sigTypes))
      in Maybe.maybeToList <$> convertSpecialiseNameM doc docSince sigText lName
   Syntax.SpecSigE _ _ lExpr _ -> convertSpecSigEM doc docSince lExpr
   Syntax.CompleteMatchSig _ names mTyCon ->
     let namesSig = Outputable.hsep (Outputable.punctuate (Outputable.text ",") (fmap Outputable.ppr names))
-        sigText = Just . Text.pack . Outputable.showSDocUnsafe $ case mTyCon of
+        sigText = Just . Text.pack . Internal.showSDocShort $ case mTyCon of
           Nothing -> namesSig
           Just tyCon -> namesSig Outputable.<+> Outputable.text "::" Outputable.<+> Outputable.ppr tyCon
      in Maybe.maybeToList <$> Internal.mkItemM (Annotation.getLocA lDecl) Nothing Nothing doc docSince sigText ItemKind.CompletePragma
@@ -531,7 +531,7 @@ convertSpecSigEM ::
   Internal.ConvertM [Located.Located Item.Item]
 convertSpecSigEM doc docSince lExpr = case SrcLoc.unLoc lExpr of
   Syntax.ExprWithTySig _ body sigWcType ->
-    let sigText = Just . Text.pack . Outputable.showSDocUnsafe . Outputable.ppr $ sigWcType
+    let sigText = Just . Text.pack . Internal.showSDocShort . Outputable.ppr $ sigWcType
      in case SrcLoc.unLoc body of
           Syntax.HsVar _ lName ->
             Maybe.maybeToList <$> convertSpecialiseNameM doc docSince sigText lName
@@ -595,7 +595,7 @@ convertRuleDeclM lRuleDecl =
   let ruleDecl = SrcLoc.unLoc lRuleDecl
       name = Just . ItemName.MkItemName . Text.pack . FastString.unpackFS . SrcLoc.unLoc $ Syntax.rd_name ruleDecl
       sig =
-        Just . Text.pack . Outputable.showSDocUnsafe $
+        Just . Text.pack . Internal.showSDocShort $
           Outputable.ppr (Syntax.rd_bndrs ruleDecl)
             Outputable.<+> Outputable.ppr (Syntax.rd_lhs ruleDecl)
             Outputable.<+> Outputable.text "="
@@ -728,7 +728,7 @@ convertDefaultSigDeclM ::
   Internal.ConvertM [Located.Located Item.Item]
 convertDefaultSigDeclM nameToKey doc docSince lDecl = case SrcLoc.unLoc lDecl of
   Syntax.SigD _ (Syntax.ClassOpSig _ True names sigTy) ->
-    let sig = Just . Text.pack . Outputable.showSDocUnsafe $ Outputable.ppr sigTy
+    let sig = Just . Text.pack . Internal.showSDocShort $ Outputable.ppr sigTy
      in Maybe.catMaybes <$> traverse (convertDefaultSigNameM nameToKey doc docSince sig) names
   _ -> pure []
 
@@ -759,7 +759,7 @@ convertMinimalSigM ::
   Internal.ConvertM (Maybe (Located.Located Item.Item))
 convertMinimalSigM parentKey lSig = case SrcLoc.unLoc lSig of
   Syntax.MinimalSig _ lBooleanFormula ->
-    let sig = Just . Text.pack . Outputable.showSDocUnsafe . Outputable.ppr $ SrcLoc.unLoc lBooleanFormula
+    let sig = Just . Text.pack . Internal.showSDocShort . Outputable.ppr $ SrcLoc.unLoc lBooleanFormula
      in Internal.mkItemM (Annotation.getLocA lSig) parentKey Nothing Doc.Empty Nothing sig ItemKind.MinimalPragma
   _ -> pure Nothing
 
@@ -801,7 +801,7 @@ convertTyFamInstEqnM ::
   Internal.ConvertM (Maybe (Located.Located Item.Item))
 convertTyFamInstEqnM parentKey lEqn =
   let eqn = SrcLoc.unLoc lEqn
-      sig = Just . Text.pack . Outputable.showSDocUnsafe $ extractTyFamInstEqnSig eqn
+      sig = Just . Text.pack . Internal.showSDocShort $ extractTyFamInstEqnSig eqn
    in Internal.mkItemM (Annotation.getLocA lEqn) parentKey Nothing Doc.Empty Nothing sig ItemKind.TypeFamilyInstance
 
 -- | Pretty-print a type family instance equation.

--- a/source/library/Scrod/Convert/FromGhc/Constructors.hs
+++ b/source/library/Scrod/Convert/FromGhc/Constructors.hs
@@ -97,7 +97,7 @@ extractConDeclSignature mParentType conDecl = case conDecl of
     } ->
       case mParentType of
         Nothing ->
-          Just . Text.pack . Outputable.showSDocUnsafe . Outputable.ppr $
+          Just . Text.pack . Internal.showSDocShort . Outputable.ppr $
             conDecl
               { Syntax.con_doc = Nothing,
                 Syntax.con_args = stripH98DetailsDocs args
@@ -123,11 +123,11 @@ extractConDeclSignature mParentType conDecl = case conDecl of
               bodyDoc = case argsDoc of
                 Nothing -> Outputable.text (Text.unpack parentType)
                 Just ad -> ad Outputable.<+> Outputable.text "->" Outputable.<+> Outputable.text (Text.unpack parentType)
-           in Just . Text.pack . Outputable.showSDocUnsafe $
+           in Just . Text.pack . Internal.showSDocShort $
                 forallDoc Outputable.<+> cxtDoc Outputable.<+> bodyDoc
   c@Syntax.ConDeclGADT {} ->
     let full =
-          Text.pack . Outputable.showSDocUnsafe . Outputable.ppr $
+          Text.pack . Internal.showSDocShort . Outputable.ppr $
             c
               { Syntax.con_doc = Nothing,
                 Syntax.con_g_args = stripGADTDetailsDocs (Syntax.con_g_args c)
@@ -240,7 +240,7 @@ convertPrefixArgM ::
 convertPrefixArgM parentKey field =
   let (argDoc, argSince) = maybe (Doc.Empty, Nothing) GhcDoc.convertLHsDoc $ Syntax.cdf_doc field
       sig =
-        Just . Text.pack . Outputable.showSDocUnsafe $
+        Just . Text.pack . Internal.showSDocShort $
           unpackednessDoc (Syntax.cdf_unpack field)
             Outputable.<> strictnessDoc (Syntax.cdf_bang field)
             Outputable.<> Outputable.ppr (Syntax.cdf_type field)
@@ -270,7 +270,7 @@ convertConDeclFieldM parentKey lField =
       fieldSpec = Syntax.cdrf_spec recField
       (doc, docSince) = maybe (Doc.Empty, Nothing) GhcDoc.convertLHsDoc $ Syntax.cdf_doc fieldSpec
       sig =
-        Just . Text.pack . Outputable.showSDocUnsafe $
+        Just . Text.pack . Internal.showSDocShort $
           unpackednessDoc (Syntax.cdf_unpack fieldSpec)
             Outputable.<> strictnessDoc (Syntax.cdf_bang fieldSpec)
             Outputable.<> Outputable.ppr (Syntax.cdf_type fieldSpec)

--- a/source/library/Scrod/Convert/FromGhc/Internal.hs
+++ b/source/library/Scrod/Convert/FromGhc/Internal.hs
@@ -103,6 +103,12 @@ warningTxtToWarning warningTxt =
           $ Warnings.warningTxtMessage warningTxt
     }
 
+-- | Render an SDoc with a short line length to encourage line breaks.
+showSDocShort :: Outputable.SDoc -> String
+showSDocShort =
+  Outputable.renderWithContext
+    Outputable.defaultSDocContext {Outputable.sdocLineLength = 40}
+
 -- | Convert GHC WarningCategory to our 'Category' type.
 categoryFromGhc :: Warnings.WarningCategory -> Category.Category
 categoryFromGhc =

--- a/source/library/Scrod/Convert/FromGhc/Names.hs
+++ b/source/library/Scrod/Convert/FromGhc/Names.hs
@@ -39,7 +39,7 @@ extractStandaloneKindSigName (Syntax.StandaloneKindSig _ lName _) = Internal.ext
 -- For example, @type X :: a -> a@ produces @"a -> a"@.
 extractKindSigSignature :: Syntax.StandaloneKindSig Ghc.GhcPs -> Text.Text
 extractKindSigSignature (Syntax.StandaloneKindSig _ _ lSigType) =
-  Text.pack . Outputable.showSDocUnsafe . Outputable.ppr $ lSigType
+  Text.pack . Internal.showSDocShort . Outputable.ppr $ lSigType
 
 -- | Extract name from a type/class declaration.
 extractTyClDeclName :: Syntax.TyClDecl Ghc.GhcPs -> Maybe ItemName.ItemName
@@ -54,7 +54,7 @@ extractTyClDeclName tyClDecl = case tyClDecl of
 extractParentTypeText :: Syntax.TyClDecl Ghc.GhcPs -> Maybe Text.Text
 extractParentTypeText tyClDecl = case tyClDecl of
   Syntax.DataDecl {Syntax.tcdLName = lName, Syntax.tcdTyVars = tyVars} ->
-    Just . Text.pack . Outputable.showSDocUnsafe $ case Syntax.hsQTvExplicit tyVars of
+    Just . Text.pack . Internal.showSDocShort $ case Syntax.hsQTvExplicit tyVars of
       [] -> Outputable.ppr lName
       tvs -> Outputable.ppr lName Outputable.<+> Outputable.hsep (fmap Outputable.ppr tvs)
   _ -> Nothing
@@ -74,7 +74,7 @@ extractTyClDeclTyVars tyClDecl = case tyClDecl of
 tyVarsToText :: Syntax.LHsQTyVars Ghc.GhcPs -> Maybe Text.Text
 tyVarsToText tyVars = case Syntax.hsQTvExplicit tyVars of
   [] -> Nothing
-  tvs -> Just . Text.pack . Outputable.showSDocUnsafe $ Outputable.hsep (fmap Outputable.ppr tvs)
+  tvs -> Just . Text.pack . Internal.showSDocShort $ Outputable.hsep (fmap Outputable.ppr tvs)
 
 -- | Extract the signature for a type synonym declaration.
 -- For @type T = ()@, this produces @Just "= ()"@.
@@ -82,7 +82,7 @@ tyVarsToText tyVars = case Syntax.hsQTvExplicit tyVars of
 extractSynDeclSignature :: Syntax.TyClDecl Ghc.GhcPs -> Maybe Text.Text
 extractSynDeclSignature tyClDecl = case tyClDecl of
   Syntax.SynDecl {Syntax.tcdTyVars = tyVars, Syntax.tcdRhs = rhs} ->
-    let rhsText = Text.pack . Outputable.showSDocUnsafe $ Outputable.ppr rhs
+    let rhsText = Text.pack . Internal.showSDocShort $ Outputable.ppr rhs
      in Just $ case tyVarsToText tyVars of
           Nothing -> Text.pack "= " <> rhsText
           Just tvs -> tvs <> Text.pack " = " <> rhsText
@@ -99,7 +99,7 @@ extractForeignDeclName foreignDecl = Internal.extractIdPName $ Syntax.fd_name fo
 -- | Extract signature from a foreign declaration.
 extractForeignDeclSignature :: Syntax.ForeignDecl Ghc.GhcPs -> Text.Text
 extractForeignDeclSignature foreignDecl =
-  Text.pack . Outputable.showSDocUnsafe . Outputable.ppr $ Syntax.fd_sig_ty foreignDecl
+  Text.pack . Internal.showSDocShort . Outputable.ppr $ Syntax.fd_sig_ty foreignDecl
 
 -- | Extract name from a binding.
 extractBindName :: Syntax.HsBindLR Ghc.GhcPs Ghc.GhcPs -> Maybe ItemName.ItemName
@@ -184,11 +184,11 @@ extractSigName sig = case sig of
 extractSigSignature :: Syntax.Sig Ghc.GhcPs -> Maybe Text.Text
 extractSigSignature sig = case sig of
   Syntax.TypeSig _ _ ty ->
-    Just . Text.pack . Outputable.showSDocUnsafe . Outputable.ppr $ stripHsSigWcType ty
+    Just . Text.pack . Internal.showSDocShort . Outputable.ppr $ stripHsSigWcType ty
   Syntax.PatSynSig _ _ ty ->
-    Just . Text.pack . Outputable.showSDocUnsafe . Outputable.ppr $ stripHsSigType ty
+    Just . Text.pack . Internal.showSDocShort . Outputable.ppr $ stripHsSigType ty
   Syntax.ClassOpSig _ _ _ ty ->
-    Just . Text.pack . Outputable.showSDocUnsafe . Outputable.ppr $ stripHsSigType ty
+    Just . Text.pack . Internal.showSDocShort . Outputable.ppr $ stripHsSigType ty
   _ -> Nothing
 
 -- | Strip 'HsDocTy' wrappers from a wildcard-wrapped signature type.
@@ -266,11 +266,11 @@ extractArg ::
   Syntax.LHsType Ghc.GhcPs -> (Text.Text, Maybe (HsDoc.LHsDoc Ghc.GhcPs))
 extractArg lTy = case SrcLoc.unLoc lTy of
   Syntax.HsDocTy _ inner doc ->
-    ( Text.pack . Outputable.showSDocUnsafe . Outputable.ppr $ stripHsDocTy inner,
+    ( Text.pack . Internal.showSDocShort . Outputable.ppr $ stripHsDocTy inner,
       Just doc
     )
   _ ->
-    ( Text.pack . Outputable.showSDocUnsafe . Outputable.ppr $ stripHsDocTy lTy,
+    ( Text.pack . Internal.showSDocShort . Outputable.ppr $ stripHsDocTy lTy,
       Nothing
     )
 
@@ -278,13 +278,13 @@ extractArg lTy = case SrcLoc.unLoc lTy of
 extractInstDeclName :: Syntax.InstDecl Ghc.GhcPs -> Maybe ItemName.ItemName
 extractInstDeclName inst = Just $ case inst of
   Syntax.ClsInstD _ clsInst ->
-    ItemName.MkItemName . Text.pack . Outputable.showSDocUnsafe . Outputable.ppr $
+    ItemName.MkItemName . Text.pack . Internal.showSDocShort . Outputable.ppr $
       Syntax.cid_poly_ty clsInst
   Syntax.DataFamInstD _ dataFamInst ->
-    ItemName.MkItemName . Text.pack . Outputable.showSDocUnsafe . Outputable.ppr $
+    ItemName.MkItemName . Text.pack . Internal.showSDocShort . Outputable.ppr $
       dataFamInst
   Syntax.TyFamInstD _ tyFamInst ->
-    ItemName.MkItemName . Text.pack . Outputable.showSDocUnsafe . Outputable.ppr $
+    ItemName.MkItemName . Text.pack . Internal.showSDocShort . Outputable.ppr $
       tyFamInst
 
 -- | Extract name from a standalone deriving declaration.
@@ -293,7 +293,7 @@ extractDerivDeclName =
   Just
     . ItemName.MkItemName
     . Text.pack
-    . Outputable.showSDocUnsafe
+    . Internal.showSDocShort
     . Outputable.ppr
     . Syntax.hswc_body
     . Syntax.deriv_type

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -2579,7 +2579,7 @@ spec s = Spec.describe s "integration" $ do
         """
         [ ("/items/0/value/kind/type", "\"Function\""),
           ("/items/0/value/name", "\"f\""),
-          ("/items/0/value/signature", "\"forall a. Show a => a -> String\""),
+          ("/items/0/value/signature", "\"forall a. Show a =>\\n          a -> String\""),
           ("/items/1/value/kind/type", "\"Argument\""),
           ("/items/1/value/parentKey", "0"),
           ("/items/1/value/signature", "\"a\""),


### PR DESCRIPTION
## Summary
- Added `showSDocShort` helper in `Internal.hs` that uses `sdocLineLength = 40` (vs default 100) to encourage line breaks in long type signatures
- Replaced `Outputable.showSDocUnsafe` with `Internal.showSDocShort` for all signature-rendering code paths (type sigs, kind sigs, constructor sigs, etc.)
- Names, extension strings, and other short identifiers continue using the default line length

Closes #286

## Test plan
- [x] All 769 tests pass
- [ ] Verify long type signatures are split across lines on scrod.fyi

🤖 Generated with [Claude Code](https://claude.com/claude-code)