### PR TITLE
Upload to Hackage as part of release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,4 +238,4 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: gh release create ${{ needs.meta.outputs.version }} --draft --generate-notes --target ${{ github.sha }} ${{ needs.meta.outputs.name }}-*.tar.gz ${{ needs.meta.outputs.name }}-*.json *.vsix
       - run: cabal upload --publish --token '${{ secrets.HACKAGE_TOKEN }}' ${{ needs.meta.outputs.name }}-${{ needs.meta.outputs.version }}.tar.gz
-      - run: cabal --http-transport=plain-http upload --documentation --publish --token '${{ secrets.HACKAGE_TOKEN }}' ${{ needs.meta.outputs.name }}-${{ needs.meta.outputs.version }}-docs.tar.gz
+      - run: cabal upload --documentation --publish --token '${{ secrets.HACKAGE_TOKEN }}' ${{ needs.meta.outputs.name }}-${{ needs.meta.outputs.version }}-docs.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - run: mkdir artifact
       - run: ghc-pkg list
       - run: cabal sdist --output-dir artifact
-      - run: cabal configure ${{ matrix.bench && '--enable-benchmarks' || '' }} ${{ matrix.doc && '--enable-documentation --haddock-for-hackage' || '' }} ${{ matrix.test && '--enable-tests' || '' }} --flags=pedantic --jobs
+      - run: cabal configure ${{ matrix.bench && '--enable-benchmarks' || '' }} ${{ matrix.test && '--enable-tests' || '' }} --flags=pedantic --jobs
       - run: cat cabal.project.local
       - run: cp cabal.project.local artifact
       - run: cabal freeze
@@ -45,6 +45,8 @@ jobs:
       - run: cabal build --only-download
       - run: cabal build --only-dependencies
       - run: cabal build
+      - if: matrix.doc
+        run: cabal haddock --haddock-for-hackage
       - if: matrix.doc
         run: cp dist-newstyle/${{ needs.meta.outputs.name }}-${{ needs.meta.outputs.version }}-docs.tar.gz artifact
       - run: cp $( cabal list-bin ${{ needs.meta.outputs.name }} ) artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,10 @@ jobs:
       - if: runner.os == 'Linux'
         run: cp dist-newstyle/${{ needs.meta.outputs.name }}-${{ needs.meta.outputs.version }}-docs.tar.gz artifact
       - run: cp $( cabal list-bin ${{ needs.meta.outputs.name }} ) artifact
-      - run: cp $( cabal list-bin ${{ needs.meta.outputs.name }}-test-suite ) artifact
-      - run: cp $( cabal list-bin ${{ needs.meta.outputs.name }}-benchmark ) artifact
+      - if: runner.os == 'Linux'
+        run: cp $( cabal list-bin ${{ needs.meta.outputs.name }}-test-suite ) artifact
+      - if: runner.os == 'Linux'
+        run: cp $( cabal list-bin ${{ needs.meta.outputs.name }}-benchmark ) artifact
       - run: artifact/${{ needs.meta.outputs.name }}${{ runner.os == 'Windows' && '.exe' || '' }} --schema > artifact/schema.json
         shell: bash
       - run: tar --create --file artifact.tar --verbose artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - run: mkdir artifact
       - run: ghc-pkg list
       - run: cabal sdist --output-dir artifact
-      - run: cabal configure ${{ matrix.bench && '--enable-benchmarks' || '' }} ${{ matrix.test && '--enable-tests' || '' }} --flags=pedantic --jobs
+      - run: cabal configure ${{ matrix.bench && '--enable-benchmarks' || '' }} ${{ matrix.doc && '--enable-documentation --haddock-for-hackage' || '' }} ${{ matrix.test && '--enable-tests' || '' }} --flags=pedantic --jobs
       - run: cat cabal.project.local
       - run: cp cabal.project.local artifact
       - run: cabal freeze
@@ -45,8 +45,6 @@ jobs:
       - run: cabal build --only-download
       - run: cabal build --only-dependencies
       - run: cabal build
