### PR TITLE
Support module description fields

### DIFF
--- a/source/library/Scrod/Convert/FromGhc.hs
+++ b/source/library/Scrod/Convert/FromGhc.hs
@@ -171,7 +171,7 @@ extractModuleDocAndSince ::
   SrcLoc.Located (Syntax.HsModule Ghc.GhcPs) ->
   (Doc.Doc, Maybe Since.Since)
 extractModuleDocAndSince lHsModule =
-  maybe (Doc.Empty, Nothing) GhcDoc.parseDoc (extractRawDocString lHsModule)
+  maybe (Doc.Empty, Nothing) GhcDoc.parseModuleDoc (extractRawDocString lHsModule)
 
 -- | Extract raw documentation string from the module header.
 extractRawDocString ::

--- a/source/library/Scrod/Convert/FromGhc/Doc.hs
+++ b/source/library/Scrod/Convert/FromGhc/Doc.hs
@@ -118,14 +118,19 @@ parseFieldLines allLines@(l : rest) =
     Nothing -> ([], allLines)
 
 -- | Try to parse a line as a field header (@FieldName: value@).
+--
+-- Allows optional whitespace between the field name and the colon,
+-- e.g. both @Description: foo@ and @Description : foo@.
 parseFieldHeader :: String -> Maybe (String, String)
 parseFieldHeader line =
   let stripped = dropWhile Char.isSpace line
       lowered = fmap Char.toLower stripped
-   in case List.find (\name -> fmap Char.toLower (name <> ":") `List.isPrefixOf` lowered) moduleHeaderFieldNames of
+   in case List.find (\name -> fmap Char.toLower name `List.isPrefixOf` lowered) moduleHeaderFieldNames of
         Just name ->
-          let after = drop (length name + 1) stripped
-           in Just (name, after)
+          let afterName = dropWhile Char.isSpace $ drop (length name) stripped
+           in case afterName of
+                ':' : after -> Just (name, after)
+                _ -> Nothing
         Nothing -> Nothing
 
 -- | A continuation line starts with whitespace and is not blank.

--- a/source/library/Scrod/Convert/FromGhc/Doc.hs
+++ b/source/library/Scrod/Convert/FromGhc/Doc.hs
@@ -5,6 +5,8 @@
 -- 'Doc.Doc' type via the Haddock parser.
 module Scrod.Convert.FromGhc.Doc where
 
+import qualified Data.Char as Char
+import qualified Data.List as List
 import qualified Data.Set as Set
 import qualified Data.Text as Text
 import qualified Documentation.Haddock.Parser as Haddock
@@ -17,6 +19,7 @@ import qualified GHC.Types.SrcLoc as SrcLoc
 import qualified Language.Haskell.Syntax as Syntax
 import qualified Scrod.Convert.FromGhc.Internal as Internal
 import qualified Scrod.Convert.FromHaddock as FromHaddock
+import qualified Scrod.Core.Definition as Definition
 import qualified Scrod.Core.Doc as Doc
 import qualified Scrod.Core.Since as Since
 
@@ -44,6 +47,97 @@ parseDoc input =
       doc = FromHaddock.fromHaddock $ Haddock._doc metaDoc
       itemSince = Haddock._metaSince (Haddock._meta metaDoc) >>= Internal.metaSinceToSince
    in (doc, itemSince)
