### PR TITLE
Show named default declarations in output

### DIFF
--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -2347,6 +2347,15 @@ spec s = Spec.describe s "integration" $ do
     Spec.it s "default declaration" $ do
       check s "default ()" [("/items", "[]")]
 
+    Spec.it s "named default declaration" $ do
+      check
+        s
+        "{-# language NamedDefaults #-} default Num (Int, Double)"
+        [ ("/items/0/value/kind/type", "\"Default\""),
+          ("/items/0/value/name", "\"Num\""),
+          ("/items/0/value/signature", "\"Int, Double\"")
+        ]
+
     Spec.it s "foreign import" $ do
       check
         s


### PR DESCRIPTION
## Summary
- Named defaults (e.g. `default Num (Int, Double)` via `NamedDefaults`) are now converted to documentation items with the class as the name and default types as the signature
- Unnamed defaults like `default ()` remain excluded since they don't contribute to documentation
- Adds `convertDefaultDeclM` that inspects the `defd_class` field to distinguish named from unnamed defaults

Closes #323

## Test plan
- [x] All existing tests pass (unnamed `default ()` still produces `[]`)
- [x] New test for named default: verifies kind is `Default`, name is class name, signature is types
- [x] Builds with `--flags=pedantic`

🤖 Generated with [Claude Code](https://claude.com/claude-code)