-      - if: matrix.doc
-        run: cabal haddock --haddock-for-hackage
       - if: matrix.doc
         run: cp dist-newstyle/${{ needs.meta.outputs.name }}-${{ needs.meta.outputs.version }}-docs.tar.gz artifact
       - run: cp $( cabal list-bin ${{ needs.meta.outputs.name }} ) artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,10 @@ jobs:
       - run: mkdir artifact
       - run: ghc-pkg list
       - run: cabal sdist --output-dir artifact
-      - run: cabal configure --enable-documentation --enable-tests --enable-benchmarks --flags=pedantic --haddock-for-hackage --jobs
+      - if: runner.os == 'Linux'
+        run: cabal configure --enable-benchmarks --enable-documentation --enable-tests --flags=pedantic --haddock-for-hackage --jobs
+      - if: runner.os != 'Linux'
+        run: cabal configure --flags=pedantic --jobs
       - run: cat cabal.project.local
       - run: cp cabal.project.local artifact
       - run: cabal freeze

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - run: mkdir artifact
       - run: ghc-pkg list
       - run: cabal sdist --output-dir artifact
-      - run: cabal configure --enable-tests --enable-benchmarks --flags=pedantic --jobs
+      - run: cabal configure --enable-documentation --enable-tests --enable-benchmarks --flags=pedantic --haddock-for-hackage --jobs
       - run: cat cabal.project.local
       - run: cp cabal.project.local artifact
       - run: cabal freeze
@@ -42,6 +42,8 @@ jobs:
       - run: cabal build --only-download
       - run: cabal build --only-dependencies
       - run: cabal build
+      - if: runner.os == 'Linux'
+        run: cp dist-newstyle/${{ needs.meta.outputs.name }}-${{ needs.meta.outputs.version }}-docs.tar.gz artifact
       - run: cp $( cabal list-bin ${{ needs.meta.outputs.name }} ) artifact
       - run: cp $( cabal list-bin ${{ needs.meta.outputs.name }}-test-suite ) artifact
       - run: cp $( cabal list-bin ${{ needs.meta.outputs.name }}-benchmark ) artifact
@@ -230,3 +232,5 @@ jobs:
       - env:
           GH_TOKEN: ${{ github.token }}
         run: gh release create ${{ needs.meta.outputs.version }} --draft --generate-notes --target ${{ github.sha }} ${{ needs.meta.outputs.name }}-*.tar.gz ${{ needs.meta.outputs.name }}-*.json *.vsix
+      - run: cabal upload --publish --username '${{ secrets.HACKAGE_USERNAME }}' --password '${{ secrets.HACKAGE_PASSWORD }}' ${{ needs.meta.outputs.name }}-${{ needs.meta.outputs.version }}.tar.gz
+      - run: cabal --http-transport=plain-http upload --documentation --publish --username '${{ secrets.HACKAGE_USERNAME }}' --password '${{ secrets.HACKAGE_PASSWORD }}' ${{ needs.meta.outputs.name }}-${{ needs.meta.outputs.version }}-docs.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,13 @@ jobs:
     needs: meta
     strategy:
       matrix:
-        os:
-          - macos
-          - ubuntu
-          - windows
+        include:
+          - os: macos
+          - os: ubuntu
+            bench: true
+            doc: true
+            test: true
+          - os: windows
     steps:
       - uses: actions/checkout@v6
       - id: haskell
@@ -27,10 +30,7 @@ jobs:
       - run: mkdir artifact
       - run: ghc-pkg list
       - run: cabal sdist --output-dir artifact
-      - if: runner.os == 'Linux'
-        run: cabal configure --enable-benchmarks --enable-documentation --enable-tests --flags=pedantic --haddock-for-hackage --jobs
-      - if: runner.os != 'Linux'
-        run: cabal configure --flags=pedantic --jobs
+      - run: cabal configure ${{ matrix.bench && '--enable-benchmarks' || '' }} ${{ matrix.doc && '--enable-documentation --haddock-for-hackage' || '' }} ${{ matrix.test && '--enable-tests' || '' }} --flags=pedantic --jobs
       - run: cat cabal.project.local
       - run: cp cabal.project.local artifact
       - run: cabal freeze
