### PR TITLE
Extract SigArguments module from Names

### DIFF
--- a/scrod.cabal
+++ b/scrod.cabal
@@ -106,6 +106,7 @@ library
     Scrod.Convert.FromGhc.Names
     Scrod.Convert.FromGhc.ParentAssociation
     Scrod.Convert.FromGhc.RoleParents
+    Scrod.Convert.FromGhc.SigArguments
     Scrod.Convert.FromGhc.SpecialiseParents
     Scrod.Convert.FromGhc.Visibility
     Scrod.Convert.FromGhc.WarningParents

--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -48,6 +48,7 @@ import qualified Scrod.Convert.FromGhc.Merge as Merge
 import qualified Scrod.Convert.FromGhc.Names as Names
 import qualified Scrod.Convert.FromGhc.ParentAssociation as ParentAssociation
 import qualified Scrod.Convert.FromGhc.RoleParents as RoleParents
+import qualified Scrod.Convert.FromGhc.SigArguments as SigArguments
 import qualified Scrod.Convert.FromGhc.SpecialiseParents as SpecialiseParents
 import qualified Scrod.Convert.FromGhc.Visibility as Visibility
 import qualified Scrod.Convert.FromGhc.WarningParents as WarningParents
@@ -428,7 +429,7 @@ convertSigDeclM ::
 convertSigDeclM doc docSince lDecl sig = case sig of
   Syntax.TypeSig _ names _ ->
     let sigText = Names.extractSigSignature sig
-        (args, retType) = Names.extractSigArguments sig
+        (args, retType) = SigArguments.extractSigArguments sig
      in fmap concat . Traversable.for names $ \lName -> do
           parentResult <-
             Internal.mkItemWithKeyM
@@ -447,7 +448,7 @@ convertSigDeclM doc docSince lDecl sig = case sig of
               pure $ [parentItem] <> argItems <> retItem
   Syntax.PatSynSig _ names _ ->
     let sigText = Names.extractSigSignature sig
-        (args, retType) = Names.extractSigArguments sig
+        (args, retType) = SigArguments.extractSigArguments sig
      in fmap concat . Traversable.for names $ \lName -> do
           parentResult <-
             Internal.mkItemWithKeyM
@@ -695,7 +696,7 @@ convertClassDeclWithDocM parentKey doc docSince lDecl = case SrcLoc.unLoc lDecl 
   Syntax.SigD _ sig -> case sig of
     Syntax.ClassOpSig _ _ names _ ->
       let sigText = Names.extractSigSignature sig
-          (args, retType) = Names.extractSigArguments sig
+          (args, retType) = SigArguments.extractSigArguments sig
        in fmap concat . Traversable.for names $ \lName -> do
             parentResult <-
               Internal.mkItemWithKeyM

--- a/source/library/Scrod/Convert/FromGhc/Names.hs
+++ b/source/library/Scrod/Convert/FromGhc/Names.hs
@@ -10,12 +10,12 @@ import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Maybe as Maybe
 import qualified Data.Text as Text
 import GHC.Hs ()
-import qualified GHC.Hs.Doc as HsDoc
 import qualified GHC.Hs.Extension as Ghc
 import qualified GHC.Types.SrcLoc as SrcLoc
 import qualified GHC.Utils.Outputable as Outputable
 import qualified Language.Haskell.Syntax as Syntax
 import qualified Scrod.Convert.FromGhc.Internal as Internal
+import qualified Scrod.Convert.FromGhc.SigArguments as SigArguments
 import qualified Scrod.Core.ItemName as ItemName
 
 -- | Extract declaration name.
@@ -188,108 +188,12 @@ extractSigName sig = case sig of
 extractSigSignature :: Syntax.Sig Ghc.GhcPs -> Maybe Text.Text
 extractSigSignature sig = case sig of
   Syntax.TypeSig _ _ ty ->
-    Just . Text.pack . Internal.showSDocShort . Outputable.ppr $ stripHsSigWcType ty
+    Just . Text.pack . Internal.showSDocShort . Outputable.ppr $ SigArguments.stripHsSigWcType ty
   Syntax.PatSynSig _ _ ty ->
-    Just . Text.pack . Internal.showSDocShort . Outputable.ppr $ stripHsSigType ty
+    Just . Text.pack . Internal.showSDocShort . Outputable.ppr $ SigArguments.stripHsSigType ty
   Syntax.ClassOpSig _ _ _ ty ->
-    Just . Text.pack . Internal.showSDocShort . Outputable.ppr $ stripHsSigType ty
+    Just . Text.pack . Internal.showSDocShort . Outputable.ppr $ SigArguments.stripHsSigType ty
   _ -> Nothing
