### PR TITLE
Use export namespace to inform kind of unresolved exports

### DIFF
--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -3209,6 +3209,24 @@ spec s = Spec.describe s "integration" $ do
           ("/items/1/value/visibility/type", "\"Exported\"")
         ]
 
+    Spec.it s "explicit type namespace in export informs item kind" $ do
+      check
+        s
+        "{-# language ExplicitNamespaces #-} module A ( type B ) where"
+        [ ("/items/0/value/kind/type", "\"TypeSynonym\""),
+          ("/items/0/value/name", "\"B\""),
+          ("/items/0/value/signature", "")
+        ]
+
+    Spec.it s "explicit pattern namespace in export informs item kind" $ do
+      check
+        s
+        "{-# language ExplicitNamespaces, PatternSynonyms #-} module A ( pattern P ) where"
+        [ ("/items/0/value/kind/type", "\"PatternSynonym\""),
+          ("/items/0/value/name", "\"P\""),
+          ("/items/0/value/signature", "")
+        ]
+
 -- | Run the pipeline on the given Haskell source and assert JSON pointer
 -- expectations. Each @(pointer, json)@ pair asserts that the value at
 -- @pointer@ equals the parsed @json@. Use an empty string for @json@


### PR DESCRIPTION
## Summary
- When an export list uses an explicit namespace keyword (`type B`, `pattern P`), the namespace now informs the `ItemKind` (`TypeSynonym` or `PatternSynonym`) instead of being stored in the signature field
- Previously, `module A (type B) where` produced an `UnresolvedExport` with signature `"type"`, rendering confusingly as `type B (export)`. Now it produces a `TypeSynonym` named `B` with no signature
- Module re-exports (`module M`) retain `"module"` in the signature since there is no distinct item kind for them

Closes #325

## Test plan
- [x] All 792 tests pass
- [x] New test for `type B` export: verifies kind is `TypeSynonym` and name is just `B`
- [x] New test for `pattern P` export: verifies kind is `PatternSynonym`
- [x] Existing module re-export test still passes unchanged
- [x] Builds with `--flags=pedantic`

🤖 Generated with [Claude Code](https://claude.com/claude-code)