@@ -45,12 +45,12 @@ jobs:
       - run: cabal build --only-download
       - run: cabal build --only-dependencies
       - run: cabal build
-      - if: runner.os == 'Linux'
+      - if: matrix.doc
         run: cp dist-newstyle/${{ needs.meta.outputs.name }}-${{ needs.meta.outputs.version }}-docs.tar.gz artifact
       - run: cp $( cabal list-bin ${{ needs.meta.outputs.name }} ) artifact
-      - if: runner.os == 'Linux'
+      - if: matrix.test
         run: cp $( cabal list-bin ${{ needs.meta.outputs.name }}-test-suite ) artifact
-      - if: runner.os == 'Linux'
+      - if: matrix.bench
         run: cp $( cabal list-bin ${{ needs.meta.outputs.name }}-benchmark ) artifact
       - run: artifact/${{ needs.meta.outputs.name }}${{ runner.os == 'Windows' && '.exe' || '' }} --schema > artifact/schema.json
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,5 +232,5 @@ jobs:
       - env:
           GH_TOKEN: ${{ github.token }}
         run: gh release create ${{ needs.meta.outputs.version }} --draft --generate-notes --target ${{ github.sha }} ${{ needs.meta.outputs.name }}-*.tar.gz ${{ needs.meta.outputs.name }}-*.json *.vsix
-      - run: cabal upload --publish --username '${{ secrets.HACKAGE_USERNAME }}' --password '${{ secrets.HACKAGE_PASSWORD }}' ${{ needs.meta.outputs.name }}-${{ needs.meta.outputs.version }}.tar.gz
-      - run: cabal --http-transport=plain-http upload --documentation --publish --username '${{ secrets.HACKAGE_USERNAME }}' --password '${{ secrets.HACKAGE_PASSWORD }}' ${{ needs.meta.outputs.name }}-${{ needs.meta.outputs.version }}-docs.tar.gz
+      - run: cabal upload --publish --token '${{ secrets.HACKAGE_TOKEN }}' ${{ needs.meta.outputs.name }}-${{ needs.meta.outputs.version }}.tar.gz
+      - run: cabal --http-transport=plain-http upload --documentation --publish --token '${{ secrets.HACKAGE_TOKEN }}' ${{ needs.meta.outputs.name }}-${{ needs.meta.outputs.version }}-docs.tar.gz

--- a/source/library/Scrod/Convert/FromGhc/Constructors.hs
+++ b/source/library/Scrod/Convert/FromGhc/Constructors.hs
@@ -128,12 +128,12 @@ extractConDeclSignature mParentType conDecl = case conDecl of
                 Just ad -> Outputable.hsep [ad, Outputable.text "->", Outputable.text (Text.unpack parentType)]
            in Just . Text.pack . Internal.showSDocShort $
                 Outputable.hsep [forallDoc, cxtDoc, bodyDoc]
-  c@Syntax.ConDeclGADT {} ->
+  c@Syntax.ConDeclGADT {Syntax.con_g_args = gArgs} ->
     let full =
           Text.pack . Internal.showSDocShort . Outputable.ppr $
             c
               { Syntax.con_doc = Nothing,
-                Syntax.con_g_args = stripGADTDetailsDocs (Syntax.con_g_args c)
+                Syntax.con_g_args = stripGADTDetailsDocs gArgs
               }
         sep = Text.pack " :: "
         (_, rest) = Text.breakOn sep full


### PR DESCRIPTION
Fixes #334.

## Summary

Adds Hackage upload steps to the CI release workflow, matching the approach used by [cabal-gild](https://github.com/tfausak/cabal-gild/blob/6372d59b18f054e4e4d1450df158f413efd8f5fe/.github/workflows/ci.yml#L93-L94):

- Adds `--enable-documentation --haddock-for-hackage` to the build job's `cabal configure` so that `cabal build` also generates a Hackage-ready documentation tarball
- Copies the docs tarball into the build artifact on Linux
- After creating the GitHub release, uploads the sdist tarball and documentation tarball to Hackage using `cabal upload`

**Note:** The `HACKAGE_USERNAME` and `HACKAGE_PASSWORD` secrets must be configured in the repository settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)