### PR TITLE
Preserve type variables when merging kind signatures

### DIFF
--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -2284,7 +2284,7 @@ spec s = Spec.describe s "integration" $ do
         data X a = X
         """
         [ ("/items/0/value/kind/type", "\"DataType\""),
-          ("/items/0/value/name", "\"X\""),
+          ("/items/0/value/name", "\"X a\""),
           ("/items/0/value/signature", "\"a -> a\""),
           ("/items/1/value/kind/type", "\"DataConstructor\""),
           ("/items/1/value/name", "\"X\""),
@@ -2299,7 +2299,7 @@ spec s = Spec.describe s "integration" $ do
         newtype Phantom a = MkPhantom ()
         """
         [ ("/items/0/value/kind/type", "\"Newtype\""),
-          ("/items/0/value/name", "\"Phantom\""),
+          ("/items/0/value/name", "\"Phantom a\""),
           ("/items/0/value/signature", "\"* -> *\""),
           ("/items/1/value/kind/type", "\"DataConstructor\""),
           ("/items/1/value/name", "\"MkPhantom\""),


### PR DESCRIPTION
## Summary
- When a standalone kind signature is merged into a data/newtype/type data declaration, the type variables from the declaration are now folded into the item name
- Before: `type A :: Type -> Type; data A b` produced name `"A"` with signature `"Type -> Type"` (variables lost)
- After: produces name `"A b"` with signature `"Type -> Type"` (renders as `A b (data) :: Type -> Type`)
- Only applies to data, newtype, and type data declarations; type synonyms, classes, and families are unaffected

Closes #322

## Test plan
- [x] All 790 tests pass
- [x] Updated tests for data + kind sig and newtype + kind sig to expect variables in name
- [x] Type synonym + kind sig test unchanged (type synonym signature is different)
- [x] Builds with `--flags=pedantic`

🤖 Generated with [Claude Code](https://claude.com/claude-code)