### PR TITLE
Add CalVer versioning note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Change log
 
-Scrod follows the [Package Versioning Policy](https://pvp.haskell.org).
+Scrod will follow the [Package Versioning Policy](https://pvp.haskell.org).
+While at major version 0, Scrod follows [CalVer](https://calver.org) instead.
+It uses the scheme `0.YYYY.MM.DD`.
+No stability is expected during this period.
 You can find release notes [on GitHub](https://github.com/tfausak/scrod/releases).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,6 @@
 
 Scrod will follow the [Package Versioning Policy](https://pvp.haskell.org).
 While at major version 0, Scrod follows [CalVer](https://calver.org) instead.
-It uses the scheme `0.YYYY.MM.DD`.
+It uses the scheme `0.YYYY.M.D`.
 No stability is expected during this period.
 You can find release notes [on GitHub](https://github.com/tfausak/scrod/releases).


### PR DESCRIPTION
## Summary
- Notes in CHANGELOG.md that while at major version 0, Scrod follows CalVer (`0.YYYY.MM.DD`) instead of PVP
- Clarifies no stability is expected during this period

## Test plan
- [x] Verify CHANGELOG.md content reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)