### PR TITLE
Support collapsible headers

### DIFF
--- a/scrod.cabal
+++ b/scrod.cabal
@@ -114,6 +114,7 @@ library
     Scrod.Convert.ToHtml
     Scrod.Convert.ToJsonSchema
     Scrod.Core.Category
+    Scrod.Core.Collapsible
     Scrod.Core.Column
     Scrod.Core.Definition
     Scrod.Core.Doc

--- a/source/library/Scrod/Convert/FromHaddock.hs
+++ b/source/library/Scrod/Convert/FromHaddock.hs
@@ -133,16 +133,22 @@ groupCollapsible doc = case doc of
   Doc.Append xs -> case groupHeaders $ flattenAppend xs of
     [single] -> single
     grouped -> Doc.Append grouped
-  Doc.Paragraph x -> Doc.Paragraph $ groupCollapsible x
-  Doc.Emphasis x -> Doc.Emphasis $ groupCollapsible x
-  Doc.Monospaced x -> Doc.Monospaced $ groupCollapsible x
-  Doc.Bold x -> Doc.Bold $ groupCollapsible x
-  Doc.UnorderedList xs -> Doc.UnorderedList $ fmap groupCollapsible xs
-  Doc.OrderedList xs -> Doc.OrderedList $ fmap (\ni -> ni {NumberedItem.item = groupCollapsible $ NumberedItem.item ni}) xs
-  Doc.DefList xs -> Doc.DefList $ fmap (\d -> d {Definition.term = groupCollapsible $ Definition.term d, Definition.definition = groupCollapsible $ Definition.definition d}) xs
-  Doc.CodeBlock x -> Doc.CodeBlock $ groupCollapsible x
-  Doc.Header h -> Doc.Header h {Header.title = groupCollapsible $ Header.title h}
-  _ -> doc
+  _ -> mapDocChildren groupCollapsible doc
+
+-- | Apply a function to all immediate 'Doc.Doc' children of a node.
+mapDocChildren :: (Doc.Doc -> Doc.Doc) -> Doc.Doc -> Doc.Doc
+mapDocChildren f doc = case doc of
+  Doc.Paragraph x -> Doc.Paragraph $ f x
+  Doc.Emphasis x -> Doc.Emphasis $ f x
+  Doc.Monospaced x -> Doc.Monospaced $ f x
+  Doc.Bold x -> Doc.Bold $ f x
+  Doc.UnorderedList xs -> Doc.UnorderedList $ fmap f xs
+  Doc.OrderedList xs -> Doc.OrderedList $ fmap (\ni -> ni {NumberedItem.item = f $ NumberedItem.item ni}) xs
+  Doc.DefList xs -> Doc.DefList $ fmap (\d -> d {Definition.term = f $ Definition.term d, Definition.definition = f $ Definition.definition d}) xs
+  Doc.CodeBlock x -> Doc.CodeBlock $ f x
+  Doc.Header h -> Doc.Header h {Header.title = f $ Header.title h}
+  Doc.CollapsibleHeader c -> Doc.CollapsibleHeader c {Collapsible.header = (Collapsible.header c) {Header.title = f . Header.title $ Collapsible.header c}, Collapsible.body = f $ Collapsible.body c}
+  other -> other
 
 flattenAppend :: [Doc.Doc] -> [Doc.Doc]
 flattenAppend = concatMap go
@@ -156,10 +162,14 @@ groupHeaders (Doc.Header h : rest)
   | Doc.Bold title <- Header.title h =
       let level = Header.level h
           (body, remaining) = break (isHeaderAtOrAbove level) rest
+          groupedBody = groupHeaders body
        in Doc.CollapsibleHeader
             Collapsible.MkCollapsible
               { Collapsible.header = h {Header.title = title},
-                Collapsible.body = body
+                Collapsible.body = case groupedBody of
+                  [] -> Doc.Empty
+                  [single] -> single
+                  multiple -> Doc.Append multiple
               }
             : groupHeaders remaining
 groupHeaders (x : rest) = x : groupHeaders rest
@@ -315,7 +325,7 @@ spec s = do
             Doc.CollapsibleHeader
               Collapsible.MkCollapsible
                 { Collapsible.header = Header.MkHeader {Header.level = Level.Two, Header.title = Doc.String $ Text.pack "Examples:"},
-                  Collapsible.body = [Doc.Paragraph . Doc.String $ Text.pack "content"]
+                  Collapsible.body = Doc.Paragraph . Doc.String $ Text.pack "content"
                 }
       Spec.assertEq s (fromHaddock input) expected
 

--- a/source/library/Scrod/Convert/FromHaddock.hs
+++ b/source/library/Scrod/Convert/FromHaddock.hs
@@ -12,6 +12,7 @@ import qualified Data.Text as Text
 import qualified Data.Void as Void
 import qualified Documentation.Haddock.Parser as Haddock
 import qualified Documentation.Haddock.Types as Haddock
