### PR TITLE
Extract setParentKey utility to deduplicate record updates

### DIFF
--- a/source/library/Scrod/Convert/FromGhc/CompleteParents.hs
+++ b/source/library/Scrod/Convert/FromGhc/CompleteParents.hs
@@ -85,7 +85,4 @@ resolveCompleteParent completeNames locationToKey locItem =
               Just loc -> case Map.lookup loc locationToKey of
                 Nothing -> locItem
                 Just parentKey ->
-                  locItem
-                    { Located.value =
-                        val {Item.parentKey = Just parentKey}
-                    }
+                  Internal.setParentKey parentKey locItem

--- a/source/library/Scrod/Convert/FromGhc/FamilyInstanceParents.hs
+++ b/source/library/Scrod/Convert/FromGhc/FamilyInstanceParents.hs
@@ -91,7 +91,4 @@ resolveFamilyInstanceParent familyInstanceNames familyNameToKey locItem =
       case Map.lookup familyName familyNameToKey of
         Nothing -> locItem
         Just parentKey ->
-          locItem
-            { Located.value =
-                (Located.value locItem) {Item.parentKey = Just parentKey}
-            }
+          Internal.setParentKey parentKey locItem

--- a/source/library/Scrod/Convert/FromGhc/InstanceParents.hs
+++ b/source/library/Scrod/Convert/FromGhc/InstanceParents.hs
@@ -177,10 +177,10 @@ resolveInstanceParent headTypeNames classNames typeNameToKey locItem =
           if Item.kind val == ItemKind.ClassInstance || Item.kind val == ItemKind.StandaloneDeriving
             then case lookupParentKey (Located.location locItem) headTypeNames typeNameToKey of
               Just parentKey ->
-                locItem {Located.value = val {Item.parentKey = Just parentKey}}
+                Internal.setParentKey parentKey locItem
               Nothing -> case lookupParentKey (Located.location locItem) classNames typeNameToKey of
                 Just parentKey ->
-                  locItem {Located.value = val {Item.parentKey = Just parentKey}}
+                  Internal.setParentKey parentKey locItem
                 Nothing -> locItem
             else locItem
 

--- a/source/library/Scrod/Convert/FromGhc/Internal.hs
+++ b/source/library/Scrod/Convert/FromGhc/Internal.hs
@@ -170,6 +170,11 @@ metaSinceToSince metaSince = do
           Version.MkVersion $ fmap (fromIntegral :: Int -> Natural.Natural) versionNE
       }
 
+-- | Set the parent key on a located item.
+setParentKey :: ItemKey.ItemKey -> Located.Located Item.Item -> Located.Located Item.Item
+setParentKey pk li =
+  li {Located.value = (Located.value li) {Item.parentKey = Just pk}}
+
 -- | Create an Item from a source span with the given properties.
 mkItemM ::
   SrcLoc.SrcSpan ->

--- a/source/library/Scrod/Convert/FromGhc/ParentAssociation.hs
+++ b/source/library/Scrod/Convert/FromGhc/ParentAssociation.hs
@@ -9,6 +9,7 @@ module Scrod.Convert.FromGhc.ParentAssociation where
 import qualified Data.Map as Map
 import qualified Data.Maybe as Maybe
 import qualified Data.Set as Set
+import qualified Scrod.Convert.FromGhc.Internal as Internal
 import qualified Scrod.Core.Item as Item
 import qualified Scrod.Core.ItemKey as ItemKey
 import qualified Scrod.Core.ItemName as ItemName
@@ -64,8 +65,5 @@ resolveParent pragmaLocations nameToKey locItem =
         case Map.lookup name nameToKey of
           Nothing -> locItem
           Just parentKey ->
-            locItem
-              { Located.value =
-                  (Located.value locItem) {Item.parentKey = Just parentKey}
-              }
+            Internal.setParentKey parentKey locItem
     else locItem


### PR DESCRIPTION
## Summary
- Adds `setParentKey` to `Scrod.Convert.FromGhc.Internal`, mirroring the existing shared utility pattern
- Replaces four inline record-update expressions in InstanceParents, FamilyInstanceParents, CompleteParents, and ParentAssociation
- Eliminates minor syntactic inconsistencies (some used a bound `val`, others repeated `Located.value locItem`)

## Test plan
- [ ] `cabal build` compiles successfully
- [ ] `cabal test` passes (pure refactoring, no behavioral change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)