+
+-- | Parse module documentation, extracting header fields as a definition list.
+--
+-- Haddock module comments may begin with metadata fields like
+-- @Description@, @Copyright@, @License@, etc. This function strips
+-- those fields from the input, parses the remaining text with
+-- 'parseDoc', and prepends the fields as a 'Doc.DefList'.
+parseModuleDoc :: String -> (Doc.Doc, Maybe Since.Since)
+parseModuleDoc input =
+  let (fields, rest) = parseModuleHeaderFields input
+      (doc, since) = parseDoc rest
+      fieldsDoc = case fields of
+        [] -> Doc.Empty
+        _ ->
+          Doc.DefList $
+            fmap
+              ( \(name, value) ->
+                  Definition.MkDefinition
+                    { Definition.term = Doc.String $ Text.pack name,
+                      Definition.definition = Doc.String . Text.pack $ trimValue value
+                    }
+              )
+              fields
+   in (prependDoc fieldsDoc doc, since)
+
+-- | Prepend a doc node before another, handling empty cases.
+prependDoc :: Doc.Doc -> Doc.Doc -> Doc.Doc
+prependDoc Doc.Empty d = d
+prependDoc d Doc.Empty = d
+prependDoc a (Doc.Append xs) = Doc.Append (a : xs)
+prependDoc a b = Doc.Append [a, b]
+
+-- | Trim leading and trailing whitespace from a field value.
+trimValue :: String -> String
+trimValue = List.dropWhileEnd Char.isSpace . dropWhile Char.isSpace
+
+-- | Parse Haddock module header fields from a doc string.
+--
+-- Returns the list of @(fieldName, fieldValue)@ pairs and the
+-- remaining doc string after the fields section.
+parseModuleHeaderFields :: String -> ([(String, String)], String)
+parseModuleHeaderFields input =
+  let ls = lines input
+      (blanks, nonBlanks) = span (all Char.isSpace) ls
+      (fieldLines, restLines) = parseFieldLines nonBlanks
+   in case fieldLines of
+        [] -> ([], input)
+        _ -> (fieldLines, unlines (blanks <> restLines))
+
+-- | Known Haddock module header field names.
+moduleHeaderFieldNames :: [String]
+moduleHeaderFieldNames =
+  [ "Module",
+    "Description",
+    "Copyright",
+    "License",
+    "Maintainer",
+    "Stability",
+    "Portability"
+  ]
+
+-- | Parse field lines from the beginning of a doc string.
+--
+-- Each field is @FieldName: value@ possibly followed by indented
+-- continuation lines. Parsing stops at the first line that is not
+-- a known field header or a continuation of the previous field.
+parseFieldLines :: [String] -> ([(String, String)], [String])
+parseFieldLines [] = ([], [])
+parseFieldLines allLines@(l : rest) =
+  case parseFieldHeader l of
+    Just (name, value) ->
+      let (continuations, remaining) = span isContinuationLine rest
+          fullValue = List.intercalate "\n" (value : continuations)
+          (moreFields, finalRest) = parseFieldLines remaining
+       in ((name, fullValue) : moreFields, finalRest)
+    Nothing -> ([], allLines)
+
+-- | Try to parse a line as a field header (@FieldName: value@).
+parseFieldHeader :: String -> Maybe (String, String)
+parseFieldHeader line =
+  let stripped = dropWhile Char.isSpace line
+   in case List.find (\name -> (name <> ":") `List.isPrefixOf` stripped) moduleHeaderFieldNames of
+        Just name ->
+          let after = drop (length name + 1) stripped
+           in Just (name, after)
+        Nothing -> Nothing
+
+-- | A continuation line starts with whitespace and is not blank.
+isContinuationLine :: String -> Bool
+isContinuationLine [] = False
+isContinuationLine (c : cs) = Char.isSpace c && not (all Char.isSpace cs)
 
 -- | Associate documentation comments with their target declarations.
 --

--- a/source/library/Scrod/Convert/FromGhc/Doc.hs
+++ b/source/library/Scrod/Convert/FromGhc/Doc.hs
@@ -70,14 +70,7 @@ parseModuleDoc input =
                     }
               )
               fields
-   in (prependDoc fieldsDoc doc, since)
-
--- | Prepend a doc node before another, handling empty cases.
-prependDoc :: Doc.Doc -> Doc.Doc -> Doc.Doc
-prependDoc Doc.Empty d = d
-prependDoc d Doc.Empty = d
-prependDoc a (Doc.Append xs) = Doc.Append (a : xs)
-prependDoc a b = Doc.Append [a, b]
+   in (Internal.appendDoc fieldsDoc doc, since)
 
 -- | Trim leading and trailing whitespace from a field value.
 trimValue :: String -> String
@@ -128,7 +121,8 @@ parseFieldLines allLines@(l : rest) =
 parseFieldHeader :: String -> Maybe (String, String)
 parseFieldHeader line =
   let stripped = dropWhile Char.isSpace line
-   in case List.find (\name -> (name <> ":") `List.isPrefixOf` stripped) moduleHeaderFieldNames of
+      lowered = fmap Char.toLower stripped
+   in case List.find (\name -> fmap Char.toLower (name <> ":") `List.isPrefixOf` lowered) moduleHeaderFieldNames of
         Just name ->
           let after = drop (length name + 1) stripped
            in Just (name, after)

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -600,6 +600,83 @@ spec s = Spec.describe s "integration" $ do
           ("/documentation/value/bodyRows/1/1/contents/value", "\"g\"")
         ]
 
