### PR TITLE
Extract shared extractDeclLocations helper for pragma modules

### DIFF
--- a/source/library/Scrod/Convert/FromGhc/FixityParents.hs
+++ b/source/library/Scrod/Convert/FromGhc/FixityParents.hs
@@ -18,10 +18,7 @@ import qualified Scrod.Core.Location as Location
 extractFixityLocations ::
   SrcLoc.Located (Syntax.HsModule Ghc.GhcPs) ->
   Set.Set Location.Location
-extractFixityLocations lHsModule =
-  let hsModule = SrcLoc.unLoc lHsModule
-      decls = Syntax.hsmodDecls hsModule
-   in Set.fromList $ concatMap extractDeclFixityLocations decls
+extractFixityLocations = Internal.extractDeclLocations extractDeclFixityLocations
 
 -- | Extract fixity name locations from a single declaration.
 extractDeclFixityLocations ::

--- a/source/library/Scrod/Convert/FromGhc/InlineParents.hs
+++ b/source/library/Scrod/Convert/FromGhc/InlineParents.hs
@@ -18,10 +18,7 @@ import qualified Scrod.Core.Location as Location
 extractInlineLocations ::
   SrcLoc.Located (Syntax.HsModule Ghc.GhcPs) ->
   Set.Set Location.Location
-extractInlineLocations lHsModule =
-  let hsModule = SrcLoc.unLoc lHsModule
-      decls = Syntax.hsmodDecls hsModule
-   in Set.fromList $ concatMap extractDeclInlineLocations decls
+extractInlineLocations = Internal.extractDeclLocations extractDeclInlineLocations
 
 -- | Extract inline name locations from a single declaration.
 extractDeclInlineLocations ::

--- a/source/library/Scrod/Convert/FromGhc/Internal.hs
+++ b/source/library/Scrod/Convert/FromGhc/Internal.hs
@@ -8,6 +8,7 @@ module Scrod.Convert.FromGhc.Internal where
 
 import qualified Control.Monad.Trans.State.Strict as State
 import qualified Data.List.NonEmpty as NonEmpty
+import qualified Data.Set as Set
 import qualified Data.Text as Text
 import qualified Documentation.Haddock.Types as Haddock
 import qualified GHC.Data.FastString as FastString
@@ -182,6 +183,17 @@ mkItemM ::
   ConvertM (Maybe (Located.Located Item.Item))
 mkItemM srcSpan parentKey itemName doc itemSince sig itemKind =
   fmap fst <$> mkItemWithKeyM srcSpan parentKey itemName doc itemSince sig itemKind
+
+-- | Extract source locations from module declarations using the given
+-- per-declaration extractor. Common skeleton for pragma location extraction.
+extractDeclLocations ::
+  (Syntax.LHsDecl Ghc.GhcPs -> [Location.Location]) ->
+  SrcLoc.Located (Syntax.HsModule Ghc.GhcPs) ->
+  Set.Set Location.Location
+extractDeclLocations extractFromDecl lHsModule =
+  let hsModule = SrcLoc.unLoc lHsModule
+      decls = Syntax.hsmodDecls hsModule
+   in Set.fromList $ concatMap extractFromDecl decls
 
 -- | Create an Item and return both the item and its allocated key.
 mkItemWithKeyM ::

--- a/source/library/Scrod/Convert/FromGhc/RoleParents.hs
+++ b/source/library/Scrod/Convert/FromGhc/RoleParents.hs
@@ -18,10 +18,7 @@ import qualified Scrod.Core.Location as Location
 extractRoleLocations ::
   SrcLoc.Located (Syntax.HsModule Ghc.GhcPs) ->
   Set.Set Location.Location
-extractRoleLocations lHsModule =
-  let hsModule = SrcLoc.unLoc lHsModule
-      decls = Syntax.hsmodDecls hsModule
-   in Set.fromList $ concatMap extractDeclRoleLocations decls
+extractRoleLocations = Internal.extractDeclLocations extractDeclRoleLocations
 
 -- | Extract role annotation name locations from a single declaration.
 extractDeclRoleLocations ::

--- a/source/library/Scrod/Convert/FromGhc/SpecialiseParents.hs
+++ b/source/library/Scrod/Convert/FromGhc/SpecialiseParents.hs
@@ -18,10 +18,7 @@ import qualified Scrod.Core.Location as Location
 extractSpecialiseLocations ::
   SrcLoc.Located (Syntax.HsModule Ghc.GhcPs) ->
   Set.Set Location.Location
-extractSpecialiseLocations lHsModule =
-  let hsModule = SrcLoc.unLoc lHsModule
-      decls = Syntax.hsmodDecls hsModule
-   in Set.fromList $ concatMap extractDeclSpecialiseLocations decls
+extractSpecialiseLocations = Internal.extractDeclLocations extractDeclSpecialiseLocations
 
 -- | Extract specialise name locations from a single declaration.
 extractDeclSpecialiseLocations ::

--- a/source/library/Scrod/Convert/FromGhc/WarningParents.hs
+++ b/source/library/Scrod/Convert/FromGhc/WarningParents.hs
@@ -19,10 +19,7 @@ import qualified Scrod.Core.Location as Location
 extractWarningLocations ::
   SrcLoc.Located (Syntax.HsModule Ghc.GhcPs) ->
   Set.Set Location.Location
-extractWarningLocations lHsModule =
-  let hsModule = SrcLoc.unLoc lHsModule
-      decls = Syntax.hsmodDecls hsModule
-   in Set.fromList $ concatMap extractDeclWarningLocations decls
+extractWarningLocations = Internal.extractDeclLocations extractDeclWarningLocations
 
 -- | Extract warning name locations from a single declaration.
 extractDeclWarningLocations ::


### PR DESCRIPTION
## Summary
- Adds `extractDeclLocations` to `Scrod.Convert.FromGhc.Internal` — a higher-order helper that unpacks an `LHsModule`, walks its declarations, and collects locations into a `Set`
- Replaces identical 4-line boilerplate in WarningParents, FixityParents, InlineParents, SpecialiseParents, and RoleParents with a single call to the shared function
- Each module retains its per-declaration pattern-match function; only the top-level skeleton is deduplicated

## Test plan
- [ ] `cabal build` compiles successfully
- [ ] `cabal test` passes (pure refactoring, no behavioral change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)