### PR TITLE
Fix self-closing non-void HTML tags in XML renderer

### DIFF
--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -4,7 +4,7 @@
 --
 -- Produces a complete @\<html\>@ document with Bootstrap 5 and KaTeX
 -- loaded from CDNs. The output uses the custom XML types in
--- @Scrod.Xml.*@ and can be serialized with 'Xml.encode'.
+-- @Scrod.Xml.*@ and can be serialized with 'Xml.encodeHtml'.
 module Scrod.Convert.ToHtml (toHtml) where
 
 import qualified Data.List as List
@@ -669,11 +669,7 @@ kindToString x = case x of
 
 docContents :: Doc.Doc -> [Content.Content Element.Element]
 docContents doc = case doc of
-  -- The empty string node prevents the XML renderer from emitting a
-  -- self-closing tag (e.g. <div/>) on any parent element, which is not valid
-  -- HTML. Use 'Content.isEmpty' rather than 'null' to test whether the
-  -- resulting content list is effectively empty.
-  Doc.Empty -> [Xml.string ""]
+  Doc.Empty -> []
   Doc.Append xs -> foldMap docContents xs
   Doc.String x -> [element "span" [("class", "text-break")] [Xml.text x]]
   Doc.Paragraph x -> [element "p" [] $ docContents x]
@@ -690,7 +686,7 @@ docContents doc = case doc of
   Doc.Pic x -> [pictureContent x]
   Doc.MathInline x -> [Xml.string "\\(", Xml.text x, Xml.string "\\)"]
   Doc.MathDisplay x -> [Xml.string "\\[", Xml.text x, Xml.string "\\]"]
-  Doc.AName x -> [element "a" [("id", Text.unpack x)] [Xml.string ""]]
+  Doc.AName x -> [element "a" [("id", Text.unpack x)] []]
   Doc.Property x -> [propertyContent x]
   Doc.Examples xs -> exampleContent <$> NonEmpty.toList xs
   Doc.Header x -> [headerContent x]

--- a/source/library/Scrod/Executable/Main.hs
+++ b/source/library/Scrod/Executable/Main.hs
@@ -69,5 +69,5 @@ mainWith name arguments myGetContents = ExceptT.runExceptT $ do
   module_ <- Either.throw . Bifunctor.first userError $ FromGhc.fromGhc isSignature result
   let convert = case Config.format config of
         Format.Json -> Json.encode . ToJson.toJson
-        Format.Html -> Xml.encode . ToHtml.toHtml
+        Format.Html -> Xml.encodeHtml . ToHtml.toHtml
   pure $ convert module_ <> Builder.charUtf8 '\n'

--- a/source/library/Scrod/Xml/Content.hs
+++ b/source/library/Scrod/Xml/Content.hs
@@ -21,8 +21,7 @@ data Content a
 
 -- | Returns 'True' for content nodes that render as the empty string (empty
 -- 'Text' or 'Raw' nodes). Useful for checking whether a list of content is
--- effectively empty without stripping the nodes themselves (which may be
--- needed to prevent self-closing tags).
+-- effectively empty.
 isEmpty :: Content a -> Bool
 isEmpty c = case c of
   Text t -> Text.null t

--- a/source/library/Scrod/Xml/Element.hs
+++ b/source/library/Scrod/Xml/Element.hs
@@ -3,6 +3,7 @@
 module Scrod.Xml.Element where
 
 import qualified Data.ByteString.Builder as Builder
+import qualified Data.Set as Set
 import qualified Data.Text as Text
 import qualified Scrod.Extra.Builder as Builder
 import qualified Scrod.Spec as Spec
@@ -46,6 +47,47 @@ encodeWithContents el =
 encodeAttributes :: [Attribute.Attribute] -> Builder.Builder
 encodeAttributes = foldMap (\a -> Builder.charUtf8 ' ' <> Attribute.encode a)
 
