### PR TITLE
Extract baseItemName utility to deduplicate base-name logic

### DIFF
--- a/source/library/Scrod/Convert/FromGhc/ExportOrdering.hs
+++ b/source/library/Scrod/Convert/FromGhc/ExportOrdering.hs
@@ -14,6 +14,7 @@ import qualified Data.Maybe as Maybe
 import qualified Data.Set as Set
 import qualified Data.Text as Text
 import qualified Numeric.Natural as Natural
+import qualified Scrod.Convert.FromGhc.Internal as Internal
 import qualified Scrod.Core.Category as Category
 import qualified Scrod.Core.Column as Column
 import qualified Scrod.Core.Doc as Doc
@@ -66,12 +67,8 @@ topLevelNameMap items =
       Maybe.isNothing (Item.parentKey (Located.value li)),
       Just n <- [Item.name (Located.value li)],
       let full = ItemName.unwrap n,
-      entry <- (full, li) : [(base, li) | Just base <- [stripTyVars full], base /= full]
+      entry <- (full, li) : [(base, li) | Just base <- [Internal.baseItemName full]]
     ]
-  where
-    stripTyVars t = case Text.words t of
-      (w : _) -> Just w
-      _ -> Nothing
 
 -- | Compute the next available item key (one past the maximum).
 nextItemKey :: [Located.Located Item.Item] -> Natural.Natural

--- a/source/library/Scrod/Convert/FromGhc/InstanceParents.hs
+++ b/source/library/Scrod/Convert/FromGhc/InstanceParents.hs
@@ -9,7 +9,6 @@ module Scrod.Convert.FromGhc.InstanceParents where
 
 import qualified Data.Map as Map
 import qualified Data.Maybe as Maybe
-import qualified Data.Text as Text
 import GHC.Hs ()
 import qualified GHC.Hs.Extension as Ghc
 import qualified GHC.Parser.Annotation as Annotation
@@ -144,11 +143,8 @@ buildTypeNameToKeyMap =
                   Just n ->
                     let k = Item.key val
                         full = ItemName.unwrap n
-                     in (n, k) : [(ItemName.MkItemName base, k) | Just base <- [baseName full], base /= full]
+                     in (n, k) : [(ItemName.MkItemName base, k) | Just base <- [Internal.baseItemName full]]
                 else []
-    baseName t = case Text.words t of
-      (w : _) -> Just w
-      _ -> Nothing
 
 -- | Check if an item kind represents a type or class definition.
 isTypeOrClassKind :: ItemKind.ItemKind -> Bool

--- a/source/library/Scrod/Convert/FromGhc/Internal.hs
+++ b/source/library/Scrod/Convert/FromGhc/Internal.hs
@@ -170,6 +170,14 @@ metaSinceToSince metaSince = do
           Version.MkVersion $ fmap (fromIntegral :: Int -> Natural.Natural) versionNE
       }
 
+-- | Extract the base name (first word) from an item name that contains
+-- type variables. Returns 'Nothing' if the name is a single word (no
+-- type variables) or empty.
+baseItemName :: Text.Text -> Maybe Text.Text
+baseItemName t = case Text.words t of
+  (w : _ : _) -> Just w
+  _ -> Nothing
+
 -- | Create an Item from a source span with the given properties.
 mkItemM ::
   SrcLoc.SrcSpan ->

--- a/source/library/Scrod/Convert/FromGhc/KindSigParents.hs
+++ b/source/library/Scrod/Convert/FromGhc/KindSigParents.hs
@@ -13,7 +13,6 @@ module Scrod.Convert.FromGhc.KindSigParents where
 import qualified Data.Map as Map
 import qualified Data.Maybe as Maybe
 import qualified Data.Set as Set
-import qualified Data.Text as Text
 import qualified Scrod.Convert.FromGhc.Internal as Internal
 import qualified Scrod.Core.Item as Item
 import qualified Scrod.Core.ItemKind as ItemKind
@@ -62,11 +61,8 @@ buildDeclNameSet =
               Nothing -> []
               Just n ->
                 let full = ItemName.unwrap n
-                 in n : [ItemName.MkItemName base | Just base <- [baseName full], base /= full]
+                 in n : [ItemName.MkItemName base | Just base <- [Internal.baseItemName full]]
             else []
-    baseName t = case Text.words t of
-      (w : _) -> Just w
-      _ -> Nothing
 
 -- | For each item, either merge a matching kind signature into it,
 -- remove a consumed kind signature, or pass it through unchanged.
@@ -100,9 +96,9 @@ mergeOrRemoveKindSig kindSigMap declNames locItem =
         Just x -> Just x
         Nothing ->
           let full = ItemName.unwrap name
-           in case Text.words full of
-                (w : _ : _) -> Map.lookup (ItemName.MkItemName w) m
-                _ -> Nothing
+           in case Internal.baseItemName full of
+                Just w -> Map.lookup (ItemName.MkItemName w) m
+                Nothing -> Nothing
 
 -- | Merge a standalone kind signature's metadata into a declaration.
 -- The kind signature's signature text and \@since\@ annotation take

--- a/source/library/Scrod/Convert/FromGhc/Visibility.hs
+++ b/source/library/Scrod/Convert/FromGhc/Visibility.hs
@@ -5,6 +5,7 @@ import qualified Data.Map as Map
 import qualified Data.Maybe as Maybe
 import qualified Data.Set as Set
 import qualified Data.Text as Text
+import qualified Scrod.Convert.FromGhc.Internal as Internal
 import qualified Scrod.Core.Export as Export
 import qualified Scrod.Core.ExportIdentifier as ExportIdentifier
 import qualified Scrod.Core.ExportName as ExportName
@@ -70,9 +71,9 @@ computeVisibility (Just exports) items =
     nameIsExported :: Text.Text -> Set.Set Text.Text -> Bool
     nameIsExported full names =
       Set.member full names
-        || case Text.words full of
-          (w : _ : _) -> Set.member w names
-          _ -> False
+        || case Internal.baseItemName full of
+          Just w -> Set.member w names
+          Nothing -> False
 
     -- Classify a child of an exported parent based on subordinate
     -- restrictions. Non-traditional subordinates (e.g. associated type
@@ -176,9 +177,5 @@ topLevelNameToKey items =
       Just n <- [Item.name (Located.value li)],
       let full = ItemName.unwrap n,
       let k = Item.key (Located.value li),
-      entry <- (full, k) : [(base, k) | Just base <- [stripTyVars full], base /= full]
+      entry <- (full, k) : [(base, k) | Just base <- [Internal.baseItemName full]]
     ]
-  where
-    stripTyVars t = case Text.words t of
-      (w : _) -> Just w
-      _ -> Nothing


### PR DESCRIPTION
## Summary
- Adds `baseItemName` to `Scrod.Convert.FromGhc.Internal` — extracts the first word from names containing type variables (e.g., `"C a"` → `Just "C"`)
- Replaces four independent implementations of the same logic in ExportOrdering, Visibility, InstanceParents, and KindSigParents
- Standardizes on `(w : _ : _)` pattern, fixing a subtle inconsistency where three modules would return a base name even for single-word names

## Test plan
- [ ] `cabal build` compiles successfully
- [ ] `cabal test` passes (no behavioral change expected — only Visibility already used the stricter pattern, and the others only call base-name lookup with names that have spaces)

🤖 Generated with [Claude Code](https://claude.com/claude-code)