### PR TITLE
Skip bench artifact in release script

### DIFF
--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -36,6 +36,10 @@ do
       cp "$dir"/*.vsix .
       continue
       ;;
+    # The bench job uploads an artifact matching the same name pattern. The
+    # release job doesn't depend on bench, so the artifact may or may not be
+    # present depending on timing. Skip it if it shows up.
+    bench) continue ;;
     *) echo "unknown platform: $platform" >&2; exit 1 ;;
   esac
   tar --extract --file "$dir/artifact.tar"


### PR DESCRIPTION
## Summary
- The release job downloads all artifacts matching `scrod-<sha>-*`, which can include the `bench` artifact depending on timing since the release job doesn't depend on the bench job
- This race condition caused the [2026-02-21 release](https://github.com/tfausak/scrod/actions/runs/22248055244/job/64366338874) to fail with `unknown platform: bench`
- Add a `bench) continue ;;` case to `release.sh` so it skips the bench artifact if present

## Test plan
- [x] Re-run the failed release workflow dispatch after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)