+import qualified Scrod.Core.Collapsible as Collapsible
 import qualified Scrod.Core.Definition as Definition
 import qualified Scrod.Core.Doc as Doc
 import qualified Scrod.Core.Example as Example
@@ -29,7 +30,7 @@ import qualified Scrod.Core.TableCell as TableCell
 import qualified Scrod.Spec as Spec
 
 fromHaddock :: Haddock.DocH Void.Void Haddock.Identifier -> Doc.Doc
-fromHaddock = convertDoc . Haddock.overIdentifier convertIdentifier
+fromHaddock = groupCollapsible . convertDoc . Haddock.overIdentifier convertIdentifier
 
 convertIdentifier :: Haddock.Namespace -> String -> Maybe Identifier.Identifier
 convertIdentifier ns str =
@@ -122,6 +123,51 @@ convertTableCell cell =
       TableCell.rowspan = fromIntegral $ Haddock.tableCellRowspan cell,
       TableCell.contents = convertDoc $ Haddock.tableCellContents cell
     }
+
+-- | Post-processes a 'Doc.Doc' tree to detect collapsible headers.
+-- A collapsible header is a 'Doc.Header' whose title is wrapped in
+-- 'Doc.Bold'. The collapsible section extends until a header of equal
+-- or higher level (smaller level number), or the end of the list.
+groupCollapsible :: Doc.Doc -> Doc.Doc
+groupCollapsible doc = case doc of
+  Doc.Append xs -> case groupHeaders $ flattenAppend xs of
+    [single] -> single
+    grouped -> Doc.Append grouped
+  Doc.Paragraph x -> Doc.Paragraph $ groupCollapsible x
+  Doc.Emphasis x -> Doc.Emphasis $ groupCollapsible x
+  Doc.Monospaced x -> Doc.Monospaced $ groupCollapsible x
+  Doc.Bold x -> Doc.Bold $ groupCollapsible x
+  Doc.UnorderedList xs -> Doc.UnorderedList $ fmap groupCollapsible xs
+  Doc.OrderedList xs -> Doc.OrderedList $ fmap (\ni -> ni {NumberedItem.item = groupCollapsible $ NumberedItem.item ni}) xs
+  Doc.DefList xs -> Doc.DefList $ fmap (\d -> d {Definition.term = groupCollapsible $ Definition.term d, Definition.definition = groupCollapsible $ Definition.definition d}) xs
+  Doc.CodeBlock x -> Doc.CodeBlock $ groupCollapsible x
+  Doc.Header h -> Doc.Header h {Header.title = groupCollapsible $ Header.title h}
+  _ -> doc
+
+flattenAppend :: [Doc.Doc] -> [Doc.Doc]
+flattenAppend = concatMap go
+  where
+    go (Doc.Append xs) = flattenAppend xs
+    go x = [groupCollapsible x]
+
+groupHeaders :: [Doc.Doc] -> [Doc.Doc]
+groupHeaders [] = []
+groupHeaders (Doc.Header h : rest)
+  | Doc.Bold title <- Header.title h =
+      let level = Header.level h
+          (body, remaining) = break (isHeaderAtOrAbove level) rest
+       in Doc.CollapsibleHeader
+            Collapsible.MkCollapsible
+              { Collapsible.header = h {Header.title = title},
+                Collapsible.body = body
+              }
+            : groupHeaders remaining
+groupHeaders (x : rest) = x : groupHeaders rest
+
+isHeaderAtOrAbove :: Level.Level -> Doc.Doc -> Bool
+isHeaderAtOrAbove level doc = case doc of
+  Doc.Header h -> Header.level h <= level
+  _ -> False
 
 spec :: (Applicative m, Monad n) => Spec.Spec m n -> n ()
 spec s = do
@@ -257,6 +303,20 @@ spec s = do
       let input :: Haddock.DocH Void.Void Haddock.Identifier
           input = Haddock.DocHeader Haddock.Header {Haddock.headerLevel = 2, Haddock.headerTitle = Haddock.DocString "Section"}
       let expected = Doc.Header Header.MkHeader {Header.level = Level.Two, Header.title = Doc.String $ Text.pack "Section"}
+      Spec.assertEq s (fromHaddock input) expected
+
+    Spec.it s "works with collapsible header" $ do
+      let input :: Haddock.DocH Void.Void Haddock.Identifier
+          input =
+            Haddock.DocAppend
+              (Haddock.DocHeader Haddock.Header {Haddock.headerLevel = 2, Haddock.headerTitle = Haddock.DocBold (Haddock.DocString "Examples:")})
+              (Haddock.DocParagraph (Haddock.DocString "content"))
+      let expected =
+            Doc.CollapsibleHeader
+              Collapsible.MkCollapsible
+                { Collapsible.header = Header.MkHeader {Header.level = Level.Two, Header.title = Doc.String $ Text.pack "Examples:"},
+                  Collapsible.body = [Doc.Paragraph . Doc.String $ Text.pack "content"]
+                }
       Spec.assertEq s (fromHaddock input) expected
 
     Spec.it s "works with table" $ do

