### PR TITLE
Render doc anchors as visible self-links

### DIFF
--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -701,7 +701,7 @@ docContents doc = case doc of
   Doc.Pic x -> [pictureContent x]
   Doc.MathInline x -> [Xml.string "\\(", Xml.text x, Xml.string "\\)"]
   Doc.MathDisplay x -> [Xml.string "\\[", Xml.text x, Xml.string "\\]"]
-  Doc.AName x -> [element "a" [("id", Text.unpack x)] []]
+  Doc.AName x -> [element "a" [("id", Text.unpack x), ("href", "#" <> Text.unpack x)] [Xml.string "#"]]
   Doc.Property x -> [propertyContent x]
   Doc.Examples xs -> exampleContent <$> NonEmpty.toList xs
   Doc.Header x -> [headerContent x]


### PR DESCRIPTION
## Summary
- Haddock anchors (`#name#`) now render as `<a id="name" href="#name">#</a>` instead of an empty invisible `<a id="name"></a>`
- The anchor is displayed as a hash symbol (`#`) that links to itself

Closes #317

## Test plan
- [x] All 792 tests pass
- [x] Verified HTML output: `<a id="a" href="#a">#</a>`
- [x] Builds with `--flags=pedantic`

🤖 Generated with [Claude Code](https://claude.com/claude-code)