### PR TITLE
Fix card header background color mismatch in VSCode extension

### DIFF
--- a/extra/vscode/src/extension.ts
+++ b/extra/vscode/src/extension.ts
@@ -183,6 +183,7 @@ function wrapperHtml(): string {
       border-color: var(--vscode-widget-border) !important;
     }
     .card-header {
+      background-color: transparent !important;
       border-color: var(--vscode-widget-border) !important;
     }
     .badge.text-bg-secondary {


### PR DESCRIPTION
## Summary

Fixes #347.

- Added `background-color: transparent !important;` to the `.card-header` CSS override in the VSCode webview.
- The `.card` background was already overridden to `var(--vscode-editorWidget-background)`, but Bootstrap's default `.card-header` background (`--bs-card-cap-bg`, a semi-transparent overlay) was creating a visible darker shade on the card header name area.
- Setting it to `transparent` makes the header inherit the card's background, matching the web app's appearance.

## Test plan

- [x] `cabal build` succeeds
- [x] All 793 tests pass
- [x] TypeScript type-check passes (`npx tsc --noEmit`)
- [ ] Manually verify in VSCode dark theme that the card header and body backgrounds match

🤖 Generated with [Claude Code](https://claude.com/claude-code)