### PR TITLE
Extract hooky derivation into nix/hooky.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,47 +19,7 @@
         system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
-          hooky =
-            let
-              version = "1.0.2";
-              assets = {
-                aarch64-darwin = {
-                  suffix = "darwin-arm64";
-                  hash = "sha256-v1VeSGibVHVpO3SyaKKS0+AvZ8wuSIVu5cOhOrsMIT4=";
-                };
-                aarch64-linux = {
-                  suffix = "linux-arm64";
-                  hash = "sha256-R51KwBTSgL0x+DBodXApjhuYOQuPOcZwnlEqoNDfJlM=";
-                };
-                x86_64-darwin = {
-                  suffix = "darwin-x86_64";
-                  hash = "sha256-DAaWhze5gkSDvJN3oAojct3gIYmtRDzb7ejadxrT5MY=";
-                };
-                x86_64-linux = {
-                  suffix = "linux-x86_64";
-                  hash = "sha256-RVPI287fjjqV8lVfgRfnbJsF3JNOKWj8RmbmsCSE8JY=";
-                };
-              };
-              asset = assets.${system};
-            in
-            pkgs.stdenv.mkDerivation {
-              pname = "hooky";
-              inherit version;
-              src = pkgs.fetchurl {
-                url = "https://github.com/brandonchinn178/hooky/releases/download/v${version}/hooky-${version}-${asset.suffix}";
-                inherit (asset) hash;
-              };
-              dontUnpack = true;
-              nativeBuildInputs = pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux [
-                pkgs.autoPatchelfHook
-              ];
-              buildInputs = pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux [
-                pkgs.gmp
-              ];
-              installPhase = ''
-                install -Dm755 $src $out/bin/hooky
-              '';
-            };
+          hooky = import ./nix/hooky.nix { inherit pkgs; };
         in
         {
           default = pkgs.mkShell {

--- a/nix/hooky.nix
+++ b/nix/hooky.nix
@@ -1,0 +1,41 @@
+{ pkgs }:
+let
+  version = "1.0.2";
+  assets = {
+    aarch64-darwin = {
+      suffix = "darwin-arm64";
+      hash = "sha256-v1VeSGibVHVpO3SyaKKS0+AvZ8wuSIVu5cOhOrsMIT4=";
+    };
+    aarch64-linux = {
+      suffix = "linux-arm64";
+      hash = "sha256-R51KwBTSgL0x+DBodXApjhuYOQuPOcZwnlEqoNDfJlM=";
+    };
+    x86_64-darwin = {
+      suffix = "darwin-x86_64";
+      hash = "sha256-DAaWhze5gkSDvJN3oAojct3gIYmtRDzb7ejadxrT5MY=";
+    };
+    x86_64-linux = {
+      suffix = "linux-x86_64";
+      hash = "sha256-RVPI287fjjqV8lVfgRfnbJsF3JNOKWj8RmbmsCSE8JY=";
+    };
+  };
+  asset = assets.${pkgs.system};
+in
+pkgs.stdenv.mkDerivation {
+  pname = "hooky";
+  inherit version;
+  src = pkgs.fetchurl {
+    url = "https://github.com/brandonchinn178/hooky/releases/download/v${version}/hooky-${version}-${asset.suffix}";
+    inherit (asset) hash;
+  };
+  dontUnpack = true;
+  nativeBuildInputs = pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+    pkgs.autoPatchelfHook
+  ];
+  buildInputs = pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+    pkgs.gmp
+  ];
+  installPhase = ''
+    install -Dm755 $src $out/bin/hooky
+  '';
+}


### PR DESCRIPTION
## Summary
- Extracts the inline `hooky` derivation from `flake.nix` into a standalone `nix/hooky.nix` file
- Makes the derivation easier to reuse or promote to a separate flake later

## Test plan
- [ ] `nix develop` still provides `hooky` in the shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)