### PR TITLE
Retain conlike and phase modifiers on inline pragmas

### DIFF
--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -2096,7 +2096,7 @@ spec s = Spec.describe s "integration" $ do
         {-# inline [1] j #-}
         """
         [ ("/items/1/value/kind/type", "\"InlineSignature\""),
-          ("/items/1/value/signature", "\"INLINE\""),
+          ("/items/1/value/signature", "\"INLINE [1]\""),
           ("/items/1/value/parentKey", "0")
         ]
 
@@ -2108,7 +2108,19 @@ spec s = Spec.describe s "integration" $ do
         {-# inline [~2] k #-}
         """
         [ ("/items/1/value/kind/type", "\"InlineSignature\""),
-          ("/items/1/value/signature", "\"INLINE\""),
+          ("/items/1/value/signature", "\"INLINE [~2]\""),
+          ("/items/1/value/parentKey", "0")
+        ]
+
+    Spec.it s "inline pragma with conlike modifier" $ do
+      check
+        s
+        """
+        k2 = ()
+        {-# inline conlike k2 #-}
+        """
+        [ ("/items/1/value/kind/type", "\"InlineSignature\""),
+          ("/items/1/value/signature", "\"INLINE CONLIKE\""),
           ("/items/1/value/parentKey", "0")
         ]
 


### PR DESCRIPTION
## Summary
- Extract CONLIKE modifier and phase activation (e.g., `[1]`, `[~2]`) from GHC's `InlinePragma` into the signature text, instead of discarding them
- Replaces `inlineSpecToText` (which only extracted the keyword) with `inlinePragmaToText` (which extracts keyword + conlike + phase)
- Adds a new test for the conlike modifier and updates existing phase control tests

Closes #319
Closes #320

## Test plan
- [x] All 791 existing tests pass
- [x] New test for conlike modifier added
- [x] Phase control tests updated to verify `[1]` and `[~2]` are retained
- [x] Builds with `--flags=pedantic`

🤖 Generated with [Claude Code](https://claude.com/claude-code)