--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -862,15 +862,26 @@ headerContent x =
 
 collapsibleHeaderContent :: Collapsible.Collapsible Doc.Doc -> Content.Content Element.Element
 collapsibleHeaderContent x =
-  element
-    "details"
-    []
-    [ element
-        "summary"
+  let header = Collapsible.header x
+      lvl = Header.level header
+   in element
+        "details"
         []
-        [element (levelToName . Header.level $ Collapsible.header x) [] . docContents . Header.title $ Collapsible.header x],
-      element "div" [] $ foldMap docContents (Collapsible.body x)
-    ]
+        [ element
+            "summary"
+            []
+            [element "span" [("role", "heading"), ("aria-level", levelToNumber lvl), ("class", levelToName lvl)] . docContents $ Header.title header],
+          element "div" [] $ docContents (Collapsible.body x)
+        ]
+
+levelToNumber :: Level.Level -> String
+levelToNumber x = case x of
+  Level.One -> "1"
+  Level.Two -> "2"
+  Level.Three -> "3"
+  Level.Four -> "4"
+  Level.Five -> "5"
+  Level.Six -> "6"
 
 levelToName :: Level.Level -> String
 levelToName x = case x of

--- a/source/library/Scrod/Convert/ToHtml.hs
+++ b/source/library/Scrod/Convert/ToHtml.hs
@@ -13,6 +13,7 @@ import qualified Data.Map as Map
 import qualified Data.Maybe as Maybe
 import qualified Data.Text as Text
 import qualified Scrod.Core.Category as Category
+import qualified Scrod.Core.Collapsible as Collapsible
 import qualified Scrod.Core.Column as Column
 import qualified Scrod.Core.Definition as Definition
 import qualified Scrod.Core.Doc as Doc
@@ -705,6 +706,7 @@ docContents doc = case doc of
   Doc.Property x -> [propertyContent x]
   Doc.Examples xs -> exampleContent <$> NonEmpty.toList xs
   Doc.Header x -> [headerContent x]
+  Doc.CollapsibleHeader x -> [collapsibleHeaderContent x]
   Doc.Table x -> [tableContent x]
 
 definitionContents :: Definition.Definition Doc.Doc -> [Content.Content Element.Element]
@@ -857,6 +859,18 @@ exampleContent x =
 headerContent :: Header.Header Doc.Doc -> Content.Content Element.Element
 headerContent x =
   element (levelToName $ Header.level x) [] . docContents $ Header.title x
+
+collapsibleHeaderContent :: Collapsible.Collapsible Doc.Doc -> Content.Content Element.Element
+collapsibleHeaderContent x =
+  element
+    "details"
+    []
+    [ element
+        "summary"
+        []
+        [element (levelToName . Header.level $ Collapsible.header x) [] . docContents . Header.title $ Collapsible.header x],
+      element "div" [] $ foldMap docContents (Collapsible.body x)
+    ]
 
 levelToName :: Level.Level -> String
 levelToName x = case x of

--- a/source/library/Scrod/Core/Collapsible.hs
+++ b/source/library/Scrod/Core/Collapsible.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+
+module Scrod.Core.Collapsible where
+
+import qualified GHC.Generics as Generics
+import qualified Scrod.Core.Header as Header
+import qualified Scrod.Json.ToJson as ToJson
+import qualified Scrod.Schema as Schema
+
+-- | A collapsible section with a header and body content.
+-- Corresponds to Haddock's collapsible headers, where the header title
+-- is wrapped in bold syntax (@__title__@).
+data Collapsible doc = MkCollapsible
+  { header :: Header.Header doc,
+    body :: [doc]
+  }
+  deriving (Eq, Generics.Generic, Ord, Show)
+  deriving (ToJson.ToJson, Schema.ToSchema) via Generics.Generically (Collapsible doc)

--- a/source/library/Scrod/Core/Collapsible.hs
+++ b/source/library/Scrod/Core/Collapsible.hs
@@ -13,7 +13,7 @@ import qualified Scrod.Schema as Schema
 -- is wrapped in bold syntax (@__title__@).
 data Collapsible doc = MkCollapsible
   { header :: Header.Header doc,
-    body :: [doc]
+    body :: doc
   }
   deriving (Eq, Generics.Generic, Ord, Show)
   deriving (ToJson.ToJson, Schema.ToSchema) via Generics.Generically (Collapsible doc)

