### PR TITLE
Set up Hooky pre-commit hooks

### DIFF
--- a/.hooky.kdl
+++ b/.hooky.kdl
@@ -14,20 +14,20 @@ hook ormolu {
     files *.hs
 }
 
-hook cabal_gild {
+hook cabal-gild {
     command cabal-gild {
         check_args --input scrod.cabal --mode check
         fix_args --io scrod.cabal --mode format
         pass_files none
     }
-    files /scrod.cabal
+    files "/scrod.cabal"
 }
 
-hook cabal_check {
+hook cabal-check {
     command cabal check {
         pass_files none
     }
-    files /scrod.cabal
+    files "/scrod.cabal"
 }
 
 hook hooky {

--- a/.hooky.kdl
+++ b/.hooky.kdl
@@ -1,0 +1,52 @@
+hook hlint {
+    command hlint {
+        pass_files xargs
+    }
+    files *.hs
+}
+
+hook ormolu {
+    command ormolu {
+        check_args --mode check
+        fix_args --mode inplace
+        pass_files xargs
+    }
+    files *.hs
+}
+
+hook cabal_gild {
+    command cabal-gild {
+        check_args --input scrod.cabal --mode check
+        fix_args --io scrod.cabal --mode format
+        pass_files none
+    }
+    files /scrod.cabal
+}
+
+hook cabal_check {
+    command cabal check {
+        pass_files none
+    }
+    files /scrod.cabal
+}
+
+hook hooky {
+    command hooky lint {
+        fix_args --fix
+        pass_files file
+    }
+    files *
+}
+
+lint_rules {
+    - check_broken_symlinks
+    - check_case_conflict
+    - check_merge_conflict
+    - end_of_file_fixer
+    - no_commit_to_branch {
+        branches {
+            - main
+        }
+    }
+    - trailing_whitespace
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ hlint source/                                        # lint Haskell
 ormolu --mode check $(find source -name "*.hs")      # check formatting
 ormolu --mode inplace $(find source -name "*.hs")    # fix formatting
 cabal-gild --input scrod.cabal --mode check          # check .cabal formatting
-cabal-gild --input scrod.cabal --mode format         # fix .cabal formatting
+cabal-gild --io scrod.cabal --mode format         # fix .cabal formatting
 cabal check                                          # validate .cabal file
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,13 @@
 # Contributing
 
+## Setup
+
+After cloning the repo, install Git hooks:
+
+```bash
+hooky install
+```
+
 ## Build Commands
 
 ```bash

--- a/flake.nix
+++ b/flake.nix
@@ -63,9 +63,6 @@
         in
         {
           default = pkgs.mkShell {
-            shellHook = ''
-              hooky install
-            '';
             nativeBuildInputs = [
               ghc-wasm-meta.packages.${system}.default
               hooky

--- a/flake.nix
+++ b/flake.nix
@@ -63,6 +63,9 @@
         in
         {
           default = pkgs.mkShell {
+            shellHook = ''
+              hooky install
+            '';
             nativeBuildInputs = [
               ghc-wasm-meta.packages.${system}.default
               hooky

--- a/flake.nix
+++ b/flake.nix
@@ -19,11 +19,53 @@
         system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
+          hooky =
+            let
+              version = "1.0.2";
+              assets = {
+                aarch64-darwin = {
+                  suffix = "darwin-arm64";
+                  hash = "sha256-v1VeSGibVHVpO3SyaKKS0+AvZ8wuSIVu5cOhOrsMIT4=";
+                };
+                aarch64-linux = {
+                  suffix = "linux-arm64";
+                  hash = "sha256-R51KwBTSgL0x+DBodXApjhuYOQuPOcZwnlEqoNDfJlM=";
+                };
+                x86_64-darwin = {
+                  suffix = "darwin-x86_64";
+                  hash = "sha256-DAaWhze5gkSDvJN3oAojct3gIYmtRDzb7ejadxrT5MY=";
+                };
+                x86_64-linux = {
+                  suffix = "linux-x86_64";
+                  hash = "sha256-RVPI287fjjqV8lVfgRfnbJsF3JNOKWj8RmbmsCSE8JY=";
+                };
+              };
+              asset = assets.${system};
+            in
+            pkgs.stdenv.mkDerivation {
+              pname = "hooky";
+              inherit version;
+              src = pkgs.fetchurl {
+                url = "https://github.com/brandonchinn178/hooky/releases/download/v${version}/hooky-${version}-${asset.suffix}";
+                inherit (asset) hash;
+              };
+              dontUnpack = true;
+              nativeBuildInputs = pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+                pkgs.autoPatchelfHook
+              ];
+              buildInputs = pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+                pkgs.gmp
+              ];
+              installPhase = ''
+                install -Dm755 $src $out/bin/hooky
+              '';
+            };
         in
         {
           default = pkgs.mkShell {
             nativeBuildInputs = [
               ghc-wasm-meta.packages.${system}.default
+              hooky
               pkgs.cabal-install
               pkgs.fzf
               pkgs.gh


### PR DESCRIPTION
Fixes #303.

## Summary

- Adds a `.hooky.kdl` configuration file for [Hooky](https://github.com/brandonchinn178/hooky), a minimal git hooks manager
- Configures the following hooks:
  - **hlint** — lints staged Haskell files
  - **ormolu** — checks/fixes formatting of staged Haskell files (`--mode check` / `--mode inplace`)
  - **cabal_gild** — checks/fixes `.cabal` file formatting (`--mode check` / `--mode format`)
  - **cabal_check** — validates the `.cabal` file when it changes
  - **hooky** — runs Hooky's built-in lint rules
- Enables all requested built-in lint rules:
  - `check_broken_symlinks`
  - `check_case_conflict`
  - `check_merge_conflict`
  - `end_of_file_fixer`
  - `no_commit_to_branch` (blocks commits to `main`)
  - `trailing_whitespace`

After merging, contributors install the hooks locally with `hooky install` (or `hooky install --mode fix` to auto-fix on commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)