+  Spec.describe s "module description fields" $ do
+    Spec.it s "works with a single field" $ do
+      check
+        s
+        """
+        {-|
+        Description: some text
+        -}
+        module M where
+        """
+        [ ("/documentation/type", "\"DefList\""),
+          ("/documentation/value/0/term/type", "\"String\""),
+          ("/documentation/value/0/term/value", "\"Description\""),
+          ("/documentation/value/0/definition/type", "\"String\""),
+          ("/documentation/value/0/definition/value", "\"some text\"")
+        ]
+
+    Spec.it s "works with all fields" $ do
+      check
+        s
+        """
+        {-|
+        Module: a
+        Description: b
+        Copyright: c
+        License: d
+        Maintainer: e
+        Stability: f
+        Portability: g
+        -}
+        module M where
+        """
+        [ ("/documentation/type", "\"DefList\""),
+          ("/documentation/value/0/term/value", "\"Module\""),
+          ("/documentation/value/0/definition/value", "\"a\""),
+          ("/documentation/value/6/term/value", "\"Portability\""),
+          ("/documentation/value/6/definition/value", "\"g\"")
+        ]
+
+    Spec.it s "works with fields followed by documentation" $ do
+      check
+        s
+        """
+        {-|
+        Description: hello
+
+        Some docs.
+        -}
+        module M where
+        """
+        [ ("/documentation/type", "\"Append\""),
+          ("/documentation/value/0/type", "\"DefList\""),
+          ("/documentation/value/0/value/0/term/value", "\"Description\""),
+          ("/documentation/value/0/value/0/definition/value", "\"hello\""),
+          ("/documentation/value/1/type", "\"Paragraph\""),
+          ("/documentation/value/1/value/type", "\"String\""),
+          ("/documentation/value/1/value/value", "\"Some docs.\"")
+        ]
+
+    Spec.it s "works with multi-line field values" $ do
+      check
+        s
+        """
+        {-|
+        Copyright: (c) Someone, 2023
+                   Someone Else, 2024
+        License: BSD3
+        -}
+        module M where
+        """
+        [ ("/documentation/type", "\"DefList\""),
+          ("/documentation/value/0/term/value", "\"Copyright\""),
+          ("/documentation/value/0/definition/value", "\"(c) Someone, 2023\\n           Someone Else, 2024\""),
+          ("/documentation/value/1/term/value", "\"License\""),
+          ("/documentation/value/1/definition/value", "\"BSD3\"")
+        ]
+
   Spec.describe s "since" $ do
     Spec.it s "defaults to absent" $ do
       check s "" [("/since", "")]

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -676,6 +676,20 @@ spec s = Spec.describe s "integration" $ do
           ("/documentation/value/1/definition/value", "\"BSD3\"")
         ]
 
+    Spec.it s "works with space before colon" $ do
+      check
+        s
+        """
+        {-|
+        Description : hello
+        -}
+        module M where
+        """
+        [ ("/documentation/type", "\"DefList\""),
+          ("/documentation/value/0/term/value", "\"Description\""),
+          ("/documentation/value/0/definition/value", "\"hello\"")
+        ]
+
     Spec.it s "works with multi-line field values" $ do
       check
         s

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -659,6 +659,23 @@ spec s = Spec.describe s "integration" $ do
           ("/documentation/value/1/value/value", "\"Some docs.\"")
         ]
 
+    Spec.it s "works with case-insensitive field names" $ do
+      check
+        s
+        """
+        {-|
+        description: hello
+        LICENSE: BSD3
+        -}
+        module M where
+        """
+        [ ("/documentation/type", "\"DefList\""),
+          ("/documentation/value/0/term/value", "\"Description\""),
+          ("/documentation/value/0/definition/value", "\"hello\""),
+          ("/documentation/value/1/term/value", "\"License\""),
+          ("/documentation/value/1/definition/value", "\"BSD3\"")
+        ]
+
     Spec.it s "works with multi-line field values" $ do
       check
         s


### PR DESCRIPTION
Fixes #357.

## Summary

- Parses Haddock module header fields (Module, Description, Copyright, License, Maintainer, Stability, Portability) from module documentation comments
- Renders the parsed fields as a `DefList` (definition list) prepended to the module documentation
- In HTML output, this produces a `<dl>` with `<dt>`/`<dd>` pairs for each field
- In JSON output, fields appear as a `DefList` doc node — no changes needed to the `Module` type or rendering code
- Supports multi-line field values (continuation lines with leading whitespace)
- Adds 4 integration tests covering single field, all fields, fields with following documentation, and multi-line values

🤖 Generated with [Claude Code](https://claude.com/claude-code)