-
--- | Strip 'HsDocTy' wrappers from a wildcard-wrapped signature type.
-stripHsSigWcType ::
-  Syntax.LHsSigWcType Ghc.GhcPs -> Syntax.LHsSigWcType Ghc.GhcPs
-stripHsSigWcType wc =
-  wc {Syntax.hswc_body = stripHsSigType (Syntax.hswc_body wc)}
-
--- | Strip 'HsDocTy' wrappers from a signature type.
-stripHsSigType :: Syntax.LHsSigType Ghc.GhcPs -> Syntax.LHsSigType Ghc.GhcPs
-stripHsSigType lSigType = case SrcLoc.unLoc lSigType of
-  Syntax.HsSig {Syntax.sig_ext = ext, Syntax.sig_bndrs = bndrs, Syntax.sig_body = body} ->
-    let stripped = stripHsDocTy body
-     in SrcLoc.L
-          (SrcLoc.getLoc lSigType)
-          Syntax.HsSig
-            { Syntax.sig_ext = ext,
-              Syntax.sig_bndrs = bndrs,
-              Syntax.sig_body = stripped
-            }
-
--- | Recursively strip 'HsDocTy' wrappers from a located type.
--- Recurses into 'HsFunTy', 'HsForAllTy', 'HsQualTy', and 'HsParTy' to
--- ensure all embedded doc comments are removed.
-stripHsDocTy :: Syntax.LHsType Ghc.GhcPs -> Syntax.LHsType Ghc.GhcPs
-stripHsDocTy lTy = case lTy of
-  SrcLoc.L ann hsType -> case hsType of
-    Syntax.HsDocTy _ inner _ -> stripHsDocTy inner
-    Syntax.HsFunTy x mult arg res ->
-      SrcLoc.L ann $ Syntax.HsFunTy x mult (stripHsDocTy arg) (stripHsDocTy res)
-    Syntax.HsForAllTy x tele body ->
-      SrcLoc.L ann $ Syntax.HsForAllTy x tele (stripHsDocTy body)
-    Syntax.HsQualTy x ctx body ->
-      SrcLoc.L ann $ Syntax.HsQualTy x ctx (stripHsDocTy body)
-    Syntax.HsParTy x inner ->
-      SrcLoc.L ann $ Syntax.HsParTy x (stripHsDocTy inner)
-    _ -> lTy
-
--- | Extract argument types and their optional doc comments from a type
--- signature. Walks the 'HsFunTy' chain, collecting each argument's
--- pretty-printed type text and its 'LHsDoc' (if the argument was wrapped
--- in 'HsDocTy'). The return type is included only when it has documentation.
---
--- Returns a pair of (arguments, optional return type).
---
--- Handles 'TypeSig' (unwrap via 'hswc_body'), 'PatSynSig', and
--- 'ClassOpSig' (unwrap via 'sig_body' on 'HsSigType').
-extractSigArguments ::
-  Syntax.Sig Ghc.GhcPs ->
-  ( [(Text.Text, Maybe (HsDoc.LHsDoc Ghc.GhcPs))],
-    Maybe (Text.Text, Maybe (HsDoc.LHsDoc Ghc.GhcPs))
-  )
-extractSigArguments sig = case sig of
-  Syntax.TypeSig _ _ wc ->
-    extractArgsFromBody . Syntax.sig_body . SrcLoc.unLoc $ Syntax.hswc_body wc
-  Syntax.PatSynSig _ _ lSigType ->
-    extractArgsFromBody . Syntax.sig_body $ SrcLoc.unLoc lSigType
-  Syntax.ClassOpSig _ _ _ lSigType ->
-    extractArgsFromBody . Syntax.sig_body $ SrcLoc.unLoc lSigType
-  _ -> ([], Nothing)
-
--- | Skip through 'HsForAllTy' and 'HsQualTy' to reach the arrow chain,
--- then extract arguments from the 'HsFunTy' chain. Returns the arguments
--- and the optional documented return type separately.
-extractArgsFromBody ::
-  Syntax.LHsType Ghc.GhcPs ->
-  ( [(Text.Text, Maybe (HsDoc.LHsDoc Ghc.GhcPs))],
-    Maybe (Text.Text, Maybe (HsDoc.LHsDoc Ghc.GhcPs))
-  )
-extractArgsFromBody lTy = case SrcLoc.unLoc lTy of
-  Syntax.HsForAllTy _ _ body -> extractArgsFromBody body
-  Syntax.HsQualTy _ _ body -> extractArgsFromBody body
-  Syntax.HsFunTy _ _ arg res ->
-    let (args, ret) = extractArgsFromBody res
-     in (extractArg arg : args, ret)
-  Syntax.HsDocTy _ inner _doc -> case SrcLoc.unLoc inner of
-    Syntax.HsFunTy _ _ arg res ->
-      let (args, ret) = extractArgsFromBody res
-       in (extractArg arg : args, ret)
-    _ -> ([], Just (extractArg lTy))
-  _ -> ([], Nothing)
-
--- | Extract the type text and optional doc comment from a single argument.
--- If the argument is wrapped in 'HsDocTy', the doc is extracted and the
--- inner type is pretty-printed (with any nested doc annotations stripped).
--- Otherwise, the argument is pretty-printed as-is with no doc.
-extractArg ::
-  Syntax.LHsType Ghc.GhcPs -> (Text.Text, Maybe (HsDoc.LHsDoc Ghc.GhcPs))
-extractArg lTy = case SrcLoc.unLoc lTy of
-  Syntax.HsDocTy _ inner doc ->
-    ( Text.pack . Internal.showSDocShort . Outputable.ppr $ stripHsDocTy inner,
-      Just doc
-    )
-  _ ->
-    ( Text.pack . Internal.showSDocShort . Outputable.ppr $ stripHsDocTy lTy,
-      Nothing
-    )
 
 -- | Extract name from an instance declaration.
 extractInstDeclName :: Syntax.InstDecl Ghc.GhcPs -> Maybe ItemName.ItemName