--- a/source/library/Scrod/Core/Doc.hs
+++ b/source/library/Scrod/Core/Doc.hs
@@ -6,6 +6,7 @@ module Scrod.Core.Doc where
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Text as Text
 import qualified GHC.Generics as Generics
+import qualified Scrod.Core.Collapsible as Collapsible
 import qualified Scrod.Core.Definition as Definition
 import qualified Scrod.Core.Example as Example
 import qualified Scrod.Core.Header as Header
@@ -41,6 +42,7 @@ data Doc
   | Property Text.Text
   | Examples (NonEmpty.NonEmpty Example.Example)
   | Header (Header.Header Doc)
+  | CollapsibleHeader (Collapsible.Collapsible Doc)
   | Table (Table.Table Doc)
   deriving (Eq, Generics.Generic, Ord, Show)
   deriving (ToJson.ToJson, Schema.ToSchema) via Generics.Generically Doc

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -555,6 +555,22 @@ spec s = Spec.describe s "integration" $ do
           ("/documentation/value/level", "3")
         ]
 
+    Spec.it s "works with a collapsible header" $ do
+      check
+        s
+        """
+        -- |
+        -- == __Examples:__
+        -- content
+        module M where
+        """
+        [ ("/documentation/type", "\"CollapsibleHeader\""),
+          ("/documentation/value/header/level", "2"),
+          ("/documentation/value/header/title/type", "\"String\""),
+          ("/documentation/value/header/title/value", "\"Examples:\""),
+          ("/documentation/value/body/0/type", "\"Paragraph\"")
+        ]
+
     Spec.it s "works with a table" $ do
       check
         s

--- a/source/library/Scrod/TestSuite/Integration.hs
+++ b/source/library/Scrod/TestSuite/Integration.hs
@@ -568,7 +568,55 @@ spec s = Spec.describe s "integration" $ do
           ("/documentation/value/header/level", "2"),
           ("/documentation/value/header/title/type", "\"String\""),
           ("/documentation/value/header/title/value", "\"Examples:\""),
-          ("/documentation/value/body/0/type", "\"Paragraph\"")
+          ("/documentation/value/body/type", "\"Paragraph\"")
+        ]
+
+    Spec.it s "works with nested collapsible headers" $ do
+      check
+        s
+        """
+        -- |
+        -- = __a__
+        --
+        -- b
+        --
+        -- == __c__
+        --
+        -- d
+        module M where
+        """
+        [ ("/documentation/type", "\"CollapsibleHeader\""),
+          ("/documentation/value/header/level", "1"),
+          ("/documentation/value/header/title/type", "\"String\""),
+          ("/documentation/value/header/title/value", "\"a\""),
+          ("/documentation/value/body/type", "\"Append\""),
+          ("/documentation/value/body/value/1/type", "\"CollapsibleHeader\""),
+          ("/documentation/value/body/value/1/value/header/level", "2"),
+          ("/documentation/value/body/value/1/value/header/title/type", "\"String\""),
+          ("/documentation/value/body/value/1/value/header/title/value", "\"c\"")
+        ]
+
+    Spec.it s "escapes collapsible header with a larger header" $ do
+      check
+        s
+        """
+        -- |
+        -- == __a__
+        --
+        -- b
+        --
+        -- = c
+        --
+        -- d
+        module M where
+        """
+        [ ("/documentation/type", "\"Append\""),
+          ("/documentation/value/0/type", "\"CollapsibleHeader\""),
+          ("/documentation/value/0/value/header/level", "2"),
+          ("/documentation/value/0/value/header/title/value", "\"a\""),
+          ("/documentation/value/0/value/body/type", "\"Paragraph\""),
+          ("/documentation/value/1/type", "\"Header\""),
+          ("/documentation/value/1/value/level", "1")
         ]
 
     Spec.it s "works with a table" $ do


### PR DESCRIPTION
Fixes #359.

## Summary

- Adds a new `Scrod.Core.Collapsible` type representing a collapsible section (header + body content)
- Adds a `CollapsibleHeader` constructor to the `Doc` type
- Detects Haddock collapsible headers (headers whose title is wrapped in bold, e.g. `== __Examples:__`) during `FromHaddock` conversion by post-processing `Append` lists
- The collapsible section extends until a header of equal or higher level, or the end of the doc — matching Haddock's behavior
- Renders collapsible headers as `<details>`/`<summary>` elements in HTML output
- JSON output gets automatic support via generic `ToJson` derivation
- Includes both unit and integration tests

## Test plan

- [x] `cabal build` succeeds
- [x] `cabal build --flags=pedantic` succeeds (no warnings)
- [x] All 808 tests pass
- [x] Ormolu formatting check passes
- [x] HLint check passes
- [x] cabal-gild check passes