+-- | Encode an element as HTML. Only void elements are self-closing; all
+-- other elements use open and close tags even when empty.
+encodeHtml :: Element -> Builder.Builder
+encodeHtml el =
+  if null (contents el) && isHtmlVoidElement (Name.unwrap $ name el)
+    then encodeSelfClosing el
+    else
+      Builder.charUtf8 '<'
+        <> Name.encode (name el)
+        <> encodeAttributes (attributes el)
+        <> Builder.charUtf8 '>'
+        <> foldMap (Content.encode encodeHtml) (contents el)
+        <> Builder.stringUtf8 "</"
+        <> Name.encode (name el)
+        <> Builder.charUtf8 '>'
+
+-- | Whether a tag name is an HTML void element that may be self-closing.
+-- See <https://html.spec.whatwg.org/multipage/syntax.html#void-elements>.
+isHtmlVoidElement :: Text.Text -> Bool
+isHtmlVoidElement = (`Set.member` htmlVoidElements)
+
+htmlVoidElements :: Set.Set Text.Text
+htmlVoidElements =
+  Set.fromList $
+    fmap
+      Text.pack
+      [ "area",
+        "base",
+        "br",
+        "col",
+        "embed",
+        "hr",
+        "img",
+        "input",
+        "link",
+        "meta",
+        "source",
+        "track",
+        "wbr"
+      ]
+
 spec :: (Applicative m, Monad n) => Spec.Spec m n -> n ()
 spec s = do
   let mkName :: String -> Name.Name
@@ -75,3 +117,22 @@ spec s = do
 
     Spec.it s "escapes text content" $ do
       Spec.assertEq s (Builder.toString . encode $ MkElement (mkName "foo") [] [Content.Text $ Text.pack "a & b"]) "<foo>a &amp; b</foo>"
+
+  Spec.named s 'encodeHtml $ do
+    Spec.it s "self-closes void elements" $ do
+      Spec.assertEq s (Builder.toString . encodeHtml $ MkElement (mkName "br") [] []) "<br />"
+
+    Spec.it s "self-closes void elements with attributes" $ do
+      Spec.assertEq s (Builder.toString . encodeHtml $ MkElement (mkName "img") [mkAttr "src" "x.png"] []) "<img src=\"x.png\" />"
+
+    Spec.it s "uses paired tags for non-void elements when empty" $ do
+      Spec.assertEq s (Builder.toString . encodeHtml $ MkElement (mkName "div") [] []) "<div></div>"
+
+    Spec.it s "uses paired tags for non-void elements with content" $ do
+      Spec.assertEq s (Builder.toString . encodeHtml $ MkElement (mkName "div") [] [mkText "hello"]) "<div>hello</div>"
+
+    Spec.it s "applies recursively to nested elements" $ do
+      Spec.assertEq s (Builder.toString . encodeHtml $ MkElement (mkName "div") [] [mkElement "span" [] []]) "<div><span></span></div>"
+
+    Spec.it s "applies recursively to nested void elements" $ do
+      Spec.assertEq s (Builder.toString . encodeHtml $ MkElement (mkName "div") [] [mkElement "br" [] []]) "<div><br /></div>"


### PR DESCRIPTION
Fixes #312.

## Summary

- Added `encodeHtml` functions to `Scrod.Xml.Element` and `Scrod.Xml.Document` that only self-close HTML void elements (`area`, `base`, `br`, `col`, `embed`, `hr`, `img`, `input`, `link`, `meta`, `source`, `track`, `wbr`). All other elements use paired open/close tags even when empty.
- Updated `Scrod.Executable.Main` to use `Xml.encodeHtml` for HTML output.
- Removed the `Xml.string ""` workaround in `ToHtml.docContents` for `Doc.Empty` and `Doc.AName` that existed solely to prevent self-closing tags on parent elements.

## Test plan

- [x] Added unit tests for `encodeHtml` in `Element.hs` (void vs non-void, attributes, recursive behavior)
- [x] Added unit tests for `encodeHtml` in `Document.hs`
- [x] All 790 tests pass
- [x] Verified the issue example (`f :: a {-^ x -} -> a`) no longer produces `<div />`

🤖 Generated with [Claude Code](https://claude.com/claude-code)