--- a/source/library/Scrod/Convert/FromGhc/SigArguments.hs
+++ b/source/library/Scrod/Convert/FromGhc/SigArguments.hs
@@ -1,0 +1,112 @@
+-- | Argument and return-type extraction from GHC type signatures.
+--
+-- Provides functions to walk the 'HsFunTy' chain of a type signature,
+-- collecting each argument's pretty-printed type text and its optional
+-- Haddock documentation. Also provides utilities to strip 'HsDocTy'
+-- wrappers from types before pretty-printing.
+module Scrod.Convert.FromGhc.SigArguments where
+
+import qualified Data.Text as Text
+import GHC.Hs ()
+import qualified GHC.Hs.Doc as HsDoc
+import qualified GHC.Hs.Extension as Ghc
+import qualified GHC.Types.SrcLoc as SrcLoc
+import qualified GHC.Utils.Outputable as Outputable
+import qualified Language.Haskell.Syntax as Syntax
+import qualified Scrod.Convert.FromGhc.Internal as Internal
+
+-- | Extract argument types and their optional doc comments from a type
+-- signature. Walks the 'HsFunTy' chain, collecting each argument's
+-- pretty-printed type text and its 'LHsDoc' (if the argument was wrapped
+-- in 'HsDocTy'). The return type is included only when it has documentation.
+--
+-- Returns a pair of (arguments, optional return type).
+--
+-- Handles 'TypeSig' (unwrap via 'hswc_body'), 'PatSynSig', and
+-- 'ClassOpSig' (unwrap via 'sig_body' on 'HsSigType').
+extractSigArguments ::
+  Syntax.Sig Ghc.GhcPs ->
+  ( [(Text.Text, Maybe (HsDoc.LHsDoc Ghc.GhcPs))],
+    Maybe (Text.Text, Maybe (HsDoc.LHsDoc Ghc.GhcPs))
+  )
+extractSigArguments sig = case sig of
+  Syntax.TypeSig _ _ wc ->
+    extractArgsFromBody . Syntax.sig_body . SrcLoc.unLoc $ Syntax.hswc_body wc
+  Syntax.PatSynSig _ _ lSigType ->
+    extractArgsFromBody . Syntax.sig_body $ SrcLoc.unLoc lSigType
+  Syntax.ClassOpSig _ _ _ lSigType ->
+    extractArgsFromBody . Syntax.sig_body $ SrcLoc.unLoc lSigType
+  _ -> ([], Nothing)
+
+-- | Skip through 'HsForAllTy' and 'HsQualTy' to reach the arrow chain,
+-- then extract arguments from the 'HsFunTy' chain. Returns the arguments
+-- and the optional documented return type separately.
+extractArgsFromBody ::
+  Syntax.LHsType Ghc.GhcPs ->
+  ( [(Text.Text, Maybe (HsDoc.LHsDoc Ghc.GhcPs))],
+    Maybe (Text.Text, Maybe (HsDoc.LHsDoc Ghc.GhcPs))
+  )
+extractArgsFromBody lTy = case SrcLoc.unLoc lTy of
+  Syntax.HsForAllTy _ _ body -> extractArgsFromBody body
+  Syntax.HsQualTy _ _ body -> extractArgsFromBody body
+  Syntax.HsFunTy _ _ arg res ->
+    let (args, ret) = extractArgsFromBody res
+     in (extractArg arg : args, ret)
+  Syntax.HsDocTy _ inner _doc -> case SrcLoc.unLoc inner of
+    Syntax.HsFunTy _ _ arg res ->
+      let (args, ret) = extractArgsFromBody res
+       in (extractArg arg : args, ret)
+    _ -> ([], Just (extractArg lTy))
+  _ -> ([], Nothing)
+
+-- | Extract the type text and optional doc comment from a single argument.
+-- If the argument is wrapped in 'HsDocTy', the doc is extracted and the
+-- inner type is pretty-printed (with any nested doc annotations stripped).
+-- Otherwise, the argument is pretty-printed as-is with no doc.
+extractArg ::
+  Syntax.LHsType Ghc.GhcPs -> (Text.Text, Maybe (HsDoc.LHsDoc Ghc.GhcPs))
+extractArg lTy = case SrcLoc.unLoc lTy of
+  Syntax.HsDocTy _ inner doc ->
+    ( Text.pack . Internal.showSDocShort . Outputable.ppr $ stripHsDocTy inner,
+      Just doc
+    )
+  _ ->
+    ( Text.pack . Internal.showSDocShort . Outputable.ppr $ stripHsDocTy lTy,
+      Nothing
+    )
+
+-- | Strip 'HsDocTy' wrappers from a wildcard-wrapped signature type.
+stripHsSigWcType ::
+  Syntax.LHsSigWcType Ghc.GhcPs -> Syntax.LHsSigWcType Ghc.GhcPs
+stripHsSigWcType wc =
+  wc {Syntax.hswc_body = stripHsSigType (Syntax.hswc_body wc)}
+
+-- | Strip 'HsDocTy' wrappers from a signature type.
+stripHsSigType :: Syntax.LHsSigType Ghc.GhcPs -> Syntax.LHsSigType Ghc.GhcPs
+stripHsSigType lSigType = case SrcLoc.unLoc lSigType of
+  Syntax.HsSig {Syntax.sig_ext = ext, Syntax.sig_bndrs = bndrs, Syntax.sig_body = body} ->
+    let stripped = stripHsDocTy body
+     in SrcLoc.L
+          (SrcLoc.getLoc lSigType)
+          Syntax.HsSig
+            { Syntax.sig_ext = ext,
+              Syntax.sig_bndrs = bndrs,
+              Syntax.sig_body = stripped
+            }
+
+-- | Recursively strip 'HsDocTy' wrappers from a located type.
+-- Recurses into 'HsFunTy', 'HsForAllTy', 'HsQualTy', and 'HsParTy' to
+-- ensure all embedded doc comments are removed.
+stripHsDocTy :: Syntax.LHsType Ghc.GhcPs -> Syntax.LHsType Ghc.GhcPs
+stripHsDocTy lTy = case lTy of
+  SrcLoc.L ann hsType -> case hsType of
+    Syntax.HsDocTy _ inner _ -> stripHsDocTy inner
+    Syntax.HsFunTy x mult arg res ->
+      SrcLoc.L ann $ Syntax.HsFunTy x mult (stripHsDocTy arg) (stripHsDocTy res)
+    Syntax.HsForAllTy x tele body ->
+      SrcLoc.L ann $ Syntax.HsForAllTy x tele (stripHsDocTy body)
+    Syntax.HsQualTy x ctx body ->
+      SrcLoc.L ann $ Syntax.HsQualTy x ctx (stripHsDocTy body)
+    Syntax.HsParTy x inner ->
+      SrcLoc.L ann $ Syntax.HsParTy x (stripHsDocTy inner)
+    _ -> lTy


### PR DESCRIPTION
## Summary
- Creates new `Scrod.Convert.FromGhc.SigArguments` module for argument and return-type extraction from type signatures
- Moves `extractSigArguments`, `extractArgsFromBody`, `extractArg`, `stripHsDocTy`, `stripHsSigType`, and `stripHsSigWcType` out of Names.hs
- Names.hs now imports SigArguments for the `strip*` functions it still needs for `extractSigSignature`
- Keeps Names.hs focused on simple name/signature extraction (~200 lines instead of ~325)

## Test plan
- [ ] `cabal build` compiles successfully
- [ ] `cabal test` passes (pure module extraction, no behavioral change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)