### PR TITLE
Fix deprecated pkgs.system usage in hooky.nix

### DIFF
--- a/nix/hooky.nix
+++ b/nix/hooky.nix
@@ -19,7 +19,7 @@ let
       hash = "sha256-RVPI287fjjqV8lVfgRfnbJsF3JNOKWj8RmbmsCSE8JY=";
     };
   };
-  asset = assets.${pkgs.system};
+  asset = assets.${pkgs.stdenv.hostPlatform.system};
 in
 pkgs.stdenv.mkDerivation {
   pname = "hooky";


### PR DESCRIPTION
## Summary
- Replace `pkgs.system` with `pkgs.stdenv.hostPlatform.system` in `nix/hooky.nix` to fix the Nix evaluation warning: `'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'`

## Test plan
- [ ] Run `nix develop` and verify the warning is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)