### PR TITLE
Fix signature placement before kind badge in HTML output

### DIFF
--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -610,13 +610,13 @@ itemContent item argChildren otherChildren =
                         Just n -> [element "code" [("class", "text-break")] [Xml.text $ ItemName.unwrap n]]
                     )
                 ]
-                <> earlySignature
                 <> [ element
                        "div"
                        [("class", "mx-1")]
                        [ element "span" [("class", "badge " <> badgeColor)] [Xml.string $ kindToString kind]
                        ]
                    ]
+                <> earlySignature
                 <> lateSignature
                 <> [ element
                        "div"


### PR DESCRIPTION
## Summary

Fixes #345.

- Swaps the order of the kind badge and early signature in the HTML card header so that items with standalone kind signatures (e.g. `type A :: Type -> Type` before `data A b`) render as **NAME KIND SIGNATURE** instead of **NAME SIGNATURE KIND**.
- The fix is a one-line swap in `ToHtml.hs` — the badge element is now emitted before `earlySignature` instead of after it.

## Test plan

- [x] `cabal build` succeeds
- [x] All 793 tests pass (`cabal test --test-options='--hide-successes'`)
- [ ] Manually verify with the examples from the issue:
  - `type A :: Type -> Type` / `data A b` → should show "X a **data** a -> a"
  - `type C :: Type -> Constraint` / `class C a` → should show "C a **class** Type -> Constraint"

🤖 Generated with [Claude Code](https://claude.com/claude-code)