### PR TITLE
Show arguments and return type together as a group

### DIFF
--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -442,9 +442,8 @@ convertSigDeclM doc docSince lDecl sig = case sig of
           case parentResult of
             Nothing -> pure []
             Just (parentItem, parentKey) -> do
-              argItems <- convertArguments (Just parentKey) (Annotation.getLocA lName) args
-              retItem <- convertReturnType (Just parentKey) (Annotation.getLocA lName) retType
-              pure $ [parentItem] <> argItems <> retItem
+              childItems <- convertArgumentsAndReturnType (Just parentKey) (Annotation.getLocA lName) args retType
+              pure $ parentItem : childItems
   Syntax.PatSynSig _ names _ ->
     let sigText = Names.extractSigSignature sig
         (args, retType) = SigArguments.extractSigArguments sig
@@ -461,9 +460,8 @@ convertSigDeclM doc docSince lDecl sig = case sig of
           case parentResult of
             Nothing -> pure []
             Just (parentItem, parentKey) -> do
-              argItems <- convertArguments (Just parentKey) (Annotation.getLocA lName) args
-              retItem <- convertReturnType (Just parentKey) (Annotation.getLocA lName) retType
-              pure $ [parentItem] <> argItems <> retItem
+              childItems <- convertArgumentsAndReturnType (Just parentKey) (Annotation.getLocA lName) args retType
+              pure $ parentItem : childItems
   Syntax.FixSig _ (Syntax.FixitySig _ names (SyntaxBasic.Fixity prec dir)) ->
     let fixityDoc = Doc.Paragraph . Doc.String $ fixityDirectionToText dir <> Text.pack (" " <> show prec)
         combinedDoc = combineDoc doc fixityDoc
@@ -483,16 +481,20 @@ convertSigDeclM doc docSince lDecl sig = case sig of
      in Maybe.maybeToList <$> Internal.mkItemM (Annotation.getLocA lDecl) Nothing Nothing doc docSince sigText ItemKind.CompletePragma
   _ -> Maybe.maybeToList <$> convertDeclWithDocM Nothing doc docSince (Names.extractSigName sig) Nothing lDecl
 
--- | Convert extracted argument data into child Argument items.
--- Returns no items if none of the arguments have documentation.
-convertArguments ::
+-- | Convert extracted argument and return-type data into child items.
+-- Shows all arguments and the return type as a group: if any argument
+-- or the return type has documentation, all are included; otherwise none.
+convertArgumentsAndReturnType ::
   Maybe ItemKey.ItemKey ->
   SrcLoc.SrcSpan ->
   [(Text.Text, Maybe (HsDoc.LHsDoc Ghc.GhcPs))] ->
+  Maybe (Text.Text, Maybe (HsDoc.LHsDoc Ghc.GhcPs)) ->
   Internal.ConvertM [Located.Located Item.Item]
-convertArguments parentKey srcSpan args
-  | any (Maybe.isJust . snd) args =
-      Maybe.catMaybes <$> traverse (convertOneArgument parentKey srcSpan) args
+convertArgumentsAndReturnType parentKey srcSpan args mRet
+  | any (Maybe.isJust . snd) args || maybe False (Maybe.isJust . snd) mRet = do
+      argItems <- Maybe.catMaybes <$> traverse (convertOneArgument parentKey srcSpan) args
+      retItem <- convertReturnType parentKey srcSpan mRet
+      pure $ argItems <> retItem
   | otherwise = pure []
 
 -- | Convert a single argument to an Argument item.
@@ -746,9 +748,8 @@ convertClassDeclWithDocM parentKey doc docSince lDecl = case SrcLoc.unLoc lDecl 
             case parentResult of
               Nothing -> pure []
               Just (methodItem, methodKey) -> do
-                argItems <- convertArguments (Just methodKey) (Annotation.getLocA lName) args
-                retItem <- convertReturnType (Just methodKey) (Annotation.getLocA lName) retType
-                pure $ [methodItem] <> argItems <> retItem
+                childItems <- convertArgumentsAndReturnType (Just methodKey) (Annotation.getLocA lName) args retType
+                pure $ methodItem : childItems
     _ -> pure []
   _ -> pure []
 

--- a/source/library/Scrod/Convert/FromGhc/SigArguments.hs
+++ b/source/library/Scrod/Convert/FromGhc/SigArguments.hs
@@ -18,7 +18,8 @@ import qualified Scrod.Convert.FromGhc.Internal as Internal
 -- | Extract argument types and their optional doc comments from a type
 -- signature. Walks the 'HsFunTy' chain, collecting each argument's
 -- pretty-printed type text and its 'LHsDoc' (if the argument was wrapped
--- in 'HsDocTy'). The return type is included only when it has documentation.
+-- in 'HsDocTy'). The return type is always included when the signature has
+-- function arrows.
 --
 -- Returns a pair of (arguments, optional return type).
 --
@@ -40,7 +41,7 @@ extractSigArguments sig = case sig of
 
 -- | Skip through 'HsForAllTy' and 'HsQualTy' to reach the arrow chain,
 -- then extract arguments from the 'HsFunTy' chain. Returns the arguments
--- and the optional documented return type separately.
+-- and the return type separately.
 extractArgsFromBody ::
   Syntax.LHsType Ghc.GhcPs ->
   ( [(Text.Text, Maybe (HsDoc.LHsDoc Ghc.GhcPs))],
@@ -57,7 +58,7 @@ extractArgsFromBody lTy = case SrcLoc.unLoc lTy of
       let (args, ret) = extractArgsFromBody res
        in (extractArg arg : args, ret)
     _ -> ([], Just (extractArg lTy))
-  _ -> ([], Nothing)
+  _ -> ([], Just (extractArg lTy))
 
 -- | Extract the type text and optional doc comment from a single argument.
 -- If the argument is wrapped in 'HsDocTy', the doc is extracted and the

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -2655,11 +2655,34 @@ spec s = Spec.describe s "integration" $ do
           ("/items/0/value/name", "\"f\""),
           ("/items/0/value/signature", "\"a -> a\""),
           ("/items/0/value/documentation/type", "\"Empty\""),
-          ("/items/1/value/kind/type", "\"ReturnType\""),
+          ("/items/1/value/kind/type", "\"Argument\""),
+          ("/items/1/value/parentKey", "0"),
+          ("/items/1/value/signature", "\"a\""),
+          ("/items/1/value/documentation/type", "\"Empty\""),
+          ("/items/2/value/kind/type", "\"ReturnType\""),
+          ("/items/2/value/parentKey", "0"),
+          ("/items/2/value/signature", "\"a\""),
+          ("/items/2/value/documentation/type", "\"Paragraph\""),
+          ("/items/2/value/documentation/value/value", "\"lost\"")
+        ]
+
+    Spec.it s "function with arg doc but no return doc" $ do
+      check
+        s
+        "f :: a {- ^ x -} -> b"
+        [ ("/items/0/value/kind/type", "\"Function\""),
+          ("/items/0/value/name", "\"f\""),
+          ("/items/0/value/signature", "\"a -> b\""),
+          ("/items/0/value/documentation/type", "\"Empty\""),
+          ("/items/1/value/kind/type", "\"Argument\""),
           ("/items/1/value/parentKey", "0"),
           ("/items/1/value/signature", "\"a\""),
           ("/items/1/value/documentation/type", "\"Paragraph\""),
-          ("/items/1/value/documentation/value/value", "\"lost\"")
+          ("/items/1/value/documentation/value/value", "\"x \""),
+          ("/items/2/value/kind/type", "\"ReturnType\""),
+          ("/items/2/value/parentKey", "0"),
+          ("/items/2/value/signature", "\"b\""),
+          ("/items/2/value/documentation/type", "\"Empty\"")
         ]
 
     Spec.it s "data constructor with arg doc has argument children" $ do


### PR DESCRIPTION
## Summary

Fixes #346.

- Arguments and return type are now shown or hidden together as a group. If any argument or the return type has documentation, all are included in the output; otherwise none are.
- Changed `extractArgsFromBody` in `SigArguments.hs` to always extract the return type (not just when it has documentation), so it's available when needed.
- Replaced separate `convertArguments`/`convertReturnType` calls with a unified `convertArgumentsAndReturnType` function at all three call sites (TypeSig, PatSynSig, ClassOpSig) that makes the group visibility decision.
- Updated existing test "function with return value doc only" to expect argument items.
- Added new test "function with arg doc but no return doc" covering the originally reported case.

## Test plan

- [x] `cabal build` succeeds
- [x] All 794 tests pass (`cabal test --test-options='--hide-successes'`)
- [ ] Manually verify with the examples from the issue:
  - `f :: a {- ^ x -} -> b` → should show both the `a` argument and `b` return type
  - `f :: a -> b {- ^ y -}` → should show both the `a` argument and `b` return type

🤖 Generated with [Claude Code](https://claude.com/claude-code)